### PR TITLE
feat(nodes): implement generate_pdf node with tests

### DIFF
--- a/docs/issues/014-implement-generate-pdf-node.md
+++ b/docs/issues/014-implement-generate-pdf-node.md
@@ -12,19 +12,23 @@ The generate_pdf node converts the LLM's optimized content into a tangible PDF f
 
 ### Implementation
 
-- [ ] Import `tools.pdf_generator.generate_pdf`
-- [ ] Read `state.optimized_resume.sections` and `state.output_path`
-- [ ] If `output_path` is empty, default to `data/optimized_resume.pdf`
-- [ ] Call `generate_pdf(sections, Path(output_path))`
-- [ ] Return `{"output_path": str(result_path)}`
-- [ ] Error handling: catch exceptions, record in `state.errors`
+- [x] Import `tools.pdf_generator.generate_pdf` (aliased as `create_pdf` to avoid name collision with node function)
+- [x] Read `state.optimized_resume.sections` and `state.output_path`
+- [x] If `output_path` is empty, default to `data/optimized_resume.pdf`
+- [x] Call `generate_pdf(sections, Path(output_path))`
+- [x] Return `{"output_path": str(result_path)}`
+- [x] Error handling: catch exceptions, record in `state.errors`
+- [x] Logging: INFO at node start/completion (with output path and file size), ERROR on failure
 
 ### Tests
 
-- [ ] Create `tests/test_generate_pdf_node.py`
-- [ ] Mock `tools.pdf_generator.generate_pdf`, test node calls it correctly
-- [ ] Test error handling when generator fails
-- [ ] Test default output path when none specified
+- [x] Create `tests/test_generate_pdf.py` (named to match project convention: `test_<module>.py`)
+- [x] Mock `tools.pdf_generator.generate_pdf`, test node calls it with correct sections and path
+- [x] Test error handling when generator fails (errors recorded, no output_path returned)
+- [x] Test default output path when none specified
+- [x] Test returns only changed fields (output_path, optionally errors)
+- [x] Test preserves existing errors when new error occurs
+- [x] Test errors key omitted on success
 
 ## Acceptance Criteria
 

--- a/src/resume_operator/nodes/generate_pdf.py
+++ b/src/resume_operator/nodes/generate_pdf.py
@@ -1,8 +1,15 @@
 """Node: Generate optimized resume as PDF."""
 
+import logging
+from pathlib import Path
 from typing import Any
 
 from resume_operator.state import ResumeOptimizerState
+from resume_operator.tools.pdf_generator import generate_pdf as create_pdf
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT_PATH = "data/optimized_resume.pdf"
 
 
 def generate_pdf(state: ResumeOptimizerState) -> dict[str, Any]:
@@ -11,6 +18,26 @@ def generate_pdf(state: ResumeOptimizerState) -> dict[str, Any]:
     Takes the optimized resume sections and renders them into a
     professionally formatted PDF file.
     """
-    # TODO: Call tools/pdf_generator.py with optimized_resume data
-    # TODO: Return {"output_path": "<path to generated PDF>"}
-    return {}
+    logger.info("generate_pdf: starting")
+    errors: list[str] = list(state.errors)
+
+    output_path = state.output_path or DEFAULT_OUTPUT_PATH
+
+    try:
+        result_path = create_pdf(state.optimized_resume.sections, Path(output_path))
+    except Exception as exc:
+        logger.error("generate_pdf: PDF generation failed: %s", exc)
+        errors.append(f"generate_pdf: PDF generation failed: {exc}")
+        return {"errors": errors}
+
+    file_size = result_path.stat().st_size
+    logger.info(
+        "generate_pdf: completed — output=%s, size=%d bytes",
+        result_path,
+        file_size,
+    )
+
+    result: dict[str, Any] = {"output_path": str(result_path)}
+    if errors != list(state.errors):
+        result["errors"] = errors
+    return result

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -1,0 +1,107 @@
+"""Tests for the generate_pdf node."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from resume_operator.nodes.generate_pdf import generate_pdf
+from resume_operator.state import OptimizedResume, ResumeOptimizerState
+
+SAMPLE_SECTIONS = {
+    "summary": "Senior engineer with 8 years of Python experience.",
+    "experience": "Led backend team building microservices.",
+    "skills": "Python, AWS, Docker, Kubernetes",
+}
+
+
+def _mock_path(path_str: str, size: int = 12345) -> MagicMock:
+    """Create a MagicMock that behaves like a Path return value."""
+    mock = MagicMock(spec=Path)
+    mock.stat.return_value.st_size = size
+    mock.__str__ = lambda self: path_str
+    return mock
+
+
+class TestGeneratePdf:
+    @patch("resume_operator.nodes.generate_pdf.create_pdf")
+    def test_calls_generator_and_returns_output_path(
+        self, mock_create_pdf: MagicMock, sample_state: ResumeOptimizerState
+    ) -> None:
+        sample_state.optimized_resume = OptimizedResume(sections=SAMPLE_SECTIONS)
+        sample_state.output_path = "output/resume.pdf"
+        mock_create_pdf.return_value = _mock_path("output/resume.pdf")
+
+        result = generate_pdf(sample_state)
+
+        mock_create_pdf.assert_called_once_with(SAMPLE_SECTIONS, Path("output/resume.pdf"))
+        assert result["output_path"] == "output/resume.pdf"
+        assert "errors" not in result
+
+    @patch("resume_operator.nodes.generate_pdf.create_pdf")
+    def test_records_error_when_generator_fails(
+        self, mock_create_pdf: MagicMock, sample_state: ResumeOptimizerState
+    ) -> None:
+        sample_state.optimized_resume = OptimizedResume(sections=SAMPLE_SECTIONS)
+        sample_state.output_path = "output/resume.pdf"
+        mock_create_pdf.side_effect = ValueError("sections must not be empty")
+
+        result = generate_pdf(sample_state)
+
+        assert "errors" in result
+        assert any("PDF generation failed" in e for e in result["errors"])
+        assert "output_path" not in result
+
+    @patch("resume_operator.nodes.generate_pdf.create_pdf")
+    def test_uses_default_path_when_output_path_empty(
+        self, mock_create_pdf: MagicMock, sample_state: ResumeOptimizerState
+    ) -> None:
+        sample_state.optimized_resume = OptimizedResume(sections=SAMPLE_SECTIONS)
+        sample_state.output_path = ""
+        mock_create_pdf.return_value = _mock_path("data/optimized_resume.pdf")
+
+        result = generate_pdf(sample_state)
+
+        mock_create_pdf.assert_called_once_with(SAMPLE_SECTIONS, Path("data/optimized_resume.pdf"))
+        assert result["output_path"] == "data/optimized_resume.pdf"
+
+    @patch("resume_operator.nodes.generate_pdf.create_pdf")
+    def test_returns_only_changed_fields(
+        self, mock_create_pdf: MagicMock, sample_state: ResumeOptimizerState
+    ) -> None:
+        sample_state.optimized_resume = OptimizedResume(sections=SAMPLE_SECTIONS)
+        sample_state.output_path = "out.pdf"
+        mock_create_pdf.return_value = _mock_path("out.pdf")
+
+        result = generate_pdf(sample_state)
+
+        allowed_keys = {"output_path", "errors"}
+        assert set(result.keys()).issubset(allowed_keys)
+        assert "optimized_resume" not in result
+        assert "resume" not in result
+
+    @patch("resume_operator.nodes.generate_pdf.create_pdf")
+    def test_preserves_existing_errors(
+        self, mock_create_pdf: MagicMock, sample_state: ResumeOptimizerState
+    ) -> None:
+        sample_state.optimized_resume = OptimizedResume(sections=SAMPLE_SECTIONS)
+        sample_state.output_path = "out.pdf"
+        sample_state.errors = ["previous error"]
+        mock_create_pdf.side_effect = RuntimeError("disk full")
+
+        result = generate_pdf(sample_state)
+
+        assert "previous error" in result["errors"]
+        assert any("PDF generation failed" in e for e in result["errors"])
+        assert len(result["errors"]) == 2
+
+    @patch("resume_operator.nodes.generate_pdf.create_pdf")
+    def test_no_errors_key_on_success(
+        self, mock_create_pdf: MagicMock, sample_state: ResumeOptimizerState
+    ) -> None:
+        sample_state.optimized_resume = OptimizedResume(sections=SAMPLE_SECTIONS)
+        sample_state.output_path = "out.pdf"
+        sample_state.errors = ["pre-existing error"]
+        mock_create_pdf.return_value = _mock_path("out.pdf")
+
+        result = generate_pdf(sample_state)
+
+        assert "errors" not in result


### PR DESCRIPTION
## Summary

- Implement the `generate_pdf` node to call `tools/pdf_generator.py` with optimized resume sections and write the output PDF
- Add 6 unit tests covering happy path, error handling, default output path, and edge cases
- Update issue #014 checklist to reflect completed tasks

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/14

The `generate_pdf` node is the second-to-last step in the pipeline (`optimize_content` → **generate_pdf** → `report_results`). Without it, the LLM-optimized content stays in memory and the user gets no downloadable file.

## Changes

- **`src/resume_operator/nodes/generate_pdf.py`** — Replaced stub with full implementation:
  - Imports `tools.pdf_generator.generate_pdf` (aliased as `create_pdf` to avoid name collision)
  - Reads `state.optimized_resume.sections` and `state.output_path`
  - Falls back to `data/optimized_resume.pdf` when output path is empty
  - Catches exceptions, records in `state.errors`, pipeline continues
  - Logs start, completion (with output path and file size), and errors
- **`tests/test_generate_pdf.py`** — New test file with 6 tests:
  - `test_calls_generator_and_returns_output_path` — happy path
  - `test_records_error_when_generator_fails` — error handling
  - `test_uses_default_path_when_output_path_empty` — default fallback
  - `test_returns_only_changed_fields` — no extra state keys leaked
  - `test_preserves_existing_errors` — appends without losing prior errors
  - `test_no_errors_key_on_success` — errors key omitted when clean
- **`docs/issues/014-implement-generate-pdf-node.md`** — Marked all tasks complete

## How to Test

1. Checkout this branch
2. Run `uv sync --dev`
3. Run `uv run pytest tests/test_generate_pdf.py -v` — all 6 tests pass
4. Run `uv run pytest` — full suite (74 tests) passes
5. Run `uv run ruff check src/ tests/` — no lint issues
6. Run `uv run mypy src/` — no type errors

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests (6 new tests, all passing)
- [x] No new warnings or errors
- [x] Lint, format, and type checks pass
- [x] Updated issue documentation
