### PR TITLE
feat(graph): add conditional routing to skip optimization on high ATS…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ OPENROUTER_API_KEY=
 
 # Logging
 LOG_LEVEL=INFO
+
+# ATS Score Threshold — skip optimization when score is at or above this value
+ATS_SKIP_THRESHOLD=0.9

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,72 @@
+# Architecture
+
+## System Overview
+
+resume-operator is a LangGraph-based pipeline that parses resumes, scores ATS compatibility, analyzes gaps, optimizes content, and generates tailored PDFs.
+
+## Agent Flow
+
+```
+START
+  |
+  v
+parse_resume       Extract text from PDF, structure via LLM
+  |
+  v
+ats_score           Score resume against job description
+  |
+  v
+[conditional]       ATS score >= threshold (default 0.9)?
+  |           \
+  | NO         \ YES
+  v              \
+analyze_gaps      \
+  |                \
+  v                 \
+optimize_content     |
+  |                  |
+  v                  |
+generate_pdf         |
+  |                  |
+  v                  v
+report_results      report_results
+  |
+  v
+END
+```
+
+## Conditional Routing
+
+After `ats_score`, a routing function checks the score against `ATS_SKIP_THRESHOLD` (configurable, default 0.9):
+
+- **Score >= threshold**: Skip optimization — route directly to `report_results`. The report notes `optimization_skipped: true`.
+- **Score < threshold**: Normal path — continue through `analyze_gaps`, `optimize_content`, `generate_pdf`, then `report_results`.
+
+## Components
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| CLI | `main.py` | Typer commands: run, score, parse-resume |
+| Graph | `graph.py` | LangGraph StateGraph with conditional routing |
+| State | `state.py` | Pydantic model flowing through all nodes |
+| Nodes | `nodes/` | One function per file, returns state delta |
+| Tools | `tools/` | I/O utilities (PDF, LLM, JSON parsing) |
+| Prompts | `prompts/` | LLM prompt templates |
+| Config | `config.py` | Pydantic Settings from env vars |
+
+## Data Flow
+
+1. **Input**: Resume PDF path + job description text
+2. **parse_resume**: PDF text extraction (PyMuPDF) + LLM structuring
+3. **ats_score**: LLM-based ATS compatibility scoring (0.0-1.0)
+4. **Routing**: Skip or continue based on score threshold
+5. **analyze_gaps**: LLM identifies gaps, strengths, suggestions
+6. **optimize_content**: LLM rewrites resume sections
+7. **generate_pdf**: ReportLab renders optimized PDF
+8. **report_results**: JSON report to `data/results.json`
+
+## Error Handling
+
+- Each node catches exceptions and records them in `state.errors`
+- Pipeline continues on failure — downstream nodes check preconditions
+- Final report includes all accumulated errors

--- a/docs/issues/023-conditional-routing-skip-optimization.md
+++ b/docs/issues/023-conditional-routing-skip-optimization.md
@@ -16,13 +16,15 @@ If a resume already scores 0.95 against a job description, optimizing it would b
 
 ## Tasks
 
-- [ ] Add `ATS_SKIP_THRESHOLD` to `config.py` Settings class (default: 0.9)
-- [ ] Add `ATS_SKIP_THRESHOLD=0.9` to `.env.example`
-- [ ] In `graph.py`, replace the `ats_score -> analyze_gaps` edge with a conditional edge
-- [ ] Define routing function: if `state.ats_score.score >= threshold`, route to `report_results`; else route to `analyze_gaps`
-- [ ] Use `graph.add_conditional_edges("ats_score", routing_fn, {"optimize": "analyze_gaps", "skip": "report_results"})`
-- [ ] Update `report_results` to note whether optimization was skipped
-- [ ] Write tests in `test_graph.py`: verify routing for scores above and below threshold
+- [x] Add `ats_skip_threshold: float = 0.9` to `config.py` Settings class
+- [x] Add `ATS_SKIP_THRESHOLD=0.9` to `.env.example`
+- [x] In `graph.py`, replace `ats_score -> analyze_gaps` edge with `add_conditional_edges` using `_route_after_ats_score` routing function
+- [x] Define routing function: reads threshold from config, returns `"skip"` if score >= threshold, `"optimize"` otherwise, with INFO logging of the routing decision
+- [x] Use `graph.add_conditional_edges("ats_score", _route_after_ats_score, {"optimize": "analyze_gaps", "skip": "report_results"})`
+- [x] Update `report_results` to include `optimization_skipped` field in report (derived from empty `optimized_resume.sections`)
+- [x] Write 4 routing tests in `test_graph.py::TestConditionalRouting`: high score, exact threshold, low score, zero/default score
+- [x] Create `docs/architecture.md` with conditional flow ASCII diagram, component table, data flow, and error handling description
+- [x] Update `tests/test_report_results.py` expected keys to include `optimization_skipped`
 
 ## Acceptance Criteria
 

