### PR TITLE
docs: enhance development guide with comprehensive onboarding content

### DIFF
--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -2,6 +2,8 @@
 
 Guide for setting up, running, and contributing to resume-operator.
 
+For the system architecture diagram and data flow, see [docs/architectures/architecture.md](../architectures/architecture.md).
+
 ## Prerequisites
 
 - Python 3.12+
@@ -24,6 +26,23 @@ cp .env.example .env
 # Edit .env — add your LLM API key
 ```
 
+### Environment Variables
+
+All configuration is managed through environment variables loaded by Pydantic Settings
+in `src/resume_operator/config.py`. See `.env.example` for the full list:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LLM_PROVIDER` | `openai` | LLM backend: `openai`, `anthropic`, `google`, or `openrouter` |
+| `LLM_MODEL` | `gpt-4o` | Model name passed to the provider |
+| `OPENAI_API_KEY` | — | Required if `LLM_PROVIDER=openai` |
+| `ANTHROPIC_API_KEY` | — | Required if `LLM_PROVIDER=anthropic` |
+| `GOOGLE_API_KEY` | — | Required if `LLM_PROVIDER=google` |
+| `OPENROUTER_API_KEY` | — | Required if `LLM_PROVIDER=openrouter` |
+| `LOG_LEVEL` | `INFO` | Python logging level |
+
+You only need **one** API key — the one matching your chosen `LLM_PROVIDER`.
+
 ## Running the Agent
 
 ```bash
@@ -42,15 +61,19 @@ uv run python -m resume_operator --help
 
 ## LangGraph Concepts for This Project
 
+If you're new to LangGraph, here's how the key concepts map to this project.
+
 ### StateGraph
 
 The agent is a LangGraph `StateGraph` — a directed graph where:
-- **State** (`ResumeOptimizerState`) flows through the graph
-- **Nodes** are Python functions that read state and return updates
+- **State** (`ResumeOptimizerState` in `src/resume_operator/state.py`) flows through the graph
+- **Nodes** are Python functions that read state and return updates (in `src/resume_operator/nodes/`)
 - **Edges** define the execution order
 
+The graph is assembled in `src/resume_operator/graph.py`:
+
 ```python
-# How the graph is built (see graph.py)
+# How the graph is built (see src/resume_operator/graph.py)
 graph = StateGraph(ResumeOptimizerState)
 graph.add_node("parse_resume", parse_resume)  # Register a node
 graph.add_edge(START, "parse_resume")          # Define flow
@@ -58,12 +81,33 @@ compiled = graph.compile()                      # Make it runnable
 result = compiled.invoke(initial_state)         # Execute
 ```
 
+**`compile()`** validates the graph and returns a runnable object. **`invoke()`** runs the
+full pipeline, passing the state through each node in edge order. Each node receives the
+full state and returns a dict of fields to update — LangGraph merges the update into the
+state automatically.
+
+### State Model
+
+`ResumeOptimizerState` in `src/resume_operator/state.py` is the single data contract.
+All sub-models (`ResumeData`, `JobDescription`, `ATSScore`, `GapAnalysis`, `OptimizedResume`)
+are Pydantic `BaseModel` classes with typed fields and defaults. Nodes read from state and
+return only the fields they update.
+
 ### Node Pattern
 
-Every node follows the same pattern:
+Every node follows the same pattern (one function per file in `src/resume_operator/nodes/`):
 
 ```python
-def my_node(state: ResumeOptimizerState) -> dict:
+# src/resume_operator/nodes/my_node.py
+import logging
+from typing import Any
+from resume_operator.state import ResumeOptimizerState
+
+logger = logging.getLogger(__name__)
+
+def my_node(state: ResumeOptimizerState) -> dict[str, Any]:
+    logger.info("my_node: starting")
+
     # 1. Read what you need from state
     data = state.some_field
 
@@ -71,40 +115,65 @@ def my_node(state: ResumeOptimizerState) -> dict:
     result = some_tool(data)
 
     # 3. Return ONLY the fields you're updating
+    logger.info("my_node: completed — key_metric=%s", metric)
     return {"output_field": result}
 ```
 
 Key rules:
 - Return a **dict**, not the full state — LangGraph merges it automatically
-- Call **tools** for I/O, don't import external libraries directly
-- Use **prompt templates** from `prompts/`, not inline strings
+- Call **tools** (`src/resume_operator/tools/`) for I/O, don't import external libraries directly
+- Use **prompt templates** from `src/resume_operator/prompts/`, not inline strings
 - **Catch exceptions** and append to `state.errors` instead of crashing
+- **Log** entry/exit at INFO level (see `.claude/rules/logging.md`)
+
+For a complete working example, see `src/resume_operator/nodes/parse_resume.py`.
 
 ### Pipeline Flow
 
 ```
