### PR TITLE
feat(cli): wire parse-resume command to LangGraph pipeline

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -95,6 +95,7 @@ uv run mypy src/           # Type check
 - `.claude/rules/gh-issue.md` — Issue title format, templates for bugs/features/chores
 - `.claude/rules/ai-framework.md` — Sync protocol, skill/rule design, maintenance
 - `.claude/rules/documentation.md` — Docs structure, ADR conventions
+- `.claude/rules/logging.md` — Log levels, node logging pattern, LLM call logging, CLI verbosity
 
 ## Known Gaps
 

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -1,0 +1,94 @@
+# Logging Rules
+
+## Setup
+
+Every module that logs must use the standard library pattern:
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+Do NOT use `print()` for operational output — use `logger` or Rich console (CLI layer only).
+
+## Log Levels
+
+| Level | What to log | Example |
+|-------|------------|---------|
+| `DEBUG` | Full prompt text, raw LLM response, resume raw text, detailed state dumps | `logger.debug("LLM prompt: %s", prompt)` |
+| `INFO` | Node entry/exit, key metrics, LLM call timing, pipeline progress | `logger.info("parse_resume: completed — skills=%d", len(skills))` |
+| `WARNING` | Recoverable issues, fallback behavior, missing optional config | `logger.warning("No job description provided, skipping gap analysis")` |
+| `ERROR` | Failures recorded in `state.errors`, exceptions caught in nodes | `logger.error("parse_resume: PDF extraction failed: %s", exc)` |
+
+## Node Logging Pattern
+
+Every node function must log at these points:
+
+```python
+def example_node(state: ResumeOptimizerState) -> dict[str, Any]:
+    logger.info("example_node: starting")
+
+    # ... do work ...
+
+    logger.info("example_node: completed — <key metrics>")
+    return {<fields>}
+```
+
+On error:
+```python
+    except Exception as exc:
+        logger.error("example_node: <description>: %s", exc)
+        errors.append(f"example_node: <description>: {exc}")
+```
+
+Key metrics to log at INFO on completion:
+- `parse_resume` — char count from PDF, field counts (skills, experience, education)
+- `ats_score` — score value, keyword match/gap counts
+- `analyze_gaps` — gap count, strength count, suggestion count
+- `optimize_content` — number of sections, changes made count
+- `generate_pdf` — output path, file size
+- `report_results` — output path
+
+## LLM Call Logging
+
+In `tools/llm_provider.py` or at the call site in nodes:
+
+```python
+logger.info("LLM call: provider=%s, model=%s", provider, model)
+logger.debug("LLM prompt: %s", prompt)
+logger.info("LLM response received in %.1fs (%d chars)", elapsed, len(content))
+logger.debug("LLM response: %s", content)
+```
+
+Never log prompt content or LLM response content at INFO level — use DEBUG only.
+
+## CLI Log Configuration
+
+`main.py` configures logging based on a `--verbose` / `-v` flag:
+
+- Default (no flag): `WARNING` level — quiet output, only Rich console display
+- `--verbose`: `DEBUG` level — full pipeline visibility
+
+```python
+logging.basicConfig(
+    level=logging.DEBUG if verbose else logging.WARNING,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+```
+
+## Security Constraints (from security.md)
+
+- Never log API keys, tokens, or passwords at any level
+- Never log full resume text or personal data at INFO — DEBUG only
+- Safe to log at INFO: file paths, score values, counts, timing, status messages
+
+## Anti-Patterns (Do NOT)
+
+- Use `print()` for debug output — use `logger.debug()`
+- Log at INFO inside tight loops — use DEBUG
+- Create custom logging handlers or formatters per module — use `basicConfig` in CLI
+- Use f-strings in log calls — use `%s` formatting for lazy evaluation: `logger.info("x=%s", x)`
+- Log sensitive data (API keys, resume PII) at INFO or above
+- Skip the node entry/exit log — it's how we trace pipeline progress

--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,4 @@ data/
 .env
 
 .claude/settings.local.json
+input/

--- a/docs/issues/008-wire-parse-resume-cli.md
+++ b/docs/issues/008-wire-parse-resume-cli.md
@@ -10,11 +10,11 @@ This is the first time the user sees the system work end-to-end: PDF → LLM →
 
 ## Tasks
 
