### PR TITLE
feat(state): add facts_bank.yaml for items beyond the master resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,11 @@ cp .env.example .env
 uv run python -m resume_operator bootstrap --resume my-resume.pdf --output data/master_resume.yaml
 # Review and hand-edit data/master_resume.yaml
 
+# (Optional) Maintain a facts bank alongside the master for items that didn't fit on the trimmed resume
+# see input/facts_bank.example.yaml
+
 # Run the optimizer (preferred: master YAML)
-uv run python -m resume_operator run --master data/master_resume.yaml --job job_description.txt
+uv run python -m resume_operator run --master data/master_resume.yaml --facts data/facts_bank.yaml --job job_description.txt
 ```
 
 ## Commands

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,8 +46,11 @@ load_master            parse_resume
 |----------|----------|------|-------|
 | **Master YAML (preferred)** | `--master` | `load_master` | No LLM. Hand-maintained source of truth. |
 | **Resume PDF (legacy)** | `--resume` | `parse_resume` | LLM-parsed. Kept for back-compat and `bootstrap`. |
+| **Facts bank (optional)** | `--facts` | `load_master` | YAML pool of items beyond the master. `optimize_content` may pull from here. |
 
 Use `resume-operator bootstrap --resume old.pdf --output data/master_resume.yaml` once to seed the YAML from an existing PDF, then maintain the YAML by hand.
+
+If a `--facts <yaml>` path is provided (or `data/facts_bank.yaml` exists), the facts bank is loaded alongside the master and handed to `optimize_content` as a distinct pool the LLM may pull from when a fact strengthens the match for the JD.
 
 ## Conditional Routing
 

--- a/docs/issues/025-facts-bank-yaml.md
+++ b/docs/issues/025-facts-bank-yaml.md
@@ -1,0 +1,52 @@
+# [Feature]: Add `facts_bank.yaml` for items beyond the master resume
+
+## Description
+
+A second source-of-truth YAML for projects, metrics, achievements, extra bullets, and skills that didn't fit on the trimmed master resume. During tailoring, the optimizer can pull items from the facts bank into the output when they're a strong match for the JD.
+
+## Motivation
+
+A paper resume only fits N items. Any specific JD may need items not on the current master. Without a facts bank, the tailor can only reorder or rephrase what's already on the master — it can't *add back* a relevant project. That forces the user to manually edit the master per application, which is the friction this plan exists to eliminate.
+
+The plan doc calls this out explicitly ([plan 002, Key details](../../../../luckyplans/plans/002-resume-ats-tailor/plan.md)).
+
+## Implementation
+
+- [x] `FactItem` (with optional `role_id` for spliceable bullets) and `FactsBank` Pydantic models in [state.py](../../src/resume_operator/state.py)
+- [x] `facts_path` and `facts: FactsBank` added to `ResumeOptimizerState`
+- [x] [`tools/facts_bank.py`](../../src/resume_operator/tools/facts_bank.py) with `load_facts(path)` — returns an empty bank on missing/null path (optional by design), raises only on malformed YAML
+- [x] `load_master` node now also loads the optional facts bank (same node since it's the "ingest structured inputs" step)
+- [x] `optimize_content` prompt updated ([content_optimization.py](../../src/resume_operator/prompts/content_optimization.py)) — facts are a distinct section the LLM may pull from, with explicit instruction never to invent items
+- [x] `optimize_content` node passes `state.facts` to the prompt
+- [x] `run` CLI accepts `--facts` (optional); auto-falls-back to `data/facts_bank.yaml` if it exists
+- [x] [`input/facts_bank.example.yaml`](../../input/facts_bank.example.yaml) added
+- [x] Docs updated: `docs/architecture.md`, `README.md`
+
+## Acceptance Criteria — Verified
+
+- `run --master m.yaml --facts f.yaml --job j.txt` loads both without error (verified end-to-end against OpenRouter)
+- Missing facts bank is not an error — optimizer runs master-only (covered by unit test + real run without `--facts`)
+- Optimizer prompt receives facts as a distinct JSON block (not merged into the resume)
+- Real-run proof: LLM's `changes_made` explicitly cited `proj-1`, `proj-2`, `extra-1`, and AWS skills from the facts bank in the tailored output — "Incorporated metrics pipeline project (proj-1) and Lambda migration project (proj-2)…", "Inserted GitHub Actions adoption bullet (extra-1)…"
+
+## Key Files
+
+- `src/resume_operator/state.py`
+- `src/resume_operator/tools/facts_bank.py` (new)
+- `src/resume_operator/nodes/load_master.py`
+- `src/resume_operator/nodes/optimize_content.py`
+- `src/resume_operator/prompts/content_optimization.py`
+- `src/resume_operator/main.py`
+- `input/facts_bank.example.yaml` (new)
+
+## Follow-ups
+
+- #026 will structure the facts-used tracking into `TailoredResume.source_id` so `diff.md` can show *which* fact was pulled and from where, instead of relying on the LLM's free-form `changes_made` narration.
+
+## Dependencies
+
+- #024 ✓
+
+## Labels
+
+`enhancement`, `priority:high`

--- a/input/facts_bank.example.yaml
+++ b/input/facts_bank.example.yaml
@@ -1,0 +1,38 @@
+# Items that didn't fit on the trimmed master resume.
+# The optimizer may pull these in when they strengthen the match for a JD.
+# Everything below is optional — an empty file or missing file is valid.
+
+projects:
+  - id: proj-1
+    text: >
+      Built internal metrics pipeline (Airflow + Redshift) that reduced the
+      weekly exec dashboard refresh from 3h to 12m.
+  - id: proj-2
+    text: >
+      Led migration of 20+ Lambda functions from Node.js 14 → 18, reducing
+      cold-start latency 35% and closing 4 security advisories.
+
+extra_bullets:
+  # `role_id` links back to an ExperienceEntry.id on the master resume —
+  # use this when a bullet belongs logically under a specific role.
+  - id: extra-1
+    role_id: exp-1
+    text: >
+      Drove adoption of GitHub Actions across the org; replaced a brittle
+      Jenkins setup and cut CI flake rate from 8% to under 1%.
+  - id: extra-2
+    role_id: exp-2
+    text: >
+      Ran a monthly platform-wide bug bash program, resolving a backlog of
+      130+ open issues over 18 months.
+
+skills_beyond_master:
+  - Docker
+  - AWS Lambda
+  - AWS SQS
+  - AWS RDS
+  - Terraform
+  - Airflow
+
+certifications_beyond_master:
+  - Kubernetes CKAD (in progress)

--- a/src/resume_operator/main.py
+++ b/src/resume_operator/main.py
@@ -49,6 +49,17 @@ def _validate_master(master: Path) -> None:
         raise typer.BadParameter(f"'{master}' is not a YAML file (expected .yaml or .yml).")
 
 
+def _validate_facts(facts: Path) -> None:
+    """Validate facts bank YAML if provided (optional file)."""
+    if not facts.exists() or not facts.is_file():
+        raise typer.BadParameter(f"'{facts}' does not exist or is not a file.")
+    if facts.suffix.lower() not in {".yaml", ".yml"}:
+        raise typer.BadParameter(f"'{facts}' is not a YAML file (expected .yaml or .yml).")
+
+
+DEFAULT_FACTS_PATH = Path("data/facts_bank.yaml")
+
+
 def _validate_job(job: Path) -> None:
     """Validate job description file exists and is readable."""
     if not job.exists() or not job.is_file():
@@ -72,6 +83,12 @@ def run(
     resume: Path = typer.Option(
         None, "--resume", "-r", help="Path to resume PDF (legacy — use --master instead)"
     ),
+    facts: Path = typer.Option(
+        None,
+        "--facts",
+        "-f",
+        help=f"Path to facts_bank.yaml (optional; defaults to {DEFAULT_FACTS_PATH} if it exists)",
+    ),
     job: Path = typer.Option(..., "--job", "-j", help="Path to job description text file"),
     output: Path = typer.Option(
         Path("data/optimized_resume.pdf"), "--output", "-o", help="Output PDF path"
@@ -92,13 +109,23 @@ def run(
         _validate_resume(resume)
     _validate_job(job)
 
+    # Facts bank is optional: explicit --facts is validated; fall back to the
+    # default path only if it actually exists on disk.
+    resolved_facts: Path | None = None
+    if facts is not None:
+        _validate_facts(facts)
+        resolved_facts = facts
+    elif DEFAULT_FACTS_PATH.exists():
+        resolved_facts = DEFAULT_FACTS_PATH
+
     if dry_run:
         source_line = (
             f"[bold]Master:[/bold] {master}" if master else f"[bold]Resume:[/bold] {resume}"
         )
+        facts_line = f"\n[bold]Facts:[/bold] {resolved_facts}" if resolved_facts else ""
         console.print(
             Panel(
-                f"{source_line}\n"
+                f"{source_line}{facts_line}\n"
                 f"[bold]Job description:[/bold] {job}\n"
                 f"[bold]Output:[/bold] {output}",
                 title="Dry run — inputs validated",
@@ -115,6 +142,8 @@ def run(
         initial["master_path"] = str(master)
     else:
         initial["resume_path"] = str(resume)
+    if resolved_facts is not None:
+        initial["facts_path"] = str(resolved_facts)
 
     graph = build_graph()
     with Status("[bold cyan]Running optimization pipeline...", console=console):

--- a/src/resume_operator/nodes/load_master.py
+++ b/src/resume_operator/nodes/load_master.py
@@ -12,6 +12,7 @@ from resume_operator.state import (
     ResumeMaster,
     ResumeOptimizerState,
 )
+from resume_operator.tools.facts_bank import FactsBankError, load_facts
 from resume_operator.tools.master_resume import MasterResumeError, load_master
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,16 @@ def load_master_node(state: ResumeOptimizerState) -> dict[str, Any]:
 
     result["master"] = master
     result["resume"] = _master_to_resume_data(master)
+
+    # --- Optional facts bank ---
+    facts_path = Path(state.facts_path) if state.facts_path else None
+    try:
+        facts = load_facts(facts_path)
+    except FactsBankError as exc:
+        logger.error("load_master: %s", exc)
+        errors.append(f"load_master: {exc}")
+        return {"errors": errors}
+    result["facts"] = facts
 
     # Read job description (same contract as the legacy parse_resume node).
     job_raw_text = state.job_description_text

--- a/src/resume_operator/nodes/optimize_content.py
+++ b/src/resume_operator/nodes/optimize_content.py
@@ -25,6 +25,7 @@ def optimize_content(state: ResumeOptimizerState) -> dict[str, Any]:
         llm = get_llm()
         prompt = OPTIMIZE_CONTENT.format(
             resume_json=state.resume.model_dump_json(),
+            facts_json=state.facts.model_dump_json(),
             job_description=state.job_description.raw_text,
             gap_analysis=state.gap_analysis.model_dump_json(),
         )

--- a/src/resume_operator/prompts/content_optimization.py
+++ b/src/resume_operator/prompts/content_optimization.py
@@ -5,6 +5,9 @@ OPTIMIZE_CONTENT = """Optimize this resume to better match the job description.
 Original resume data:
 {resume_json}
 
+Facts bank (items NOT currently on the resume but available to pull in):
+{facts_json}
+
 Job description:
 {job_description}
 
@@ -13,9 +16,13 @@ Gap analysis:
 
 Rewrite the resume sections to:
 1. Incorporate missing keywords naturally
-2. Emphasize relevant experience and skills
-3. Improve ATS compatibility
-4. Keep the original profile authentic — do not fabricate experience
+2. Emphasize relevant experience and skills from the resume
+3. Pull relevant items from the facts bank into the output ONLY when they
+   strengthen the match for this JD (mention which facts you used in
+   `changes_made`)
+4. Improve ATS compatibility
+5. Keep the original profile authentic — never invent experience; only use
+   what is in the resume data or the facts bank
 
 Return ONLY valid JSON:
 {{

--- a/src/resume_operator/state.py
+++ b/src/resume_operator/state.py
@@ -69,6 +69,28 @@ class ResumeMaster(BaseModel):
     certifications: list[str] = Field(default_factory=list)
 
 
+class FactItem(BaseModel):
+    """A project, achievement, or other bullet that didn't fit on the trimmed master."""
+
+    id: str
+    text: str
+    role_id: str = ""  # optional: links to an `ExperienceEntry.id` for spliceable bullets
+
+
+class FactsBank(BaseModel):
+    """Optional pool of items beyond the master resume.
+
+    During tailoring (#026), the optimizer may pull items from here into the
+    output when they are a strong match for the JD. Everything is optional —
+    missing file or empty bank is a valid state.
+    """
+
+    projects: list[FactItem] = Field(default_factory=list)
+    extra_bullets: list[FactItem] = Field(default_factory=list)
+    skills_beyond_master: list[str] = Field(default_factory=list)
+    certifications_beyond_master: list[str] = Field(default_factory=list)
+
+
 class JobDescription(BaseModel):
     """Structured job description data."""
 
@@ -110,12 +132,14 @@ class ResumeOptimizerState(BaseModel):
     # Inputs
     resume_path: str = ""
     master_path: str = ""
+    facts_path: str = ""
     job_description_path: str = ""
     job_description_text: str = ""
 
     # Parsed data
     resume: ResumeData = Field(default_factory=ResumeData)
     master: ResumeMaster = Field(default_factory=ResumeMaster)
+    facts: FactsBank = Field(default_factory=FactsBank)
     job_description: JobDescription = Field(default_factory=JobDescription)
 
     # Analysis

--- a/src/resume_operator/tools/facts_bank.py
+++ b/src/resume_operator/tools/facts_bank.py
@@ -1,0 +1,56 @@
+"""Facts bank YAML I/O.
+
+A facts bank is an *optional* pool of items beyond the trimmed master resume:
+projects, extra bullets, skills, and certifications that wouldn't fit on a
+one-page master but might be relevant to a specific JD.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+
+from resume_operator.state import FactsBank
+
+logger = logging.getLogger(__name__)
+
+
+class FactsBankError(ValueError):
+    """Raised when the facts bank YAML exists but is malformed."""
+
+
+def load_facts(path: Path | None) -> FactsBank:
+    """Load a facts bank YAML. Returns an empty bank if `path` is None or missing.
+
+    Raises `FactsBankError` only on present-but-malformed files — a missing
+    facts bank is not an error (the master resume is sufficient on its own).
+    """
+    if path is None or not path.exists():
+        logger.debug("load_facts: no facts bank at %s — using empty bank", path)
+        return FactsBank()
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise FactsBankError(f"facts bank YAML parse error: {exc}") from exc
+    if raw is None:
+        logger.debug("load_facts: %s is empty — using empty bank", path)
+        return FactsBank()
+    if not isinstance(raw, dict):
+        raise FactsBankError(
+            f"facts bank must be a mapping at the top level, got {type(raw).__name__}"
+        )
+    try:
+        bank = FactsBank.model_validate(raw)
+    except Exception as exc:
+        raise FactsBankError(f"facts bank schema validation failed: {exc}") from exc
+    logger.info(
+        "load_facts: loaded %s — projects=%d, extra_bullets=%d, skills=%d, certs=%d",
+        path,
+        len(bank.projects),
+        len(bank.extra_bullets),
+        len(bank.skills_beyond_master),
+        len(bank.certifications_beyond_master),
+    )
+    return bank

--- a/tests/test_facts_bank.py
+++ b/tests/test_facts_bank.py
@@ -1,0 +1,58 @@
+"""Tests for `tools.facts_bank`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from resume_operator.tools.facts_bank import FactsBankError, load_facts
+
+
+class TestLoadFacts:
+    def test_returns_empty_when_path_is_none(self) -> None:
+        bank = load_facts(None)
+        assert bank.projects == []
+        assert bank.extra_bullets == []
+        assert bank.skills_beyond_master == []
+
+    def test_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
+        bank = load_facts(tmp_path / "nope.yaml")
+        assert bank.projects == []
+
+    def test_returns_empty_when_file_empty(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty.yaml"
+        path.write_text("", encoding="utf-8")
+        bank = load_facts(path)
+        assert bank.projects == []
+
+    def test_loads_valid_bank(self, tmp_path: Path) -> None:
+        path = tmp_path / "facts.yaml"
+        path.write_text(
+            "projects:\n"
+            "  - id: proj-1\n"
+            "    text: Built a pipeline\n"
+            "extra_bullets:\n"
+            "  - id: extra-1\n"
+            "    role_id: exp-1\n"
+            "    text: Did a thing\n"
+            "skills_beyond_master: [Docker, Terraform]\n",
+            encoding="utf-8",
+        )
+        bank = load_facts(path)
+        assert len(bank.projects) == 1
+        assert bank.projects[0].id == "proj-1"
+        assert bank.extra_bullets[0].role_id == "exp-1"
+        assert bank.skills_beyond_master == ["Docker", "Terraform"]
+
+    def test_raises_on_non_mapping(self, tmp_path: Path) -> None:
+        path = tmp_path / "list.yaml"
+        path.write_text("- just a list\n", encoding="utf-8")
+        with pytest.raises(FactsBankError, match="mapping"):
+            load_facts(path)
+
+    def test_raises_on_schema_mismatch(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        path.write_text("projects:\n  - not-a-mapping\n", encoding="utf-8")
+        with pytest.raises(FactsBankError, match="schema"):
+            load_facts(path)

--- a/tests/test_load_master.py
+++ b/tests/test_load_master.py
@@ -65,3 +65,28 @@ class TestLoadMasterNode:
         result = load_master_node(state)
         assert result["errors"]
         assert any("not found" in e for e in result["errors"])
+
+    def test_loads_optional_facts_bank(self, tmp_path: Path) -> None:
+        master_path = _write_master(tmp_path / "master.yaml")
+        facts_path = tmp_path / "facts.yaml"
+        facts_path.write_text(
+            "projects:\n  - id: proj-1\n    text: Built X\n",
+            encoding="utf-8",
+        )
+        state = ResumeOptimizerState(master_path=str(master_path), facts_path=str(facts_path))
+        result = load_master_node(state)
+
+        assert "facts" in result
+        assert len(result["facts"].projects) == 1
+        assert result["facts"].projects[0].id == "proj-1"
+
+    def test_missing_facts_bank_is_not_an_error(self, tmp_path: Path) -> None:
+        master_path = _write_master(tmp_path / "master.yaml")
+        state = ResumeOptimizerState(
+            master_path=str(master_path), facts_path=str(tmp_path / "no-facts.yaml")
+        )
+        result = load_master_node(state)
+
+        assert not result.get("errors"), result.get("errors")
+        assert "facts" in result
+        assert result["facts"].projects == []


### PR DESCRIPTION
## Summary

- Adds `FactItem` / `FactsBank` models and a `tools/facts_bank.py` loader (missing file → empty bank, not an error)
- `run` CLI accepts `--facts` (optional); `data/facts_bank.yaml` is auto-picked up if it exists
- `optimize_content` prompt treats facts as a distinct JSON pool with an explicit "never invent, only pull in" instruction

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/48. Without a facts bank, the tailor can only reorder/rephrase what's already on the master — it can't *add back* a relevant project for a specific JD. That forces the user to hand-edit the master per application, which is the friction this plan exists to eliminate. Context: [plan 002, Key details](../../../../luckyplans/plans/002-resume-ats-tailor/plan.md).

## Changes

- `state.py` — `FactItem` (optional `role_id` for spliceable bullets), `FactsBank`, `state.facts` + `state.facts_path`
- `tools/facts_bank.py` — `load_facts` returning an empty bank on missing/empty file
- `nodes/load_master.py` — loads the optional facts bank alongside the master (same "ingest structured inputs" step)
- `nodes/optimize_content.py` + `prompts/content_optimization.py` — pass facts as a distinct section; explicit guardrail against fabrication
- `main.py` — `--facts` option on `run`, auto-fallback to `data/facts_bank.yaml`
- `input/facts_bank.example.yaml` (new)

## How to Test

1. `uv run python -m pytest -q` — 131 tests pass (8 new)
2. `uv run python -m resume_operator run --master input/master_resume.example.yaml --facts input/facts_bank.example.yaml --job input/job.txt --output data/test_025.pdf`

## Proof of Work

Real-run verification against OpenRouter — the LLM's `changes_made` explicitly cited facts by ID:
- \"Incorporated metrics pipeline project (proj-1) and Lambda migration project (proj-2) as concrete achievements.\"
- \"Inserted GitHub Actions adoption bullet (extra-1) to show CI/CD improvement and Git proficiency.\"
- \"Added AWS service usage (Lambda, SQS, RDS, EC2) from facts bank to demonstrate cloud expertise.\"

When this PR is merged, the optimizer has a distinct pool of items it can pull back into the tailored output for any given JD — without the user having to hand-edit the master resume per application.