--- a/src/resume_operator/config.py
+++ b/src/resume_operator/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     google_api_key: str = ""
     openrouter_api_key: str = ""
     log_level: str = "INFO"
+    ats_skip_threshold: float = 0.9
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/src/resume_operator/graph.py
+++ b/src/resume_operator/graph.py
@@ -1,10 +1,12 @@
 """LangGraph StateGraph assembly for the resume optimization pipeline."""
 
+import logging
 from typing import Any
 
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 
+from resume_operator.config import get_settings
 from resume_operator.nodes.analyze_gaps import analyze_gaps
 from resume_operator.nodes.ats_score import ats_score
 from resume_operator.nodes.generate_pdf import generate_pdf
@@ -12,6 +14,26 @@ from resume_operator.nodes.optimize_content import optimize_content
 from resume_operator.nodes.parse_resume import parse_resume
 from resume_operator.nodes.report_results import report_results
 from resume_operator.state import ResumeOptimizerState
+
+logger = logging.getLogger(__name__)
+
+
+def _route_after_ats_score(state: ResumeOptimizerState) -> str:
+    """Route based on ATS score: skip optimization if score is high enough."""
+    threshold = get_settings().ats_skip_threshold
+    if state.ats_score.score >= threshold:
+        logger.info(
+            "Routing: ATS score %.2f >= threshold %.2f — skipping optimization",
+            state.ats_score.score,
+            threshold,
+        )
+        return "skip"
+    logger.info(
+        "Routing: ATS score %.2f < threshold %.2f — proceeding with optimization",
+        state.ats_score.score,
+        threshold,
+    )
+    return "optimize"
 
 
 def build_graph() -> CompiledStateGraph[Any]:
@@ -26,10 +48,14 @@ def build_graph() -> CompiledStateGraph[Any]:
     graph.add_node("generate_pdf", generate_pdf)
     graph.add_node("report_results", report_results)
 
-    # Linear pipeline edges
+    # Pipeline edges with conditional routing after ATS score
     graph.add_edge(START, "parse_resume")
     graph.add_edge("parse_resume", "ats_score")
-    graph.add_edge("ats_score", "analyze_gaps")
+    graph.add_conditional_edges(
+        "ats_score",
+        _route_after_ats_score,
+        {"optimize": "analyze_gaps", "skip": "report_results"},
+    )
     graph.add_edge("analyze_gaps", "optimize_content")
     graph.add_edge("optimize_content", "generate_pdf")
     graph.add_edge("generate_pdf", "report_results")

--- a/src/resume_operator/nodes/report_results.py
+++ b/src/resume_operator/nodes/report_results.py
@@ -23,12 +23,14 @@ def report_results(state: ResumeOptimizerState) -> dict[str, Any]:
     errors: list[str] = list(state.errors)
 
     try:
+        optimization_skipped = not state.optimized_resume.sections
         report: dict[str, object] = {
             "timestamp": datetime.now().isoformat(),
             "resume_path": state.resume_path,
             "job_description_path": state.job_description_path,
             "ats_score": state.ats_score.model_dump(),
             "gap_analysis": state.gap_analysis.model_dump(),
+            "optimization_skipped": optimization_skipped,
             "optimization_changes": state.optimized_resume.changes_made,
             "output_path": state.output_path,
             "errors": list(state.errors),

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -14,7 +14,8 @@ from unittest.mock import MagicMock, patch
 
 from langgraph.graph.state import CompiledStateGraph
 
-from resume_operator.graph import build_graph
+from resume_operator.graph import _route_after_ats_score, build_graph
+from resume_operator.state import ATSScore, ResumeOptimizerState
 
 EXPECTED_NODES = [
     "parse_resume",
@@ -101,3 +102,37 @@ class TestGraphAssembly:
 
         assert "job_description" in result
         assert result["job_description"].raw_text == "Backend Engineer role"
+
+
+class TestConditionalRouting:
+    @patch("resume_operator.graph.get_settings")
+    def test_high_score_routes_to_skip(self, mock_settings: MagicMock) -> None:
+        """ATS score at or above threshold routes to 'skip'."""
+        mock_settings.return_value.ats_skip_threshold = 0.9
+        state = ResumeOptimizerState(ats_score=ATSScore(score=0.95))
+
+        assert _route_after_ats_score(state) == "skip"
+
+    @patch("resume_operator.graph.get_settings")
+    def test_threshold_score_routes_to_skip(self, mock_settings: MagicMock) -> None:
+        """ATS score exactly at threshold routes to 'skip'."""
+        mock_settings.return_value.ats_skip_threshold = 0.9
+        state = ResumeOptimizerState(ats_score=ATSScore(score=0.9))
+
+        assert _route_after_ats_score(state) == "skip"
+
+    @patch("resume_operator.graph.get_settings")
+    def test_low_score_routes_to_optimize(self, mock_settings: MagicMock) -> None:
+        """ATS score below threshold routes to 'optimize'."""
+        mock_settings.return_value.ats_skip_threshold = 0.9
+        state = ResumeOptimizerState(ats_score=ATSScore(score=0.72))
+
+        assert _route_after_ats_score(state) == "optimize"
+
+    @patch("resume_operator.graph.get_settings")
+    def test_zero_score_routes_to_optimize(self, mock_settings: MagicMock) -> None:
+        """Default zero score routes to 'optimize'."""
+        mock_settings.return_value.ats_skip_threshold = 0.9
+        state = ResumeOptimizerState()
+
+        assert _route_after_ats_score(state) == "optimize"

--- a/tests/test_report_results.py
+++ b/tests/test_report_results.py
@@ -24,6 +24,7 @@ EXPECTED_KEYS = {
     "job_description_path",
     "ats_score",
     "gap_analysis",
+    "optimization_skipped",
     "optimization_changes",
     "output_path",
     "errors",


### PR DESCRIPTION
## Summary

- Add LangGraph conditional edge that skips optimization when ATS score is already high
- Add configurable `ATS_SKIP_THRESHOLD` (default 0.9) to settings and `.env.example`
- Add `optimization_skipped` field to JSON report
- Create `docs/architecture.md` with conditional flow diagram

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/23

If a resume already scores 0.95 against a job description, optimizing it would be unnecessary or could even make it worse. Conditional routing is also a key LangGraph concept needed for future batch mode.

## Changes

- **`src/resume_operator/config.py`** — Added `ats_skip_threshold: float = 0.9` to Settings
- **`.env.example`** — Added `ATS_SKIP_THRESHOLD=0.9` with description
- **`src/resume_operator/graph.py`** — Conditional routing:
  - Added `_route_after_ats_score()` routing function that reads threshold from config
  - Returns `"skip"` (-> report_results) or `"optimize"` (-> analyze_gaps) with INFO logging
  - Replaced `graph.add_edge("ats_score", "analyze_gaps")` with `graph.add_conditional_edges("ats_score", _route_after_ats_score, {"optimize": "analyze_gaps", "skip": "report_results"})`
- **`src/resume_operator/nodes/report_results.py`** — Added `optimization_skipped` field to report (true when `optimized_resume.sections` is empty)
- **`tests/test_graph.py`** — 4 new routing tests in `TestConditionalRouting`:
  - `test_high_score_routes_to_skip` (0.95 -> skip)
  - `test_threshold_score_routes_to_skip` (0.9 -> skip)
  - `test_low_score_routes_to_optimize` (0.72 -> optimize)
  - `test_zero_score_routes_to_optimize` (0.0 -> optimize)
- **`tests/test_report_results.py`** — Updated expected keys to include `optimization_skipped`
- **`docs/architecture.md`** — New architecture doc with:
  - ASCII conditional flow diagram
  - Routing logic explanation
  - Component table and data flow description
- **`docs/issues/023-conditional-routing-skip-optimization.md`** — Marked all tasks complete

## How to Test

1. Checkout this branch
2. Run `uv sync --dev`
3. Run `uv run pytest tests/test_graph.py::TestConditionalRouting -v` — all 4 routing tests pass
4. Run `uv run pytest` — full suite (111 tests) passes
5. Run `uv run ruff check src/ tests/` — no lint issues
6. Run `uv run mypy src/` — no type errors
7. Test routing behavior:
   ```bash
   # Normal (score < 0.9 — full optimization)
   uv run python -m resume_operator run --resume resume.pdf --job job.txt -v
   # Force skip (lower threshold)
   ATS_SKIP_THRESHOLD=0.3 uv run python -m resume_operator run --resume resume.pdf --job job.txt -v
   ```
   
 ## Checklist

- [x] Self-reviewed the code
- [x]  Added/updated tests (4 new routing tests, 111 total passing)
- [x]  No new warnings or errors
- [x]  Lint, format, and type checks pass
- [x]  Architecture doc created with flow diagram
- [x]  Updated issue documentation