### PR TITLE
test(graph): add full pipeline integration test with mocked LLM

### DIFF
--- a/docs/issues/016-full-pipeline-integration-test.md
+++ b/docs/issues/016-full-pipeline-integration-test.md
@@ -16,14 +16,15 @@ Individual node tests verify each piece works in isolation. This integration tes
 
 ## Tasks
 
-- [ ] Create `tests/test_integration.py`
-- [ ] Mock `get_llm` to return pre-canned JSON responses for each node's expected prompt
-- [ ] Mock `pdf_parser.extract_text` to return sample resume text
-- [ ] Mock `pdf_generator.generate_pdf` to return a path without creating a file
-- [ ] Invoke the compiled graph with initial state (resume_path, job_description_path, output_path)
-- [ ] Verify final state has: populated `resume`, `ats_score`, `gap_analysis`, `optimized_resume`, `output_path`, `report`
-- [ ] Verify `errors` list is empty (happy path)
-- [ ] Test: `test_pipeline_continues_on_node_error` — make one node fail, verify pipeline completes with errors recorded
+- [x] Create `tests/test_integration.py`
+- [x] Mock `get_llm` at each node's import site (4 separate patches) with pre-canned JSON responses
+- [x] Mock `pdf_parser.extract_text` to return sample resume text
+- [x] Mock `pdf_generator.generate_pdf` to return a mock Path without creating a file
+- [x] Mock `report_results.RESULTS_PATH` to redirect JSON output to `tmp_path`
+- [x] Invoke the compiled graph with initial state (resume_path, job_description_text, output_path)
+- [x] Verify final state has: populated `resume`, `ats_score`, `gap_analysis`, `optimized_resume`, `output_path`, `report`
+- [x] Verify `errors` list is empty (happy path)
+- [x] Test: `test_pipeline_continues_on_node_error` — ats_score's `get_llm` raises RuntimeError, pipeline completes with errors recorded, downstream nodes still populate their fields
 
 ## Acceptance Criteria
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,189 @@
+"""Full pipeline integration test with mocked LLM and I/O.
+
+Runs the complete LangGraph pipeline from parse_resume through report_results,
+verifying state flows correctly through all six nodes and edges work end-to-end.
+All external I/O (LLM calls, PDF parsing, PDF generation, file writes) is mocked.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from resume_operator.graph import build_graph
+
+# --- Canned LLM JSON responses for each node ---
+
+PARSE_RESUME_JSON = """{
+    "name": "Jane Smith",
+    "email": "jane@example.com",
+    "phone": "555-0100",
+    "summary": "Senior Python engineer",
+    "experience": [
+        {"title": "Engineer", "company": "Corp", "dates": "2020-now", "description": "Built APIs"}
+    ],
+    "education": [{"degree": "BS CS", "institution": "State U", "dates": "2016"}],
+    "skills": ["Python", "AWS", "Docker"],
+    "certifications": ["AWS SA"]
+}"""
+
+ATS_SCORE_JSON = """{
+    "score": 0.85,
+    "reasoning": "Strong Python and AWS match",
+    "keyword_matches": ["Python", "AWS"],
+    "keyword_gaps": ["Kubernetes", "CI/CD"]
+}"""
+
+ANALYZE_GAPS_JSON = """{
+    "gaps": ["No Kubernetes experience", "No CI/CD mentioned"],
+    "strengths": ["Strong Python background", "AWS certified"],
+    "suggestions": ["Add K8s projects", "Mention CI/CD pipelines"]
+}"""
+
+OPTIMIZE_CONTENT_JSON = """{
+    "sections": {
+        "summary": "Senior Python engineer with cloud and container expertise",
+        "experience": "Built APIs and CI/CD pipelines at Corp",
+        "skills": "Python, AWS, Docker, Kubernetes, CI/CD",
+        "education": "BS CS, State U, 2016"
+    },
+    "changes_made": ["Added Kubernetes to skills", "Mentioned CI/CD in experience"]
+}"""
+
+
+def _make_mock_llm(response_json: str) -> MagicMock:
+    """Create a mock LLM that returns the given JSON from invoke()."""
+    mock_llm = MagicMock()
+    mock_llm.invoke.return_value.content = response_json
+    return mock_llm
+
+
+def _make_mock_pdf_path(path_str: str = "data/optimized_resume.pdf") -> MagicMock:
+    """Create a mock Path return value for pdf_generator."""
+    mock_path = MagicMock(spec=Path)
+    mock_path.stat.return_value.st_size = 10000
+    mock_path.__str__ = lambda self: path_str
+    return mock_path
+
+
+class TestFullPipeline:
+    @patch("resume_operator.nodes.generate_pdf.create_pdf")
+    @patch("resume_operator.nodes.optimize_content.get_llm")
+    @patch("resume_operator.nodes.analyze_gaps.get_llm")
+    @patch("resume_operator.nodes.ats_score.get_llm")
+    @patch("resume_operator.nodes.parse_resume.get_llm")
+    @patch("resume_operator.nodes.parse_resume.extract_text")
+    def test_full_pipeline_happy_path(
+        self,
+        mock_extract: MagicMock,
+        mock_parse_llm: MagicMock,
+        mock_ats_llm: MagicMock,
+        mock_gaps_llm: MagicMock,
+        mock_optimize_llm: MagicMock,
+        mock_create_pdf: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Full pipeline runs with all state fields populated and no errors."""
+        # Arrange: mock PDF extraction
+        mock_extract.return_value = "Jane Smith\njane@example.com\nSenior Python engineer"
+
+        # Arrange: each node gets its own mock LLM with canned response
+        mock_parse_llm.return_value = _make_mock_llm(PARSE_RESUME_JSON)
+        mock_ats_llm.return_value = _make_mock_llm(ATS_SCORE_JSON)
+        mock_gaps_llm.return_value = _make_mock_llm(ANALYZE_GAPS_JSON)
+        mock_optimize_llm.return_value = _make_mock_llm(OPTIMIZE_CONTENT_JSON)
+
+        # Arrange: mock PDF generation
+        mock_create_pdf.return_value = _make_mock_pdf_path("output/resume.pdf")
+
+        # Arrange: redirect report JSON to tmp_path
+        results_file = tmp_path / "data" / "results.json"
+        with patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file):
+            # Act
+            graph = build_graph()
+            result = graph.invoke(
+                {
+                    "resume_path": "test.pdf",
+                    "job_description_text": "Backend Engineer needing Python, AWS, Kubernetes",
+                    "output_path": "output/resume.pdf",
+                }
+            )
+
+        # Assert: all state fields populated
+        assert result["resume"].name == "Jane Smith"
+        assert result["resume"].skills == ["Python", "AWS", "Docker"]
+
+        assert result["ats_score"].score == 0.85
+        assert "Python" in result["ats_score"].keyword_matches
+        assert "Kubernetes" in result["ats_score"].keyword_gaps
+
+        assert len(result["gap_analysis"].gaps) == 2
+        assert len(result["gap_analysis"].strengths) == 2
+        assert len(result["gap_analysis"].suggestions) == 2
+
+        assert "summary" in result["optimized_resume"].sections
+        assert len(result["optimized_resume"].changes_made) == 2
+
+        assert result["output_path"] == "output/resume.pdf"
+
+        assert isinstance(result["report"], dict)
+        assert "timestamp" in result["report"]
+        assert "ats_score" in result["report"]
+
+        assert result.get("errors", []) == []
+
+        # Assert: all mocks were called
+        mock_extract.assert_called_once()
+        mock_create_pdf.assert_called_once()
+
+    @patch("resume_operator.nodes.generate_pdf.create_pdf")
+    @patch("resume_operator.nodes.optimize_content.get_llm")
+    @patch("resume_operator.nodes.analyze_gaps.get_llm")
+    @patch("resume_operator.nodes.ats_score.get_llm")
+    @patch("resume_operator.nodes.parse_resume.get_llm")
+    @patch("resume_operator.nodes.parse_resume.extract_text")
+    def test_pipeline_continues_on_node_error(
+        self,
+        mock_extract: MagicMock,
+        mock_parse_llm: MagicMock,
+        mock_ats_llm: MagicMock,
+        mock_gaps_llm: MagicMock,
+        mock_optimize_llm: MagicMock,
+        mock_create_pdf: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Pipeline completes even when a node fails, with errors recorded."""
+        # Arrange: parse_resume works
+        mock_extract.return_value = "Jane Smith\njane@example.com"
+        mock_parse_llm.return_value = _make_mock_llm(PARSE_RESUME_JSON)
+
+        # Arrange: ats_score FAILS
+        mock_ats_llm.side_effect = RuntimeError("API unavailable")
+
+        # Arrange: remaining nodes work (they'll use default/empty ats_score)
+        mock_gaps_llm.return_value = _make_mock_llm(ANALYZE_GAPS_JSON)
+        mock_optimize_llm.return_value = _make_mock_llm(OPTIMIZE_CONTENT_JSON)
+        mock_create_pdf.return_value = _make_mock_pdf_path()
+
+        results_file = tmp_path / "data" / "results.json"
+        with patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file):
+            # Act
+            graph = build_graph()
+            result = graph.invoke(
+                {
+                    "resume_path": "test.pdf",
+                    "job_description_text": "Backend Engineer role",
+                    "output_path": "out.pdf",
+                }
+            )
+
+        # Assert: pipeline completed (not crashed)
+        assert "resume" in result
+        assert result["resume"].name == "Jane Smith"
+
+        # Assert: error was recorded from ats_score failure
+        assert len(result["errors"]) > 0
+        assert any("ats_score" in e for e in result["errors"])
+
+        # Assert: downstream nodes still ran
+        assert len(result["gap_analysis"].gaps) > 0
+        assert len(result["optimized_resume"].sections) > 0
+        assert isinstance(result["report"], dict)


### PR DESCRIPTION
## Summary

- Add full end-to-end integration test that runs the complete LangGraph pipeline (all 6 nodes) with mocked I/O
- Verify state accumulates correctly across nodes and the pipeline is resilient to individual node failures
- Update issue #016 checklist to reflect completed tasks

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/16

Individual node tests verify each piece in isolation. This integration test verifies they work together — state flows correctly between nodes via LangGraph's state merging, graph edges execute in order, and the pipeline continues gracefully when a node fails.

## Changes

- **`tests/test_integration.py`** — New integration test file with 2 tests:
  - `test_full_pipeline_happy_path` — Mocks all external I/O (4 LLM calls with canned JSON, PDF parser, PDF generator, report file path). Invokes the compiled graph and verifies all final state fields are populated: `resume`, `ats_score`, `gap_analysis`, `optimized_resume`, `output_path`, `report`, and no errors
  - `test_pipeline_continues_on_node_error` — Same setup but `ats_score`'s LLM raises RuntimeError. Verifies the pipeline still completes, errors are recorded, and downstream nodes (`analyze_gaps`, `optimize_content`, `generate_pdf`, `report_results`) still run and populate their fields
- **`docs/issues/016-full-pipeline-integration-test.md`** — Marked all tasks complete

### Mocking strategy

Each of the 4 LLM-calling nodes imports `get_llm` into its own module namespace, so each is patched separately with its own mock LLM returning node-specific canned JSON. PDF parser, PDF generator, and report results path are also patched to avoid any real file I/O.

## How to Test

1. Checkout this branch
2. Run `uv sync --dev`
3. Run `uv run pytest tests/test_integration.py -v` — both tests pass
4. Run `uv run pytest` — full suite (82 tests) passes
5. Run `uv run ruff check src/ tests/` — no lint issues

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests (2 new integration tests, all passing)
- [x] No new warnings or errors
- [x] Lint and format checks pass
- [x] No real files or API calls in tests
- [x] Updated issue documentation
