### PR TITLE
feat(tools): add API key validation and provider/model overrides to g…

### DIFF
--- a/docs/issues/004-implement-llm-provider.md
+++ b/docs/issues/004-implement-llm-provider.md
@@ -10,10 +10,10 @@ Four of six pipeline nodes depend on the LLM provider. A clear error when the AP
 
 ## Tasks
 
-- [ ] Add validation: if the API key for the selected provider is empty, raise `ValueError` with a message like `"OPENAI_API_KEY not set. Add it to your .env file."`
-- [ ] Add optional `provider`/`model` parameters to `get_llm()` that override settings (useful for testing)
-- [ ] Ensure `mypy` passes with strict mode
-- [ ] Verify all three provider paths work (OpenAI, Anthropic, Google)
+- [x] Add validation: if the API key for the selected provider is empty, raise `ValueError` with a message like `"OPENAI_API_KEY not set. Add it to your .env file."`
+- [x] Add optional `provider`/`model` parameters to `get_llm()` that override settings (useful for testing)
+- [x] Ensure `mypy` passes with strict mode
+- [x] Verify all four provider paths work (OpenAI, Anthropic, Google, OpenRouter)
 
 ## Acceptance Criteria
 

--- a/src/resume_operator/tools/llm_provider.py
+++ b/src/resume_operator/tools/llm_provider.py
@@ -5,38 +5,62 @@ from pydantic import SecretStr
 
 from resume_operator.config import get_settings
 
+# Maps provider name to (Settings attribute, environment variable name).
+_PROVIDER_KEY_MAP: dict[str, tuple[str, str]] = {
+    "openai": ("openai_api_key", "OPENAI_API_KEY"),
+    "anthropic": ("anthropic_api_key", "ANTHROPIC_API_KEY"),
+    "google": ("google_api_key", "GOOGLE_API_KEY"),
+    "openrouter": ("openrouter_api_key", "OPENROUTER_API_KEY"),
+}
 
-def get_llm() -> BaseChatModel:
+
+def get_llm(
+    provider: str | None = None,
+    model: str | None = None,
+) -> BaseChatModel:
     """Return a LangChain chat model based on LLM_PROVIDER env var.
 
     Supports: openai, anthropic, google, openrouter.
     Provider-specific packages are imported lazily.
+
+    Args:
+        provider: Override the configured LLM_PROVIDER.
+        model: Override the configured LLM_MODEL.
     """
     settings = get_settings()
-    provider = settings.llm_provider.lower()
+    resolved_provider = (provider or settings.llm_provider).lower()
+    resolved_model = model or settings.llm_model
 
-    if provider == "openai":
+    # Validate provider is supported and API key is present.
+    if resolved_provider not in _PROVIDER_KEY_MAP:
+        msg = f"Unsupported LLM provider: {resolved_provider}"
+        raise ValueError(msg)
+
+    attr_name, env_var = _PROVIDER_KEY_MAP[resolved_provider]
+    api_key: str = getattr(settings, attr_name)
+    if not api_key:
+        msg = f"{env_var} not set. Add it to your .env file."
+        raise ValueError(msg)
+
+    if resolved_provider == "openai":
         from langchain_openai import ChatOpenAI
 
-        return ChatOpenAI(model=settings.llm_model, api_key=SecretStr(settings.openai_api_key))
-    elif provider == "anthropic":
+        return ChatOpenAI(model=resolved_model, api_key=SecretStr(api_key))
+    elif resolved_provider == "anthropic":
         from langchain_anthropic import ChatAnthropic
 
         return ChatAnthropic(  # type: ignore[call-arg]
-            model_name=settings.llm_model, api_key=SecretStr(settings.anthropic_api_key)
+            model_name=resolved_model, api_key=SecretStr(api_key)
         )
-    elif provider == "google":
+    elif resolved_provider == "google":
         from langchain_google_genai import ChatGoogleGenerativeAI
 