-- [ ] In `main.py`, import `build_graph` or create a helper for a single-node graph
-- [ ] In `parse_resume` command: validate file exists, build initial state, invoke graph
-- [ ] Display results using Rich: name, email, skills list, experience count, education count
-- [ ] Handle errors: show `state.errors` if any, with `[red]` Rich styling
-- [ ] Add Rich `Status` spinner while the pipeline runs
+- [x] In `main.py`, import `build_graph` and invoke the full pipeline graph
+- [x] In `parse_resume` command: validate file exists, build initial state, invoke graph
+- [x] Display results using Rich: name, email, phone, skills list, experience/education/certifications counts
+- [x] Handle errors: show `state.errors` if any, with `[red]` Rich styling
+- [x] Add Rich `Status` spinner while the pipeline runs
 
 ## Acceptance Criteria
 
@@ -30,6 +30,44 @@ This is the first time the user sees the system work end-to-end: PDF → LLM →
 ## Dependencies
 
 - #006
+
+## Implementation Details
+
+### CLI command (`src/resume_operator/main.py`)
+
+- Validates `resume.exists()` and `resume.is_file()` before invoking the graph
+- Invokes `build_graph().invoke({"resume_path": str(resume)})` — full pipeline, stub nodes 2-6 are no-ops
+- Rich `Status` spinner wraps the graph invocation for user feedback
+- Errors from `result["errors"]` printed in `[red]` with `typer.Exit(code=1)`
+- Displays: name, email, phone, skills (comma-joined), experience/education/certifications entry counts
+
+### Bug fix: null coercion in parse_resume node (`src/resume_operator/nodes/parse_resume.py`)
+
+- LLMs may return `null` for optional fields (e.g., `"phone": null`)
+- `dict.get("phone", "")` only returns `""` when the key is missing, not when value is `null`
+- Changed all field accessors from `parsed.get("field", "")` to `parsed.get("field") or ""` to coerce `None` to defaults
+- Added `test_handles_null_fields_from_llm` test to cover this case
+
+### Logging rule (`.claude/rules/logging.md`)
+
+- Established logging conventions for all nodes and tools
+- Node logging pattern: entry/exit at INFO, errors at ERROR, prompts/responses at DEBUG only
+- CLI `--verbose` flag design: WARNING by default, DEBUG when verbose
+- Security: no PII or API keys at INFO level
+- Added rule reference in `.claude/CLAUDE.md`
+
+### Tests (`tests/test_main.py`)
+
+- 5 CLI tests using `typer.testing.CliRunner` with mocked `build_graph`:
+  - `test_file_not_found` — nonexistent path exits 1
+  - `test_not_a_file` — directory path exits 1
+  - `test_successful_parse` — displays name, email, skills, counts
+  - `test_pipeline_errors` — shows errors in output, exits 1
+  - `test_resume_option_required` — missing `--resume` shows error
+
+### Tests (`tests/test_parse_resume.py`)
+
+- Added `test_handles_null_fields_from_llm` — verifies null coercion for all fields
 
 ## Labels
 