-parse_resume → ats_score → analyze_gaps → optimize_content → generate_pdf → report_results
+START → parse_resume → ats_score → analyze_gaps → optimize_content → generate_pdf → report_results → END
 ```
 
-Each node adds data to the state. Later nodes read earlier nodes' output.
+Each node adds data to the state. Later nodes read earlier nodes' output. For the full
+data flow diagram, see [docs/architectures/architecture.md](../architectures/architecture.md).
 
 ## Adding a New Node
 
-1. Create `src/resume_operator/nodes/my_node.py` with one public function
-2. Add it to `src/resume_operator/nodes/__init__.py`
-3. Wire it into `src/resume_operator/graph.py`:
+1. **Create the node file** — `src/resume_operator/nodes/my_node.py` with one public function
+   following the node pattern above. Use tools from `src/resume_operator/tools/` for I/O
+   and prompts from `src/resume_operator/prompts/` for LLM calls.
+
+2. **Export it** — Add the import to `src/resume_operator/nodes/__init__.py`:
+   ```python
+   from resume_operator.nodes.my_node import my_node
+   ```
+
+3. **Wire it into the graph** — Edit `src/resume_operator/graph.py`:
    ```python
    graph.add_node("my_node", my_node)
    graph.add_edge("previous_node", "my_node")
+   graph.add_edge("my_node", "next_node")
    ```
-4. Update `.claude/CLAUDE.md` — Repository Layout + Agent Flow
-5. Update `docs/architecture.md` — system diagram
+
+4. **Add state fields** — If the node produces new data, add the corresponding Pydantic
+   model and field to `src/resume_operator/state.py`.
+
+5. **Write tests** — Create `tests/test_my_node.py`. Mock all tools (`get_llm`,
+   `extract_text`, etc.) and use fixtures from `tests/conftest.py`.
+
+6. **Update docs** — Update `.claude/CLAUDE.md` (Repository Layout + Agent Flow) and
+   `docs/architectures/architecture.md` (system diagram).
 
 ## Adding a New Tool
 
-1. Create `src/resume_operator/tools/my_tool.py`
-2. Update `.claude/rules/architecture.md` — Tools Layer table
-3. Update `.claude/CLAUDE.md` — Repository Layout
+1. **Create the tool file** — `src/resume_operator/tools/my_tool.py`. Tools handle external
+   I/O (files, APIs, LLMs). Keep them focused — one concern per file.
+
+2. **Use it from nodes** — Import the tool in your node and call it. Nodes call tools;
+   tools never call nodes.
+
+3. **Update docs** — Update `.claude/rules/architecture.md` (Tools Layer table) and
+   `.claude/CLAUDE.md` (Repository Layout).
 
 ## Testing
 
@@ -124,14 +193,19 @@ uv run coverage run -m pytest && uv run coverage report
 
 ### Mocking Pattern
 
-All external I/O must be mocked in tests:
+All external I/O must be mocked in tests. Patch at the **call site**, not the definition:
 
 ```python
 from unittest.mock import patch, MagicMock
 
-@patch("resume_operator.tools.llm_provider.get_llm")
-def test_my_node(mock_get_llm):
-    # Set up mock LLM response
+# Patch where the function is used (in the node), not where it's defined (in tools/)
+@patch("resume_operator.nodes.my_node.get_llm")
+@patch("resume_operator.nodes.my_node.extract_text")
+def test_my_node(mock_extract, mock_get_llm):
+    # Mock PDF extraction
+    mock_extract.return_value = "Jane Smith\njane@example.com\n..."
+
+    # Mock LLM response
     mock_llm = MagicMock()
     mock_llm.invoke.return_value.content = '{"key": "value"}'
     mock_get_llm.return_value = mock_llm
