### PR TITLE
test(tools): add unit tests for pdf_parser extract_text

### DIFF
--- a/docs/issues/003-test-pdf-parser.md
+++ b/docs/issues/003-test-pdf-parser.md
@@ -10,13 +10,13 @@ The PDF parser is the first external I/O tool — it must be reliable. Test-driv
 
 ## Tasks
 
-- [ ] Create `tests/test_pdf_parser.py`
-- [ ] Add a pytest fixture that generates a tiny PDF with known text using ReportLab (write to `tmp_path`)
-- [ ] Add a fixture that generates an image-only PDF (no extractable text)
-- [ ] Test: `test_extracts_text_from_valid_pdf` — verify known text is returned
-- [ ] Test: `test_raises_on_missing_file` — verify `FileNotFoundError`
-- [ ] Test: `test_raises_on_empty_text` — verify `ValueError` for image-only PDF
-- [ ] Test: `test_multipage_extraction` — verify text from multiple pages is concatenated
+- [x] Create `tests/test_pdf_parser.py`
+- [x] Add a pytest fixture that generates a tiny PDF with known text using ReportLab (write to `tmp_path`)
+- [x] Add a fixture that generates an image-only PDF (no extractable text)
+- [x] Test: `test_extracts_text_from_valid_pdf` — verify known text is returned
+- [x] Test: `test_raises_on_missing_file` — verify `FileNotFoundError`
+- [x] Test: `test_raises_on_empty_text` — verify `ValueError` for image-only PDF
+- [x] Test: `test_multipage_extraction` — verify text from multiple pages is concatenated
 
 ## Acceptance Criteria
 

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -2,44 +2,71 @@
 
 from pathlib import Path
 
-import fitz
 import pytest
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.units import inch
+from reportlab.pdfgen import canvas
 
 from resume_operator.tools.pdf_parser import extract_text
 
 
-def _create_pdf(path: Path, pages: list[str]) -> None:
-    """Helper to create a PDF with given text on each page."""
-    doc = fitz.open()
-    for text in pages:
-        page = doc.new_page()
+def _create_text_pdf(path: Path, pages: list[str]) -> None:
+    """Create a PDF with given text on each page using ReportLab."""
+    c = canvas.Canvas(str(path), pagesize=letter)
+    for i, text in enumerate(pages):
+        if i > 0:
+            c.showPage()
         if text:
-            page.insert_text((72, 72), text)
-    doc.save(str(path))
-    doc.close()
+            c.drawString(72, letter[1] - 72, text)
+    c.save()
+
+
+def _create_image_only_pdf(path: Path) -> None:
+    """Create a PDF with only a drawn shape (no extractable text)."""
+    c = canvas.Canvas(str(path), pagesize=letter)
+    c.rect(1 * inch, 1 * inch, 2 * inch, 2 * inch, fill=1)
+    c.save()
+
+
+@pytest.fixture()
+def valid_pdf(tmp_path: Path) -> Path:
+    """Generate a single-page PDF with known text."""
+    pdf_path = tmp_path / "resume.pdf"
+    _create_text_pdf(pdf_path, ["Hello World"])
+    return pdf_path
+
+
+@pytest.fixture()
+def multipage_pdf(tmp_path: Path) -> Path:
+    """Generate a multi-page PDF with known text on each page."""
+    pdf_path = tmp_path / "multi.pdf"
+    _create_text_pdf(pdf_path, ["Page one content", "Page two content"])
+    return pdf_path
+
+
+@pytest.fixture()
+def image_only_pdf(tmp_path: Path) -> Path:
+    """Generate a PDF with only graphics, no extractable text."""
+    pdf_path = tmp_path / "image_only.pdf"
+    _create_image_only_pdf(pdf_path)
+    return pdf_path
 
 
 class TestExtractText:
-    def test_extracts_text_from_valid_pdf(self, tmp_path: Path) -> None:
-        pdf_path = tmp_path / "resume.pdf"
-        _create_pdf(pdf_path, ["Hello World"])
-        result = extract_text(pdf_path)
+    def test_extracts_text_from_valid_pdf(self, valid_pdf: Path) -> None:
+        result = extract_text(valid_pdf)
         assert "Hello World" in result
 
-    def test_extracts_text_from_multipage_pdf(self, tmp_path: Path) -> None:
-        pdf_path = tmp_path / "multi.pdf"
-        _create_pdf(pdf_path, ["Page one content", "Page two content"])
-        result = extract_text(pdf_path)
+    def test_multipage_extraction(self, multipage_pdf: Path) -> None:
+        result = extract_text(multipage_pdf)
         assert "Page one content" in result
         assert "Page two content" in result
 
-    def test_raises_file_not_found_for_missing_path(self, tmp_path: Path) -> None:
+    def test_raises_on_missing_file(self, tmp_path: Path) -> None:
         missing = tmp_path / "nonexistent.pdf"
         with pytest.raises(FileNotFoundError, match="PDF file not found"):
             extract_text(missing)
 
-    def test_raises_value_error_for_empty_pdf(self, tmp_path: Path) -> None:
-        pdf_path = tmp_path / "empty.pdf"
-        _create_pdf(pdf_path, [""])
+    def test_raises_on_empty_text(self, image_only_pdf: Path) -> None:
         with pytest.raises(ValueError, match="No extractable text"):
-            extract_text(pdf_path)
+            extract_text(image_only_pdf)


### PR DESCRIPTION
## Summary

- Add 4 unit tests for `extract_text()` in `tools/pdf_parser.py` covering valid PDF, multi-page, missing file, and image-only edge cases
- Use ReportLab to generate test PDFs as pytest fixtures (no external PDF files needed)
- Mark all tasks in issue #003 as complete

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/4

## Changes

- Created `tests/test_pdf_parser.py` with `TestExtractText` class
- Added ReportLab-based helpers (`_create_text_pdf`, `_create_image_only_pdf`) to generate test PDFs in `tmp_path`
- Added fixtures: `valid_pdf`, `multipage_pdf`, `image_only_pdf`
- Tests:
  - `test_extracts_text_from_valid_pdf` — verifies known text is returned
  - `test_multipage_extraction` — verifies text from all pages is concatenated
  - `test_raises_on_missing_file` — verifies `FileNotFoundError`
  - `test_raises_on_empty_text` — verifies `ValueError` for image-only PDF

## How to Test

1. `uv sync --dev`
2. `uv run pytest tests/test_pdf_parser.py -v`
3. All 4 tests should pass

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests
- [x] No new warnings or errors
- [x] Lint passes (`ruff check`)
- [x] Tests follow project conventions (class-based, descriptive names)
