### PR TITLE
test(graph): verify LangGraph graph assembly compiles and runs parse_…

### DIFF
--- a/docs/issues/007-verify-langgraph-assembly.md
+++ b/docs/issues/007-verify-langgraph-assembly.md
@@ -18,11 +18,11 @@ Before implementing more nodes, confirm that the LangGraph machinery works: Stat
 
 ## Tasks
 
-- [ ] Create `tests/test_graph.py`
-- [ ] Test: `test_graph_compiles` — call `build_graph()`, verify it returns without error
-- [ ] Test: `test_graph_runs_parse_resume` — mock all tools, invoke graph with `resume_path` and `job_description_path` set, verify `parse_resume` was called
-- [ ] Add comments explaining LangGraph concepts for future reference
-- [ ] Verify the state type annotation in `graph.py` is correct
+- [x] Create `tests/test_graph.py`
+- [x] Test: `test_graph_compiles` — call `build_graph()`, verify it returns a `CompiledStateGraph` with all 6 expected nodes
+- [x] Test: `test_graph_runs_parse_resume` — mock `extract_text` and `get_llm`, invoke graph with `resume_path` and `job_description_text`, verify `parse_resume` executes and state is merged
+- [x] Add comments explaining LangGraph concepts for future reference
+- [x] Verify the state type annotation in `graph.py` is correct (`CompiledStateGraph[Any]`)
 
 ## Acceptance Criteria
 
@@ -30,10 +30,18 @@ Before implementing more nodes, confirm that the LangGraph machinery works: Stat
 - Graph invocation with mocked tools executes `parse_resume` node
 - Test file includes brief LangGraph concept comments
 
+## Implementation Details
+
+- `tests/test_graph.py` contains `TestGraphAssembly` class with 2 tests
+- `test_graph_compiles`: verifies `build_graph()` returns `CompiledStateGraph` and filters `__start__`/`__end__` to assert all 6 user-defined nodes are registered
+- `test_graph_runs_parse_resume`: mocks `extract_text` and `get_llm`, invokes full pipeline, asserts `parse_resume` output (`ResumeData`, `JobDescription`) is merged into state by LangGraph
+- Module docstring documents LangGraph concepts: `StateGraph`, `add_node`, `add_edge`, `compile`, `invoke`, and stub node behavior
+- `graph.py` state type annotation confirmed correct: `StateGraph(ResumeOptimizerState)` with `CompiledStateGraph[Any]` return type
+
 ## Key Files
 
 - `tests/test_graph.py` (new)
-- `src/resume_operator/graph.py`
+- `src/resume_operator/graph.py` (no changes needed)
 
 ## Dependencies
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,84 @@
+"""Tests for LangGraph graph assembly and execution.
+
+LangGraph Concepts:
+- StateGraph(Type): Creates a graph parameterized by a state type (here, Pydantic BaseModel).
+- graph.add_node("name", fn): Registers a node function that receives state and returns a dict.
+- graph.add_edge(START, "name"): Defines execution flow between nodes.
+- graph.compile(): Produces a CompiledStateGraph — a runnable that accepts initial state.
+- compiled.invoke(state): Executes the full pipeline; each node's return dict is merged into state.
+- Stub nodes returning {} are valid — they simply don't modify state, so the pipeline continues.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from langgraph.graph.state import CompiledStateGraph
+
+from resume_operator.graph import build_graph
+
+EXPECTED_NODES = [
+    "parse_resume",
+    "ats_score",
+    "analyze_gaps",
+    "optimize_content",
+    "generate_pdf",
+    "report_results",
+]
+
+VALID_LLM_JSON = """{
+    "name": "Jane Smith",
+    "email": "jane@example.com",
+    "phone": "",
+    "summary": "Engineer",
+    "experience": [],
+    "education": [],
+    "skills": ["Python"],
+    "certifications": []
+}"""
+
+
+class TestGraphAssembly:
+    def test_graph_compiles(self) -> None:
+        """build_graph() returns a compiled graph with all expected nodes."""
+        # compile() converts the StateGraph into a runnable — no nodes execute yet
+        graph = build_graph()
+
+        assert isinstance(graph, CompiledStateGraph)
+
+        # __start__ and __end__ are LangGraph internal nodes; filter to user-defined nodes
+        node_names = [n for n in graph.get_graph().nodes if not n.startswith("__")]
+        assert sorted(node_names) == sorted(EXPECTED_NODES)
+
+    @patch("resume_operator.nodes.parse_resume.get_llm")
+    @patch("resume_operator.nodes.parse_resume.extract_text")
+    def test_graph_runs_parse_resume(
+        self, mock_extract: MagicMock, mock_get_llm: MagicMock
+    ) -> None:
+        """Invoking the graph executes parse_resume and merges its output into state."""
+        mock_extract.return_value = "Jane Smith\njane@example.com"
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value.content = VALID_LLM_JSON
+        mock_get_llm.return_value = mock_llm
+
+        graph = build_graph()
+
+        # invoke() runs the full pipeline: parse_resume → ats_score → ... → report_results
+        # Only parse_resume does real work here; the remaining stub nodes return {} (no-op).
+        result = graph.invoke(
+            {
+                "resume_path": "test.pdf",
+                "job_description_text": "Backend Engineer role",
+            }
+        )
+
+        # parse_resume was called — verify via mock
+        mock_extract.assert_called_once()
+        mock_get_llm.assert_called_once()
+
+        # State merging: parse_resume returned {"resume": ResumeData, "job_description": ...}
+        # LangGraph merged those into the pipeline state dict
+        assert "resume" in result
+        assert result["resume"].name == "Jane Smith"
+        assert result["resume"].skills == ["Python"]
+
+        assert "job_description" in result
+        assert result["job_description"].raw_text == "Backend Engineer role"


### PR DESCRIPTION
## Summary

- Add integration tests verifying LangGraph `StateGraph` assembly compiles and runs `parse_resume` as the first node
- Confirm all 6 pipeline nodes are registered and state merging works end-to-end
- Update issue 007 with completed tasks and implementation details

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/12

Before implementing more nodes, we need confidence that the LangGraph machinery works: `StateGraph` compiles, state flows through nodes, and node return dicts are merged into state correctly. This is the first real integration test for the pipeline.

## Changes

- **`tests/test_graph.py`** (new)
  - `test_graph_compiles` — calls `build_graph()`, asserts it returns a `CompiledStateGraph` with all 6 expected user-defined nodes
  - `test_graph_runs_parse_resume` — mocks `extract_text` and `get_llm`, invokes the full pipeline, verifies `parse_resume` executed and its output (`ResumeData`, `JobDescription`) was merged into state
  - Module docstring documents LangGraph concepts (`StateGraph`, `compile`, `invoke`, stub node behavior)
- **`docs/issues/007-verify-langgraph-assembly.md`** — marked all tasks complete, added implementation details section

## How to Test

```bash
uv run pytest tests/test_graph.py -v
```

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests
- [x] No new warnings or errors
- [x] Passes ruff, mypy, and pytest (39/39)
- [x] Updated documentation (issue 007)