@@ -144,12 +218,22 @@ def test_my_node(mock_get_llm):
     assert "output_field" in result
 ```
 
+For a full working test example, see `tests/test_parse_resume.py`.
+
 ### Fixtures
 
 Shared fixtures in `tests/conftest.py`:
-- `sample_resume` — Pre-built `ResumeData`
-- `sample_job` — Pre-built `JobDescription`
-- `sample_state` — Full `ResumeOptimizerState` with all fields populated
+- `sample_resume` — Pre-built `ResumeData` with realistic fields
+- `sample_job` — Pre-built `JobDescription` with requirements and keywords
+- `sample_state` — Full `ResumeOptimizerState` with resume + job + analysis populated
+
+Use these to avoid boilerplate in node tests:
+
+```python
+def test_uses_resume_from_state(self, sample_state):
+    result = my_node(sample_state)
+    assert result["some_field"] is not None
+```
 
 ## Code Quality
 
@@ -172,4 +256,21 @@ uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv ru
 - **Commits**: `type(scope): description` — see `.claude/rules/git-commit.md`
 - **Files**: snake_case for files, PascalCase for classes
 - **Types**: strict mypy, all functions typed
-- **Config**: env vars via `config.py`, never hardcode
+- **Config**: env vars via `src/resume_operator/config.py`, never hardcode
+- **Logging**: use `logging.getLogger(__name__)`, never `print()` — see `.claude/rules/logging.md`
+- **Security**: never commit API keys or personal data — see `.claude/rules/security.md`
+
+## Key Files Reference
+
+| File | Purpose |
+|------|---------|
+| `src/resume_operator/main.py` | CLI entry point (Typer app) |
+| `src/resume_operator/config.py` | Pydantic Settings — env var bindings |
+| `src/resume_operator/state.py` | `ResumeOptimizerState` — central data contract |
+| `src/resume_operator/graph.py` | LangGraph StateGraph assembly |
+| `src/resume_operator/nodes/` | One node function per file |
+| `src/resume_operator/tools/` | I/O utilities (PDF parsing, LLM, PDF generation) |
+| `src/resume_operator/prompts/` | LLM prompt templates as string constants |
+| `tests/conftest.py` | Shared pytest fixtures |
+| `.env.example` | Environment variable template |
+| `docs/architectures/architecture.md` | System diagram and data flow |

--- a/docs/issues/009-development-guide.md
+++ b/docs/issues/009-development-guide.md
@@ -10,16 +10,18 @@ The project uses LangGraph patterns that may be unfamiliar to contributors. A cl
 
 ## Tasks
 
-- [ ] Create `docs/development.md`
-- [ ] Section: Prerequisites (Python 3.12+, API key)
-- [ ] Section: Setup (clone, install, .env configuration)
-- [ ] Section: Running the agent (CLI commands with examples)
-- [ ] Section: LangGraph concepts for this project (StateGraph, nodes, edges, state, compile, invoke)
-- [ ] Section: Adding a new node (step-by-step with file locations)
-- [ ] Section: Adding a new tool (step-by-step)
-- [ ] Section: Testing (how to run, how to mock, fixture patterns)
-- [ ] Section: Code quality (ruff, mypy, pytest commands)
-- [ ] Reference `docs/architecture.md` for system diagram
+- [x] Enhance `docs/guides/development.md` with comprehensive developer onboarding content
+- [x] Section: Prerequisites (Python 3.12+, uv, API key, Git)
+- [x] Section: Setup (clone, install, .env configuration) with environment variables table
+- [x] Section: Running the agent (CLI commands with examples for run, parse-resume, score)
+- [x] Section: LangGraph concepts (StateGraph, State Model, Node Pattern, Pipeline Flow) with references to actual project files
+- [x] Section: Adding a new node (6-step guide with file locations and code examples)
+- [x] Section: Adding a new tool (3-step guide)
+- [x] Section: Testing (commands, mocking pattern with call-site patching, fixture usage examples)
+- [x] Section: Code quality (ruff check, ruff format, mypy, combined command)
+- [x] Reference `docs/architectures/architecture.md` for system diagram and data flow
+- [x] Section: Key Files Reference table mapping important files to their purpose
+- [x] Section: Project Conventions (commits, files, types, config, logging, security)
 
 ## Acceptance Criteria
 
@@ -29,7 +31,8 @@ The project uses LangGraph patterns that may be unfamiliar to contributors. A cl
 
 ## Key Files
 
-- `docs/development.md` (new)
+- `docs/guides/development.md` (enhanced)
+- `docs/issues/009-development-guide.md` (updated)
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- Enhance `docs/guides/development.md` with comprehensive developer onboarding content including environment variables table, LangGraph concept explanations with actual file references, expanded step-by-step guides for adding nodes/tools, and call-site mocking patterns
- Add Key Files Reference table and architecture doc cross-references throughout
- Update issue 009 tasks to reflect completed work

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/16

## Changes

- **Environment Variables**: Added table documenting all env vars with defaults and descriptions
- **LangGraph Concepts**: Added State Model subsection, expanded StateGraph/Node Pattern with explicit file paths (`src/resume_operator/state.py`, `src/resume_operator/graph.py`, etc.)
- **Node Pattern**: Now includes logging, imports, and `dict[str, Any]` return type — references `parse_resume.py` as working example
- **Adding a New Node**: Expanded from 5 to 6 steps — includes state fields, test creation, and doc updates
- **Adding a New Tool**: Expanded with more context on tool design
- **Testing**: Mocking pattern now demonstrates call-site patching (not definition-site), shows both PDF and LLM mocks, references `test_parse_resume.py`
- **Fixtures**: Added usage example
- **Conventions**: Added logging and security rules
- **Key Files Reference**: New table mapping 10 key files to their purpose
- **Architecture references**: Linked to `docs/architectures/architecture.md` at top and in pipeline flow section

## How to Test

1. Read `docs/guides/development.md` end-to-end
2. Verify a new developer could follow from clone → `parse-resume` execution
3. Verify all referenced file paths exist in the repo

## Checklist

- [x] Self-reviewed the code
- [x] Guide references actual project files, not generic paths
- [x] No new warnings or errors
- [x] Issue 009 tasks updated to reflect implementation