-        return ChatGoogleGenerativeAI(model=settings.llm_model, api_key=settings.google_api_key)
-    elif provider == "openrouter":
+        return ChatGoogleGenerativeAI(model=resolved_model, api_key=api_key)
+    else:  # openrouter
         from langchain_openai import ChatOpenAI
 
         return ChatOpenAI(
-            model=settings.llm_model,
-            api_key=SecretStr(settings.openrouter_api_key),
+            model=resolved_model,
+            api_key=SecretStr(api_key),
             base_url="https://openrouter.ai/api/v1",
         )
-    else:
-        msg = f"Unsupported LLM provider: {provider}"
-        raise ValueError(msg)

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,123 @@
+"""Tests for LLM provider factory."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from resume_operator.tools.llm_provider import get_llm
+
+
+def _make_settings(**overrides: str) -> MagicMock:
+    """Create a mock Settings with sensible defaults and optional overrides."""
+    defaults = {
+        "llm_provider": "openai",
+        "llm_model": "gpt-4o",
+        "openai_api_key": "",
+        "anthropic_api_key": "",
+        "google_api_key": "",
+        "openrouter_api_key": "",
+    }
+    defaults.update(overrides)
+    settings = MagicMock()
+    for key, value in defaults.items():
+        setattr(settings, key, value)
+    return settings
+
+
+class TestApiKeyValidation:
+    """get_llm() must raise ValueError when the API key is missing."""
+
+    @patch("resume_operator.tools.llm_provider.get_settings")
+    def test_raises_when_openai_key_missing(self, mock_gs: MagicMock) -> None:
+        mock_gs.return_value = _make_settings(llm_provider="openai")
+        with pytest.raises(ValueError, match="OPENAI_API_KEY not set"):
+            get_llm()
+
+    @patch("resume_operator.tools.llm_provider.get_settings")
+    def test_raises_when_anthropic_key_missing(self, mock_gs: MagicMock) -> None:
+        mock_gs.return_value = _make_settings(llm_provider="anthropic")
+        with pytest.raises(ValueError, match="ANTHROPIC_API_KEY not set"):
+            get_llm()
+
+    @patch("resume_operator.tools.llm_provider.get_settings")
+    def test_raises_when_google_key_missing(self, mock_gs: MagicMock) -> None:
+        mock_gs.return_value = _make_settings(llm_provider="google")
+        with pytest.raises(ValueError, match="GOOGLE_API_KEY not set"):
+            get_llm()
+
+    @patch("resume_operator.tools.llm_provider.get_settings")
+    def test_raises_when_openrouter_key_missing(self, mock_gs: MagicMock) -> None:
+        mock_gs.return_value = _make_settings(llm_provider="openrouter")
+        with pytest.raises(ValueError, match="OPENROUTER_API_KEY not set"):
+            get_llm()
+
+    def test_raises_on_unsupported_provider(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported LLM provider: fakellm"):
+            get_llm(provider="fakellm")
+
+
+class TestProviderModelOverrides:
+    """Optional provider/model parameters override settings."""
+
+    @patch("langchain_openai.ChatOpenAI", create=True)
+    @patch("resume_operator.tools.llm_provider.get_settings")
+    def test_provider_override_selects_correct_path(
+        self, mock_gs: MagicMock, mock_cls: MagicMock
+    ) -> None:
+        """provider='openai' uses OpenAI path even if settings say anthropic."""
+        mock_gs.return_value = _make_settings(llm_provider="anthropic", openai_api_key="sk-test")
+        mock_cls.return_value = MagicMock()
+        get_llm(provider="openai")
+        mock_cls.assert_called_once()
+
+    @patch("langchain_openai.ChatOpenAI", create=True)
+    @patch("resume_operator.tools.llm_provider.get_settings")
+    def test_model_override(self, mock_gs: MagicMock, mock_cls: MagicMock) -> None:
+        mock_gs.return_value = _make_settings(openai_api_key="sk-test")
+        mock_cls.return_value = MagicMock()
+        get_llm(model="gpt-3.5-turbo")
+        call_kwargs = mock_cls.call_args
+        assert call_kwargs is not None
+        assert str(call_kwargs[1]["model"]) == "gpt-3.5-turbo"
+
+
+class TestProviderConstruction:
+    """Each provider path constructs the correct LangChain class."""
+
+    @patch("langchain_openai.ChatOpenAI", create=True)
+    @patch("resume_operator.tools.llm_provider.get_settings")
+    def test_openai_path(self, mock_gs: MagicMock, mock_cls: MagicMock) -> None:
+        mock_gs.return_value = _make_settings(openai_api_key="sk-test")
+        mock_cls.return_value = MagicMock()
+        get_llm()
+        mock_cls.assert_called_once()
+
+    @patch("langchain_anthropic.ChatAnthropic", create=True)
+    @patch("resume_operator.tools.llm_provider.get_settings")
+    def test_anthropic_path(self, mock_gs: MagicMock, mock_cls: MagicMock) -> None:
+        mock_gs.return_value = _make_settings(
+            llm_provider="anthropic", anthropic_api_key="sk-ant-test"
+        )
+        mock_cls.return_value = MagicMock()
+        get_llm()
+        mock_cls.assert_called_once()
+
+    @patch("langchain_google_genai.ChatGoogleGenerativeAI", create=True)
+    @patch("resume_operator.tools.llm_provider.get_settings")
+    def test_google_path(self, mock_gs: MagicMock, mock_cls: MagicMock) -> None:
+        mock_gs.return_value = _make_settings(llm_provider="google", google_api_key="goog-test")
+        mock_cls.return_value = MagicMock()
+        get_llm()
+        mock_cls.assert_called_once()
+
+    @patch("langchain_openai.ChatOpenAI", create=True)
+    @patch("resume_operator.tools.llm_provider.get_settings")
+    def test_openrouter_path(self, mock_gs: MagicMock, mock_cls: MagicMock) -> None:
+        mock_gs.return_value = _make_settings(
+            llm_provider="openrouter", openrouter_api_key="or-test"
+        )
+        mock_cls.return_value = MagicMock()
+        get_llm()
+        mock_cls.assert_called_once()
+        call_kwargs = mock_cls.call_args[1]
+        assert call_kwargs["base_url"] == "https://openrouter.ai/api/v1"


### PR DESCRIPTION
## Summary

- Add API key validation to `get_llm()` — raises `ValueError` with helpful `.env` guidance when key is missing
- Add optional `provider`/`model` parameters to override settings (useful for testing)
- Add 11 unit tests covering validation, overrides, and all four provider paths

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/6

Four of six pipeline nodes depend on the LLM provider. Without validation, users get cryptic SDK errors when API keys are missing. This adds clear, actionable error messages for first-time setup.

## Changes

- `src/resume_operator/tools/llm_provider.py` — Added `_PROVIDER_KEY_MAP` for centralized key lookup, API key validation before model construction, and optional `provider`/`model` parameters
- `tests/test_llm_provider.py` — New test file with 3 test classes: `TestApiKeyValidation` (5 tests), `TestProviderModelOverrides` (2 tests), `TestProviderConstruction` (4 tests)
- `docs/issues/004-implement-llm-provider.md` — Marked all tasks complete

## How to Test

1. Checkout this branch
2. `uv sync --dev`
3. `uv run pytest tests/test_llm_provider.py -v` — all 11 tests pass
4. `uv run mypy src/resume_operator/tools/llm_provider.py --strict` — no issues
5. Verify manually: call `get_llm()` without setting an API key → should see `ValueError: OPENAI_API_KEY not set. Add it to your .env file.`

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests
- [x] No new warnings or errors
- [x] Updated documentation if needed