--- a/src/resume_operator/main.py
+++ b/src/resume_operator/main.py
@@ -4,6 +4,10 @@ from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.status import Status
+
+from resume_operator.graph import build_graph
+from resume_operator.state import ResumeData
 
 app = typer.Typer(
     name="resume-operator",
@@ -33,9 +37,30 @@ def parse_resume(
     resume: Path = typer.Option(..., "--resume", "-r", help="Path to resume PDF"),
 ) -> None:
     """Parse a resume PDF and display extracted data."""
-    # TODO: Call parse_resume node and display results
-    console.print(f"[bold]Resume:[/bold] {resume}")
-    console.print("[yellow]Not implemented yet.[/yellow]")
+    if not resume.exists() or not resume.is_file():
+        console.print(f"[red]Error: '{resume}' does not exist or is not a file.[/red]")
+        raise typer.Exit(code=1)
+
+    graph = build_graph()
+    with Status("[bold cyan]Parsing resume...", console=console):
+        result = graph.invoke({"resume_path": str(resume)})
+
+    errors: list[str] = result.get("errors", [])
+    if errors:
+        for error in errors:
+            console.print(f"[red]{error}[/red]")
+        raise typer.Exit(code=1)
+
+    resume_data: ResumeData = result["resume"]
+    console.print(f"[bold green]Name:[/bold green] {resume_data.name}")
+    console.print(f"[bold green]Email:[/bold green] {resume_data.email}")
+    console.print(f"[bold green]Phone:[/bold green] {resume_data.phone}")
+    console.print(f"[bold green]Skills:[/bold green] {', '.join(resume_data.skills)}")
+    console.print(f"[bold green]Experience:[/bold green] {len(resume_data.experience)} entries")
+    console.print(f"[bold green]Education:[/bold green] {len(resume_data.education)} entries")
+    console.print(
+        f"[bold green]Certifications:[/bold green] {len(resume_data.certifications)} entries"
+    )
 
 
 @app.command()

--- a/src/resume_operator/nodes/parse_resume.py
+++ b/src/resume_operator/nodes/parse_resume.py
@@ -46,14 +46,14 @@ def parse_resume(state: ResumeOptimizerState) -> dict[str, Any]:
 
     # --- Build ResumeData ---
     resume_data = ResumeData(
-        name=parsed.get("name", ""),
-        email=parsed.get("email", ""),
-        phone=parsed.get("phone", ""),
-        summary=parsed.get("summary", ""),
-        experience=parsed.get("experience", []),
-        education=parsed.get("education", []),
-        skills=parsed.get("skills", []),
-        certifications=parsed.get("certifications", []),
+        name=parsed.get("name") or "",
+        email=parsed.get("email") or "",
+        phone=parsed.get("phone") or "",
+        summary=parsed.get("summary") or "",
+        experience=parsed.get("experience") or [],
+        education=parsed.get("education") or [],
+        skills=parsed.get("skills") or [],
+        certifications=parsed.get("certifications") or [],
         raw_text=raw_text,
     )
     result["resume"] = resume_data

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,81 @@
+"""Tests for CLI commands in main.py."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from resume_operator.main import app
+from resume_operator.state import ResumeData
+
+runner = CliRunner()
+
+
+class TestParseResumeCommand:
+    def test_file_not_found(self) -> None:
+        """Nonexistent file path prints error and exits 1."""
+        result = runner.invoke(app, ["parse-resume", "--resume", "nonexistent.pdf"])
+
+        assert result.exit_code == 1
+        assert "does not exist" in result.output
+
+    def test_not_a_file(self, tmp_path: Path) -> None:
+        """Directory path prints error and exits 1."""
+        result = runner.invoke(app, ["parse-resume", "--resume", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "does not exist or is not a file" in result.output
+
+    @patch("resume_operator.main.build_graph")
+    def test_successful_parse(self, mock_build: MagicMock, tmp_path: Path) -> None:
+        """Successful parse displays resume data."""
+        fake_pdf = tmp_path / "resume.pdf"
+        fake_pdf.touch()
+
+        mock_graph = MagicMock()
+        mock_graph.invoke.return_value = {
+            "resume": ResumeData(
+                name="Jane Smith",
+                email="jane@example.com",
+                phone="555-0100",
+                skills=["Python", "AWS"],
+                experience=[{"title": "Engineer", "company": "Corp"}],
+                education=[{"degree": "BS", "institution": "State U"}],
+                certifications=["AWS SAA"],
+            ),
+            "errors": [],
+        }
+        mock_build.return_value = mock_graph
+
+        result = runner.invoke(app, ["parse-resume", "--resume", str(fake_pdf)])
+
+        assert result.exit_code == 0
+        assert "Jane Smith" in result.output
+        assert "jane@example.com" in result.output
+        assert "Python" in result.output
+        assert "1 entries" in result.output
+
+    @patch("resume_operator.main.build_graph")
+    def test_pipeline_errors(self, mock_build: MagicMock, tmp_path: Path) -> None:
+        """Pipeline errors are displayed in output and exit code is 1."""
+        fake_pdf = tmp_path / "resume.pdf"
+        fake_pdf.touch()
+
+        mock_graph = MagicMock()
+        mock_graph.invoke.return_value = {
+            "resume": ResumeData(),
+            "errors": ["PDF extraction failed: corrupted file"],
+        }
+        mock_build.return_value = mock_graph
+
+        result = runner.invoke(app, ["parse-resume", "--resume", str(fake_pdf)])
+
+        assert result.exit_code == 1
+        assert "PDF extraction failed" in result.output
+
+    def test_resume_option_required(self) -> None:
+        """Missing --resume option shows error."""
+        result = runner.invoke(app, ["parse-resume"])
+
+        assert result.exit_code != 0
+        assert "Missing" in result.output or "--resume" in result.output

--- a/tests/test_parse_resume.py
+++ b/tests/test_parse_resume.py
@@ -142,3 +142,32 @@ class TestParseResume:
             result = parse_resume(state)
 
         assert result["job_description"].raw_text == "Backend Engineer role"
+
+    @patch("resume_operator.nodes.parse_resume.get_llm")
+    @patch("resume_operator.nodes.parse_resume.extract_text")
+    def test_handles_null_fields_from_llm(
+        self, mock_extract: MagicMock, mock_get_llm: MagicMock, base_state: ResumeOptimizerState
+    ) -> None:
+        """LLM may return null for optional fields — node should coerce to defaults."""
+        mock_extract.return_value = SAMPLE_RESUME_TEXT
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value.content = """{
+            "name": "Jane Smith",
+            "email": "jane@example.com",
+            "phone": null,
+            "summary": null,
+            "experience": null,
+            "education": [],
+            "skills": ["Python"],
+            "certifications": null
+        }"""
+        mock_get_llm.return_value = mock_llm
+
+        result = parse_resume(base_state)
+
+        assert "resume" in result
+        assert result["resume"].phone == ""
+        assert result["resume"].summary == ""
+        assert result["resume"].experience == []
+        assert result["resume"].certifications == []
+        assert result["resume"].skills == ["Python"]


### PR DESCRIPTION
## Summary

- Wire the `parse-resume` CLI command to invoke the LangGraph pipeline and display extracted resume data with Rich formatting
- Fix null coercion bug in `parse_resume` node where LLM-returned `null` values caused Pydantic `ValidationError`
- Add `.claude/rules/logging.md` establishing logging conventions for all nodes and tools

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/14

This is the first end-to-end user-visible feature: PDF → LLM → structured data → terminal output. During real-world testing, discovered that LLMs return `null` for optional fields (e.g., `"phone": null`), which crashed the pipeline — fixed alongside the CLI wiring.

## Changes

- **`src/resume_operator/main.py`** — Implemented `parse-resume` command: file validation, `build_graph().invoke()` with Rich `Status` spinner, error display in `[red]`, formatted output (name, email, phone, skills, experience/education/certifications counts)
- **`src/resume_operator/nodes/parse_resume.py`** — Changed `parsed.get("field", "")` to `parsed.get("field") or ""` for all fields to handle LLM-returned `null` values
- **`tests/test_main.py`** (new) — 5 CLI tests using `typer.testing.CliRunner` with mocked `build_graph`
- **`tests/test_parse_resume.py`** — Added `test_handles_null_fields_from_llm` covering the null coercion fix
- **`.claude/rules/logging.md`** (new) — Logging conventions: node entry/exit pattern, LLM call logging, log levels, CLI `--verbose` design, security constraints
- **`.claude/CLAUDE.md`** — Added logging rule reference
- **`docs/issues/008-wire-parse-resume-cli.md`** — Marked all tasks complete with implementation details

## How to Test

```bash
# Automated tests (45 total, all passing)
uv run pytest tests/test_main.py tests/test_parse_resume.py -v

# Manual smoke test (no API key needed)
uv run python -m resume_operator parse-resume --resume nonexistent.pdf  # should show red error

# Full end-to-end (requires .env with LLM API key)
uv run python -m resume_operator parse-resume --resume path/to/resume.pdf
```
## Checklist

- [x]  Self-reviewed the code
- [x]  Added/updated tests (6 new tests, 45 total passing)
- [x]  No new warnings or errors
- [x]  Passes ruff, mypy, and pytest
- [x]  Updated documentation (issue 008, logging rule)