### PR TITLE
feat(nodes): implement report_results node with tests

### DIFF
--- a/docs/issues/015-implement-report-results-node.md
+++ b/docs/issues/015-implement-report-results-node.md
@@ -12,18 +12,24 @@ The JSON report provides a machine-readable summary of what the optimizer did. I
 
 ### Implementation
 
-- [ ] Build a report dict from state: original resume path, job description, ATS score, gap analysis, optimization changes, output path, errors, timestamp
-- [ ] Write the report to `data/results.json` using `json.dump` with indent=2
-- [ ] Ensure `data/` directory is created if missing
-- [ ] Return `{"report": report_dict}`
-- [ ] Use `datetime.now().isoformat()` for timestamp
+- [x] Build a report dict from state: resume_path, job_description_path, ATS score (`model_dump()`), gap analysis (`model_dump()`), optimization changes, output path, errors, timestamp
+- [x] Write the report to `data/results.json` using `json.dump` with indent=2
+- [x] Ensure `data/` directory is created if missing (`mkdir(parents=True, exist_ok=True)`)
+- [x] Return `{"report": report_dict}`
+- [x] Use `datetime.now().isoformat()` for timestamp
+- [x] Error handling: catch exceptions, record in `state.errors`, return early
+- [x] Logging: INFO at node start/completion (with output path), ERROR on failure
+- [x] Defined `RESULTS_PATH = Path("data/results.json")` as patchable module constant for testability
 
 ### Tests
 
-- [ ] Create `tests/test_report_results.py`
-- [ ] Test: `test_writes_json_report` — use `tmp_path`, verify JSON written and parseable
-- [ ] Test: `test_report_contains_all_fields` — verify timestamp, ats_score, gaps, etc.
-- [ ] Test: `test_creates_data_directory` — verify dir creation
+- [x] Create `tests/test_report_results.py`
+- [x] Test: `test_writes_json_report` — use `tmp_path`, verify JSON written and parseable
+- [x] Test: `test_report_contains_all_fields` — verify all 8 keys, validate timestamp is ISO format, check ats_score.score matches fixture
+- [x] Test: `test_creates_data_directory` — verify nested dir creation
+- [x] Test: `test_handles_write_error` — mock PermissionError, verify error recorded, no report returned
+- [x] Test: `test_preserves_existing_errors` — pre-existing errors kept when new error occurs
+- [x] Test: `test_returns_only_changed_fields` — result keys subset of {report, errors}
 
 ## Acceptance Criteria
 

--- a/src/resume_operator/nodes/report_results.py
+++ b/src/resume_operator/nodes/report_results.py
@@ -1,8 +1,16 @@
 """Node: Save optimization results to JSON."""
 
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 from resume_operator.state import ResumeOptimizerState
+
+logger = logging.getLogger(__name__)
+
+RESULTS_PATH = Path("data/results.json")
 
 
 def report_results(state: ResumeOptimizerState) -> dict[str, Any]:
@@ -11,6 +19,35 @@ def report_results(state: ResumeOptimizerState) -> dict[str, Any]:
     Writes a JSON report to data/ with ATS scores, gap analysis,
     changes made, and any errors encountered.
     """
-    # TODO: Build report dict from state fields
-    # TODO: Write JSON to data/results.json
-    return {}
+    logger.info("report_results: starting")
+    errors: list[str] = list(state.errors)
+
+    try:
+        report: dict[str, object] = {
+            "timestamp": datetime.now().isoformat(),
+            "resume_path": state.resume_path,
+            "job_description_path": state.job_description_path,
+            "ats_score": state.ats_score.model_dump(),
+            "gap_analysis": state.gap_analysis.model_dump(),
+            "optimization_changes": state.optimized_resume.changes_made,
+            "output_path": state.output_path,
+            "errors": list(state.errors),
+        }
+
+        output_path = RESULTS_PATH
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with output_path.open("w") as f:
+            json.dump(report, f, indent=2)
+
+    except Exception as exc:
+        logger.error("report_results: failed: %s", exc)
+        errors.append(f"report_results: failed: {exc}")
+        return {"errors": errors}
+
+    logger.info("report_results: completed — wrote %s", output_path)
+
+    result: dict[str, Any] = {"report": report}
+    if errors != list(state.errors):
+        result["errors"] = errors
+    return result

--- a/tests/test_report_results.py
+++ b/tests/test_report_results.py
@@ -1,0 +1,123 @@
+"""Tests for the report_results node."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from resume_operator.nodes.report_results import report_results
+from resume_operator.state import OptimizedResume, ResumeOptimizerState
+
+
+def _setup_state(state: ResumeOptimizerState) -> None:
+    """Populate fields not set by the sample_state fixture."""
+    state.optimized_resume = OptimizedResume(
+        sections={"summary": "Optimized summary.", "skills": "Python, AWS"},
+        changes_made=["Added Kubernetes to skills", "Rewrote summary"],
+    )
+    state.output_path = "data/optimized_resume.pdf"
+
+
+EXPECTED_KEYS = {
+    "timestamp",
+    "resume_path",
+    "job_description_path",
+    "ats_score",
+    "gap_analysis",
+    "optimization_changes",
+    "output_path",
+    "errors",
+}
+
+
+class TestReportResults:
+    def test_writes_json_report(self, sample_state: ResumeOptimizerState, tmp_path: Path) -> None:
+        _setup_state(sample_state)
+        results_file = tmp_path / "data" / "results.json"
+
+        with patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file):
+            result = report_results(sample_state)
+
+        assert results_file.exists()
+        data = json.loads(results_file.read_text())
+        assert isinstance(data, dict)
+        assert "report" in result
+
+    def test_report_contains_all_fields(
+        self, sample_state: ResumeOptimizerState, tmp_path: Path
+    ) -> None:
+        _setup_state(sample_state)
+        results_file = tmp_path / "data" / "results.json"
+
+        with patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file):
+            result = report_results(sample_state)
+
+        report = result["report"]
+        assert set(report.keys()) == EXPECTED_KEYS
+        assert report["ats_score"]["score"] == 0.72
+        assert len(report["gap_analysis"]["gaps"]) > 0
+        assert report["optimization_changes"] == [
+            "Added Kubernetes to skills",
+            "Rewrote summary",
+        ]
+        assert report["resume_path"] == "test_resume.pdf"
+        assert report["output_path"] == "data/optimized_resume.pdf"
+        # Validate timestamp is parseable ISO format
+        datetime.fromisoformat(report["timestamp"])
+
+    def test_creates_data_directory(
+        self, sample_state: ResumeOptimizerState, tmp_path: Path
+    ) -> None:
+        _setup_state(sample_state)
+        results_file = tmp_path / "nonexistent" / "subdir" / "results.json"
+
+        with patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file):
+            report_results(sample_state)
+
+        assert results_file.parent.exists()
+        assert results_file.exists()
+
+    def test_handles_write_error(self, sample_state: ResumeOptimizerState, tmp_path: Path) -> None:
+        _setup_state(sample_state)
+        results_file = tmp_path / "data" / "results.json"
+
+        with (
+            patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file),
+            patch.object(Path, "open", side_effect=PermissionError("read-only")),
+        ):
+            result = report_results(sample_state)
+
+        assert "errors" in result
+        assert any("report_results: failed" in e for e in result["errors"])
+        assert "report" not in result
+
+    def test_preserves_existing_errors(
+        self, sample_state: ResumeOptimizerState, tmp_path: Path
+    ) -> None:
+        _setup_state(sample_state)
+        sample_state.errors = ["earlier failure"]
+        results_file = tmp_path / "data" / "results.json"
+
+        with (
+            patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file),
+            patch.object(Path, "open", side_effect=PermissionError("read-only")),
+        ):
+            result = report_results(sample_state)
+
+        assert "earlier failure" in result["errors"]
+        assert any("report_results: failed" in e for e in result["errors"])
+        assert len(result["errors"]) == 2
+
+    def test_returns_only_changed_fields(
+        self, sample_state: ResumeOptimizerState, tmp_path: Path
+    ) -> None:
+        _setup_state(sample_state)
+        results_file = tmp_path / "data" / "results.json"
+
+        with patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file):
+            result = report_results(sample_state)
+
+        allowed_keys = {"report", "errors"}
+        assert set(result.keys()).issubset(allowed_keys)
+        assert "resume" not in result
+        assert "ats_score" not in result


### PR DESCRIPTION
## Summary

- Implement the `report_results` node to compile all pipeline results into a JSON report and write it to `data/results.json`
- Add 6 unit tests using `tmp_path` covering JSON output, field completeness, directory creation, and error handling
- Update issue #015 checklist to reflect completed tasks

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/15

The `report_results` node is the final step in the pipeline (`generate_pdf` → **report_results** → END). It produces a machine-readable JSON summary of the entire optimization run — ATS score, gap analysis, changes made, errors, and timestamp — useful for reviewing results, comparing runs, and debugging.

## Changes

- **`src/resume_operator/nodes/report_results.py`** — Replaced stub with full implementation:
  - Builds report dict from state: timestamp, resume_path, job_description_path, ats_score, gap_analysis, optimization_changes, output_path, errors
  - Uses `model_dump()` to serialize Pydantic sub-models (ATSScore, GapAnalysis)
  - Creates `data/` directory if missing (`mkdir(parents=True, exist_ok=True)`)
  - Writes JSON with `indent=2` formatting
  - Catches exceptions, records in `state.errors`, pipeline continues
  - Logs start and completion (with output path)
  - Defined `RESULTS_PATH` as patchable module constant for testability
- **`tests/test_report_results.py`** — New test file with 6 tests:
  - `test_writes_json_report` — file exists and is valid JSON
  - `test_report_contains_all_fields` — all 8 keys present, values match fixture data, timestamp is valid ISO format
  - `test_creates_data_directory` — nested directory creation works
  - `test_handles_write_error` — PermissionError recorded, no report returned
  - `test_preserves_existing_errors` — pre-existing errors kept on failure
  - `test_returns_only_changed_fields` — no extra state keys leaked
- **`docs/issues/015-implement-report-results-node.md`** — Marked all tasks complete

## How to Test

1. Checkout this branch
2. Run `uv sync --dev`
3. Run `uv run pytest tests/test_report_results.py -v` — all 6 tests pass
4. Run `uv run pytest` — full suite (80 tests) passes
5. Run `uv run ruff check src/ tests/` — no lint issues
6. Run `uv run mypy src/` — no type errors

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests (6 new tests, all passing)
- [x] No new warnings or errors
- [x] Lint, format, and type checks pass
- [x] Updated issue documentation
