### PR TITLE
refactor(optimize): per-item TailoredResume with fabrication guard

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,6 +82,14 @@ After `ats_score`, a routing function checks the score against `ATS_SKIP_THRESHO
 7. **generate_pdf**: ReportLab renders optimized PDF
 8. **report_results**: JSON report to `data/results.json`
 
+## Tailoring as Per-Item Decisions
+
+`optimize_content` does not produce free-form text blobs. It builds a `TailoredResume` — a list of `TailoredItem` decisions over a `SourceIndex` (built from `ResumeMaster` + `FactsBank`). Every item references a stable `source_id` like `master:exp-1-b1` or `facts:proj-2`. Three actions: `keep`, `reword`, `drop`. Fabricated `source_id`s (LLM inventing IDs) are rejected at the node boundary and logged.
+
+`report_results` writes `data/diff.md` — a human-readable before/after of every keep/reword/drop decision, grouped into Additions (pulled from facts bank), Rewordings (with before/after text), and Deletions.
+
+`generate_pdf` currently reads the legacy `OptimizedResume.sections` blob projection of the tailored output (the projection lives in `optimize_content` for back-compat). Direct structured rendering is #027.
+
 ## LLM Output Handling
 
 All LLM-calling nodes use LangChain's `with_structured_output` (via `tools/llm_provider.get_structured_llm`). Each node defines an `…LLMOutput` Pydantic schema near its node function; LangChain hands the schema to the provider via native function/tool-calling and returns an already-validated instance. No manual JSON parsing or prompt-time "return ONLY valid JSON" boilerplate.

--- a/docs/issues/026-tailored-resume-item-level-references.md
+++ b/docs/issues/026-tailored-resume-item-level-references.md
@@ -1,0 +1,84 @@
+# [Refactor]: Restructure `OptimizedResume` → `TailoredResume` with item-level references
+
+## Description
+
+Replace `OptimizedResume.sections: dict[str, str]` (blob per section) with `TailoredResume` — a list of `TailoredItem` objects that reference master/facts items by stable ID with per-item action (keep / reword / drop). This enables a real diff and makes fabrication structurally hard.
+
+## Motivation
+
+The previous `optimize_content` node had the LLM write free-form text blobs per section. Problems:
+
+1. **No real diff.** `changes_made: list[str]` was free-form LLM narration, not a diff.
+2. **Weak fabrication guardrail.** The prompt said "do not fabricate" — that was all. No structural check.
+3. **PDF renderer lost structure.** Paragraph splitting on LLM whitespace (`pdf_generator.py`).
+
+With item-level references, the LLM's job shrinks from "rewrite the resume" to "for each master/facts item: keep, drop, or reword." Fabrication requires the source item to exist first — the node rejects any `source_id` not in the `SourceIndex`.
+
+## Implementation
+
+- [x] `TailoredItem` (source_id, action, original_text, new_text) and `TailoredResume` (items + notes) added to [state.py](../../src/resume_operator/state.py)
+- [x] `state.tailored_resume` field added to `ResumeOptimizerState` (kept alongside legacy `optimized_resume` for back-compat until #027 lands)
+- [x] [`tools/source_index.py`](../../src/resume_operator/tools/source_index.py) — builds a `SourceIndex` from master + facts, with `source_id` format like `master:exp-1-b1`, `facts:proj-1`, `master:skill:Python`, etc. Provides `as_prompt_menu()` for the prompt and `__contains__` for the fabrication guard.
+- [x] [`prompts/content_optimization.py`](../../src/resume_operator/prompts/content_optimization.py) rewritten — gives the LLM an explicit sources menu, asks for per-item keep/reword/drop decisions
+- [x] [`nodes/optimize_content.py`](../../src/resume_operator/nodes/optimize_content.py) rewritten — uses `TailoredResumeLLMOutput` schema via `with_structured_output` (#028), validates every `source_id` against the index, records rejected IDs in `state.errors`
+- [x] Legacy `OptimizedResume.sections` projection retained for back-compat — built from `TailoredResume` grouped by kind (summary/experience/skills/education). `generate_pdf` still reads this until #027 migrates it off the blob shape.
+- [x] [`tools/diff_renderer.py`](../../src/resume_operator/tools/diff_renderer.py) — renders `diff.md` with Strategy Notes, Additions (facts pulled in), Rewordings (before/after), Deletions
+- [x] [`nodes/report_results.py`](../../src/resume_operator/nodes/report_results.py) — writes `data/diff.md` whenever `tailored_resume.items` is populated
+- [x] [`nodes/parse_resume.py`](../../src/resume_operator/nodes/parse_resume.py) now also synthesizes a `ResumeMaster` (via `resume_data_to_master`) so the legacy PDF path still has a source index
+- [x] `conftest.py` fixtures updated — `sample_master` with stable IDs
+
+## Acceptance Criteria — Verified
+
+- No free-form section blobs in the pipeline's authoritative output — the `TailoredResume.items` list is the source of truth; `OptimizedResume.sections` is a derived projection for back-compat only ✓
+- `optimize_content` produces only items traceable to master or facts ✓ (test `test_rejects_fabricated_source_id` covers the path; real-run showed `fabricated_rejected=0` because the LLM respected the menu)
+- `diff.md` shows additions, deletions, and rewords with before/after text ✓ (see proof below)
+- An LLM response referencing a non-existent `source_id` is caught and logged in `state.errors` ✓
+
+## Proof of Work
+
+Real-run against OpenRouter + `openai/gpt-4o-mini` with `master_resume.example.yaml` + `facts_bank.example.yaml` + `job.txt`:
+
+```
+optimize_content: completed — items=27 (kept=21, reworded=1, dropped=5), fabricated_rejected=0, notes=1
+report_results: completed — wrote data/results.json and data/diff.md
+```
+
+Excerpt from the generated `diff.md`:
+
+```markdown
+## Additions — items pulled from the facts bank
+- **facts:proj-2** (project) Led migration of 20+ Lambda functions from Node.js 14 → 18…
+- **facts:extra-1** (extra-bullet[exp-1]) Drove adoption of GitHub Actions across the org…
+- **facts:skill:Docker** (skill) Docker
+
+## Rewordings — master or facts items with adjusted phrasing
+- **master:exp-2-b2** (experience-bullet)
+  - before: Introduced end-to-end Playwright tests, reducing regression bugs 60%.
+  - after:  Implemented comprehensive testing practices, significantly decreasing regression bugs by 60%.
+```
+
+## Key Files
+
+- `src/resume_operator/state.py`
+- `src/resume_operator/nodes/optimize_content.py`
+- `src/resume_operator/nodes/report_results.py`
+- `src/resume_operator/nodes/parse_resume.py`
+- `src/resume_operator/prompts/content_optimization.py`
+- `src/resume_operator/tools/source_index.py` (new)
+- `src/resume_operator/tools/diff_renderer.py` (new)
+- `docs/architecture.md`
+- `tests/conftest.py`, `tests/test_optimize_content.py`, `tests/test_report_results.py`, `tests/test_integration.py`
+
+## Follow-ups
+
+- #027 migrates `generate_pdf` off the back-compat `OptimizedResume.sections` projection and onto structured rendering from `TailoredResume + ResumeMaster` directly.
+- #029 writes `diff.md` into a per-application folder instead of the single `data/diff.md`.
+
+## Dependencies
+
+- #024 ✓
+- #028 ✓ (structured output makes the per-item schema clean)
+
+## Labels
+
+`refactor`, `priority:high`

--- a/src/resume_operator/nodes/optimize_content.py
+++ b/src/resume_operator/nodes/optimize_content.py
@@ -1,4 +1,15 @@
-"""Node: Optimize resume content based on gap analysis."""
+"""Node: Tailor resume content per-item against the job description.
+
+This node produces a `TailoredResume` — a list of `TailoredItem` decisions,
+each referencing a stable source ID from the master resume or facts bank.
+The fabrication guard rejects any `source_id` not present in the
+`SourceIndex`; the LLM cannot invent text that isn't traceable back to a
+source.
+
+For back-compat with #027 (not yet landed), it also populates the legacy
+`OptimizedResume.sections` string blob, derived from the tailored items
+grouped by kind.
+"""
 
 from __future__ import annotations
 
@@ -8,49 +19,51 @@ from typing import Any
 from pydantic import BaseModel, Field, ValidationError
 
 from resume_operator.prompts.content_optimization import OPTIMIZE_CONTENT
-from resume_operator.state import OptimizedResume, ResumeOptimizerState
+from resume_operator.state import (
+    OptimizedResume,
+    ResumeOptimizerState,
+    TailoredItem,
+    TailoredResume,
+)
 from resume_operator.tools.llm_provider import get_structured_llm
+from resume_operator.tools.source_index import SourceIndex, build_source_index
 
 logger = logging.getLogger(__name__)
 
 
-class OptimizedSections(BaseModel):
-    """Named resume sections the optimizer writes. Fixed keys so the JSON
-    schema is compatible with OpenAI's strict mode (every property required).
-    """
-
-    summary: str = ""
-    experience: str = ""
-    skills: str = ""
-    education: str = ""
+class TailoredItemLLM(BaseModel):
+    source_id: str
+    action: str = "keep"  # keep | reword | drop
+    original_text: str = ""
+    new_text: str = ""
 
 
-class OptimizedResumeLLMOutput(BaseModel):
-    """Schema handed to `with_structured_output` — the LLM fills this in directly."""
-
-    sections: OptimizedSections = Field(default_factory=OptimizedSections)
-    changes_made: list[str] = Field(default_factory=list)
+class TailoredResumeLLMOutput(BaseModel):
+    items: list[TailoredItemLLM] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
 
 
 def optimize_content(state: ResumeOptimizerState) -> dict[str, Any]:
-    """Rewrite and enhance resume content to better match the job description.
-
-    Takes the original resume, gap analysis, and job description to produce
-    optimized resume sections with tracked changes.
-    """
+    """Produce a `TailoredResume` — per-item decisions over master + facts."""
     logger.info("optimize_content: starting")
     errors: list[str] = list(state.errors)
 
+    index = build_source_index(state.master, state.facts)
+
+    if not index.entries:
+        logger.warning("optimize_content: empty source index — skipping")
+        errors.append("optimize_content: source index is empty")
+        return {"errors": errors}
+
     try:
-        llm = get_structured_llm(OptimizedResumeLLMOutput)
+        llm = get_structured_llm(TailoredResumeLLMOutput)
         prompt = OPTIMIZE_CONTENT.format(
-            resume_json=state.resume.model_dump_json(),
-            facts_json=state.facts.model_dump_json(),
+            source_menu=index.as_prompt_menu(),
             job_description=state.job_description.raw_text,
             gap_analysis=state.gap_analysis.model_dump_json(),
         )
         logger.debug("optimize_content: LLM prompt: %s", prompt)
-        parsed: OptimizedResumeLLMOutput = llm.invoke(prompt)
+        parsed: TailoredResumeLLMOutput = llm.invoke(prompt)
         logger.debug("optimize_content: LLM response: %s", parsed.model_dump_json())
     except ValidationError as exc:
         logger.error("optimize_content: LLM returned schema-invalid data: %s", exc)
@@ -61,18 +74,94 @@ def optimize_content(state: ResumeOptimizerState) -> dict[str, Any]:
         errors.append(f"optimize_content: LLM call failed: {exc}")
         return {"errors": errors}
 
-    optimized_resume = OptimizedResume(
-        sections=parsed.sections.model_dump(exclude_defaults=False),
-        changes_made=list(parsed.changes_made),
-    )
+    # --- Fabrication guard ---
+    validated_items, rejected = _validate_items(parsed.items, index)
+    for ref in rejected:
+        msg = f"optimize_content: rejected fabricated source_id: {ref}"
+        logger.error(msg)
+        errors.append(msg)
+
+    tailored = TailoredResume(items=validated_items, notes=list(parsed.notes))
+    optimized_legacy = _project_to_sections(tailored, index)
 
     logger.info(
-        "optimize_content: completed — sections=%d, changes=%d",
-        len(optimized_resume.sections),
-        len(optimized_resume.changes_made),
+        "optimize_content: completed — items=%d (kept=%d, reworded=%d, dropped=%d), "
+        "fabricated_rejected=%d, notes=%d",
+        len(tailored.items),
+        sum(1 for i in tailored.items if i.action == "keep"),
+        sum(1 for i in tailored.items if i.action == "reword"),
+        sum(1 for i in tailored.items if i.action == "drop"),
+        len(rejected),
+        len(tailored.notes),
     )
 
-    result: dict[str, Any] = {"optimized_resume": optimized_resume}
+    result: dict[str, Any] = {
+        "tailored_resume": tailored,
+        "optimized_resume": optimized_legacy,
+    }
     if errors != list(state.errors):
         result["errors"] = errors
     return result
+
+
+def _validate_items(
+    items: list[TailoredItemLLM], index: SourceIndex
+) -> tuple[list[TailoredItem], list[str]]:
+    """Drop items whose `source_id` isn't in the index; return (kept, rejected_ids)."""
+    kept: list[TailoredItem] = []
+    rejected: list[str] = []
+    for raw in items:
+        entry = index.get(raw.source_id)
+        if entry is None:
+            rejected.append(raw.source_id)
+            continue
+        action = raw.action.lower()
+        if action not in {"keep", "reword", "drop"}:
+            action = "keep"
+        # Always use the canonical text from the index as `original_text` — the LLM
+        # sometimes paraphrases the echo. For `new_text`, trust the LLM only when action == reword.
+        new_text = raw.new_text.strip() if action == "reword" else ""
+        kept.append(
+            TailoredItem(
+                source_id=raw.source_id,
+                action=action,
+                original_text=entry.text,
+                new_text=new_text,
+            )
+        )
+    return kept, rejected
+
+
+def _project_to_sections(tailored: TailoredResume, index: SourceIndex) -> OptimizedResume:
+    """Back-compat projection: build the legacy `OptimizedResume.sections` blob so
+    `generate_pdf` keeps working until #027 migrates it off the blob shape.
+    """
+    buckets: dict[str, list[str]] = {
+        "summary": [],
+        "experience": [],
+        "skills": [],
+        "education": [],
+    }
+    for item in tailored.kept_or_reworded():
+        text = item.new_text or item.original_text
+        entry = index.get(item.source_id)
+        if entry is None:
+            continue
+        if entry.kind == "summary":
+            buckets["summary"].append(text)
+        elif entry.kind in {"experience-header", "experience-bullet"} or entry.kind.startswith(
+            "extra-bullet"
+        ):
+            buckets["experience"].append(f"- {text}")
+        elif entry.kind == "education":
+            buckets["education"].append(text)
+        elif entry.kind == "skill":
+            buckets["skills"].append(text)
+        elif entry.kind == "certification":
+            buckets["skills"].append(f"Cert: {text}")
+        elif entry.kind == "project":
+            buckets["experience"].append(f"- Project: {text}")
+
+    sections = {name: "\n".join(lines) for name, lines in buckets.items() if lines}
+    changes_made = [f"{item.action}: {item.source_id}" for item in tailored.items]
+    return OptimizedResume(sections=sections, changes_made=changes_made)

--- a/src/resume_operator/nodes/parse_resume.py
+++ b/src/resume_operator/nodes/parse_resume.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, ValidationError
 from resume_operator.prompts.resume_parsing import PARSE_RESUME
 from resume_operator.state import JobDescription, ResumeData, ResumeOptimizerState
 from resume_operator.tools.llm_provider import get_structured_llm
+from resume_operator.tools.master_resume import resume_data_to_master
 from resume_operator.tools.pdf_parser import extract_text
 
 logger = logging.getLogger(__name__)
@@ -102,6 +103,10 @@ def parse_resume(state: ResumeOptimizerState) -> dict[str, Any]:
         raw_text=raw_text,
     )
     result["resume"] = resume_data
+    # Also synthesize a ResumeMaster with stable IDs so optimize_content (#026) has
+    # a source index even when the user is on the legacy PDF path. `bootstrap` uses
+    # this same conversion to seed a real YAML.
+    result["master"] = resume_data_to_master(resume_data)
 
     # --- Read job description ---
     job_raw_text = state.job_description_text

--- a/src/resume_operator/nodes/report_results.py
+++ b/src/resume_operator/nodes/report_results.py
@@ -1,4 +1,4 @@
-"""Node: Save optimization results to JSON."""
+"""Node: Save optimization results to JSON + write a human-readable diff.md."""
 
 import json
 import logging
@@ -7,47 +7,64 @@ from pathlib import Path
 from typing import Any
 
 from resume_operator.state import ResumeOptimizerState
+from resume_operator.tools.diff_renderer import render_diff
+from resume_operator.tools.source_index import build_source_index
 
 logger = logging.getLogger(__name__)
 
 RESULTS_PATH = Path("data/results.json")
+DIFF_PATH = Path("data/diff.md")
 
 
 def report_results(state: ResumeOptimizerState) -> dict[str, Any]:
     """Compile and save the full optimization report.
 
-    Writes a JSON report to data/ with ATS scores, gap analysis,
-    changes made, and any errors encountered.
+    Writes:
+      - `data/results.json` — machine-readable summary + tailored items
+      - `data/diff.md` — human-readable diff (when tailoring ran)
     """
     logger.info("report_results: starting")
     errors: list[str] = list(state.errors)
 
     try:
-        optimization_skipped = not state.optimized_resume.sections
+        optimization_skipped = not state.tailored_resume.items
         report: dict[str, object] = {
             "timestamp": datetime.now().isoformat(),
             "resume_path": state.resume_path,
+            "master_path": state.master_path,
+            "facts_path": state.facts_path,
             "job_description_path": state.job_description_path,
             "ats_score": state.ats_score.model_dump(),
             "gap_analysis": state.gap_analysis.model_dump(),
             "optimization_skipped": optimization_skipped,
             "optimization_changes": state.optimized_resume.changes_made,
+            "tailored_resume": state.tailored_resume.model_dump(),
             "output_path": state.output_path,
             "errors": list(state.errors),
         }
 
-        output_path = RESULTS_PATH
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-        with output_path.open("w") as f:
+        results_path = RESULTS_PATH
+        results_path.parent.mkdir(parents=True, exist_ok=True)
+        with results_path.open("w") as f:
             json.dump(report, f, indent=2)
+
+        diff_path: Path | None = None
+        if state.tailored_resume.items:
+            diff_path = DIFF_PATH
+            diff_path.parent.mkdir(parents=True, exist_ok=True)
+            index = build_source_index(state.master, state.facts)
+            diff_path.write_text(render_diff(state.tailored_resume, index), encoding="utf-8")
 
     except Exception as exc:
         logger.error("report_results: failed: %s", exc)
         errors.append(f"report_results: failed: {exc}")
         return {"errors": errors}
 
-    logger.info("report_results: completed — wrote %s", output_path)
+    logger.info(
+        "report_results: completed — wrote %s%s",
+        results_path,
+        f" and {diff_path}" if diff_path else "",
+    )
 
     result: dict[str, Any] = {"report": report}
     if errors != list(state.errors):

--- a/src/resume_operator/prompts/content_optimization.py
+++ b/src/resume_operator/prompts/content_optimization.py
@@ -1,30 +1,42 @@
-"""Prompt template for resume content optimization."""
+"""Prompt template for resume content optimization — per-item tailoring."""
 
-OPTIMIZE_CONTENT = """Optimize this resume to better match the job description.
+OPTIMIZE_CONTENT = """You are tailoring a candidate's resume for a specific job.
 
-Original resume data:
-{resume_json}
+Your job is a *per-item* decision over a menu of source items. You MAY NOT
+invent new bullets or skills — you may only keep, reword, or drop existing
+ones from the menu below.
 
-Facts bank (items NOT currently on the resume but available to pull in):
-{facts_json}
+=== SOURCES MENU ===
+Every item you reference in your output MUST use the exact `source_id` from
+this menu. An output item whose `source_id` is not in this menu will be
+rejected.
 
-Job description:
+{source_menu}
+
+=== JOB DESCRIPTION ===
 {job_description}
 
-Gap analysis:
+=== GAP ANALYSIS (from earlier pass) ===
 {gap_analysis}
 
-Rewrite the resume sections to:
-1. Incorporate missing keywords naturally
-2. Emphasize relevant experience and skills from the resume
-3. Pull relevant items from the facts bank into the output ONLY when they
-   strengthen the match for this JD (mention which facts you used in
-   `changes_made`)
-4. Improve ATS compatibility
-5. Keep the original profile authentic — never invent experience; only use
-   what is in the resume data or the facts bank
+=== YOUR TASK ===
+Return a list of `TailoredItem` decisions covering the items that belong in
+the tailored output. Each item:
 
-Populate the output schema with `sections` (summary, experience, skills,
-education) as the rewritten text per section, and `changes_made` as a short
-list of what changed and why.
+- `source_id` — exact match to a menu entry above
+- `action` — one of:
+  - `keep`   → include the source text unchanged
+  - `reword` → include, but rephrased for this JD; fill `new_text`
+  - `drop`   → the item was considered but excluded from the final resume
+- `original_text` — echo the source text so the diff reader has context
+- `new_text` — only when action is `reword`; otherwise leave empty
+
+Include `drop` decisions for items from the master that you chose NOT to
+include — the reader wants to see what was cut, not just what was kept.
+
+Pull in items from the facts bank (source_id starting with `facts:`) only
+when they strengthen the match for this specific JD.
+
+Add short free-form `notes` explaining the overall strategy (what you
+emphasized, what you downplayed, and why).
 """

--- a/src/resume_operator/state.py
+++ b/src/resume_operator/state.py
@@ -126,6 +126,42 @@ class OptimizedResume(BaseModel):
     changes_made: list[str] = Field(default_factory=list)
 
 
+class TailoredItem(BaseModel):
+    """A single per-item tailoring decision.
+
+    Every tailored item references a stable ID in the master resume or facts
+    bank — this is the fabrication guardrail (#026). The optimizer cannot
+    synthesize text that isn't traceable back to a source.
+
+    `source_id` format:
+      - `master:exp-1`                → an experience role header (summary of that entry)
+      - `master:exp-1-b1`             → a specific bullet on a role
+      - `master:edu-1`                → an education entry
+      - `master:skill:Python`         → a skill
+      - `master:cert:AWS`             → a certification
+      - `master:summary`              → the top-of-resume summary
+      - `facts:proj-1`                → a project from the facts bank
+      - `facts:extra-1`               → an extra bullet from the facts bank
+      - `facts:skill:Docker`          → a skill from the facts bank
+      - `facts:cert:CKAD`             → a cert from the facts bank
+    """
+
+    source_id: str
+    action: str = "keep"  # one of: keep | reword | drop
+    original_text: str = ""
+    new_text: str = ""  # only meaningful when action == "reword"
+
+
+class TailoredResume(BaseModel):
+    """Structured tailored output — a list of per-item decisions, not free-form text."""
+
+    items: list[TailoredItem] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+    def kept_or_reworded(self) -> list[TailoredItem]:
+        return [i for i in self.items if i.action in {"keep", "reword"}]
+
+
 class ResumeOptimizerState(BaseModel):
     """Central state flowing through the LangGraph pipeline."""
 
@@ -148,6 +184,7 @@ class ResumeOptimizerState(BaseModel):
 
     # Optimization
     optimized_resume: OptimizedResume = Field(default_factory=OptimizedResume)
+    tailored_resume: TailoredResume = Field(default_factory=TailoredResume)
 
     # Output
     output_path: str = ""

--- a/src/resume_operator/tools/diff_renderer.py
+++ b/src/resume_operator/tools/diff_renderer.py
@@ -1,0 +1,68 @@
+"""Render a human-readable `diff.md` from a `TailoredResume`.
+
+Three sections:
+  - Additions: facts-bank items pulled into the output
+  - Rewordings: master items included but rephrased (shows before/after)
+  - Deletions: master items considered but dropped
+Skills and certifications are grouped separately for readability.
+"""
+
+from __future__ import annotations
+
+from resume_operator.state import TailoredItem, TailoredResume
+from resume_operator.tools.source_index import SourceIndex
+
+
+def render_diff(tailored: TailoredResume, index: SourceIndex) -> str:
+    additions = [
+        i for i in tailored.items if i.action == "keep" and i.source_id.startswith("facts:")
+    ]
+    # "keep" master items aren't diff-worthy on their own — they were on the master already.
+    # "reword" items always show before/after regardless of source.
+    rewordings = [i for i in tailored.items if i.action == "reword"]
+    deletions = [i for i in tailored.items if i.action == "drop"]
+
+    lines: list[str] = ["# Tailoring Diff", ""]
+
+    if tailored.notes:
+        lines.append("## Strategy Notes")
+        lines.extend(f"- {note}" for note in tailored.notes)
+        lines.append("")
+
+    lines.append("## Additions — items pulled from the facts bank")
+    if additions:
+        lines.extend(_render_items(additions, index, show_new=False))
+    else:
+        lines.append("_No facts-bank items pulled in._")
+    lines.append("")
+
+    lines.append("## Rewordings — master or facts items with adjusted phrasing")
+    if rewordings:
+        for item in rewordings:
+            entry = index.get(item.source_id)
+            kind = entry.kind if entry else "unknown"
+            lines.append(f"- **{item.source_id}** ({kind})")
+            lines.append(f"  - before: {item.original_text}")
+            lines.append(f"  - after:  {item.new_text}")
+    else:
+        lines.append("_No rewordings._")
+    lines.append("")
+
+    lines.append("## Deletions — master items considered but dropped")
+    if deletions:
+        lines.extend(_render_items(deletions, index, show_new=False))
+    else:
+        lines.append("_No master items dropped._")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _render_items(items: list[TailoredItem], index: SourceIndex, *, show_new: bool) -> list[str]:
+    lines: list[str] = []
+    for item in items:
+        entry = index.get(item.source_id)
+        kind = entry.kind if entry else "unknown"
+        text = item.new_text if show_new and item.new_text else item.original_text
+        lines.append(f"- **{item.source_id}** ({kind}) {text}")
+    return lines

--- a/src/resume_operator/tools/source_index.py
+++ b/src/resume_operator/tools/source_index.py
@@ -1,0 +1,89 @@
+"""Source ID index for tailored items.
+
+Given a `ResumeMaster` and (optional) `FactsBank`, build a lookup table that
+maps every valid `source_id` to its canonical text. `optimize_content` uses
+this both to feed the LLM a menu of sources and to validate that every
+`TailoredItem.source_id` the LLM produces actually exists — the fabrication
+guard for #026.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from resume_operator.state import FactsBank, ResumeMaster
+
+
+@dataclass
+class SourceEntry:
+    """One row in the source index: canonical ID + the text the LLM may keep/reword."""
+
+    source_id: str
+    text: str
+    # `kind` lets the diff renderer group items: "experience-bullet", "skill", etc.
+    kind: str
+
+
+@dataclass
+class SourceIndex:
+    entries: dict[str, SourceEntry] = field(default_factory=dict)
+
+    def __contains__(self, source_id: str) -> bool:
+        return source_id in self.entries
+
+    def __iter__(self) -> object:
+        return iter(self.entries.values())
+
+    def as_prompt_menu(self) -> str:
+        """Render the index as a compact menu the LLM can see in the prompt."""
+        lines: list[str] = []
+        for entry in self.entries.values():
+            text = entry.text if len(entry.text) <= 300 else entry.text[:297] + "..."
+            lines.append(f"- [{entry.source_id}] ({entry.kind}) {text}")
+        return "\n".join(lines)
+
+    def get(self, source_id: str) -> SourceEntry | None:
+        return self.entries.get(source_id)
+
+
+def build_source_index(master: ResumeMaster, facts: FactsBank | None) -> SourceIndex:
+    """Build a `SourceIndex` covering every citable item on the master + facts bank."""
+    idx = SourceIndex()
+
+    if master.summary:
+        _add(idx, "master:summary", master.summary, "summary")
+
+    for exp in master.experience:
+        header = f"{exp.role} @ {exp.company}".strip(" @")
+        _add(idx, f"master:{exp.id}", header, "experience-header")
+        for bullet in exp.bullets:
+            _add(idx, f"master:{bullet.id}", bullet.text, "experience-bullet")
+
+    for edu in master.education:
+        text = f"{edu.degree} — {edu.school}".strip(" —")
+        _add(idx, f"master:{edu.id}", text, "education")
+
+    for skill in master.skills:
+        _add(idx, f"master:skill:{skill}", skill, "skill")
+
+    for cert in master.certifications:
+        _add(idx, f"master:cert:{cert}", cert, "certification")
+
+    if facts is not None:
+        for project in facts.projects:
+            _add(idx, f"facts:{project.id}", project.text, "project")
+        for extra in facts.extra_bullets:
+            kind = f"extra-bullet[{extra.role_id}]" if extra.role_id else "extra-bullet"
+            _add(idx, f"facts:{extra.id}", extra.text, kind)
+        for skill in facts.skills_beyond_master:
+            _add(idx, f"facts:skill:{skill}", skill, "skill")
+        for cert in facts.certifications_beyond_master:
+            _add(idx, f"facts:cert:{cert}", cert, "certification")
+
+    return idx
+
+
+def _add(idx: SourceIndex, source_id: str, text: str, kind: str) -> None:
+    idx.entries[source_id] = SourceEntry(source_id=source_id, text=text, kind=kind)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,13 @@ import pytest
 
 from resume_operator.state import (
     ATSScore,
+    EducationEntry,
+    ExperienceBullet,
+    ExperienceEntry,
     GapAnalysis,
     JobDescription,
     ResumeData,
+    ResumeMaster,
     ResumeOptimizerState,
 )
 
@@ -60,12 +64,62 @@ def sample_job() -> JobDescription:
 
 
 @pytest.fixture
-def sample_state(sample_resume: ResumeData, sample_job: JobDescription) -> ResumeOptimizerState:
-    """Full ResumeOptimizerState with resume + job data populated."""
+def sample_master() -> ResumeMaster:
+    """Pre-built ResumeMaster with stable IDs, aligned with `sample_resume`."""
+    return ResumeMaster(
+        name="Jane Smith",
+        email="jane@example.com",
+        phone="555-0100",
+        summary="Senior software engineer with 8 years of experience in Python and cloud.",
+        experience=[
+            ExperienceEntry(
+                id="exp-1",
+                role="Senior Engineer",
+                company="TechCorp",
+                start_date="2020",
+                end_date="present",
+                bullets=[
+                    ExperienceBullet(id="exp-1-b1", text="Led backend team"),
+                    ExperienceBullet(id="exp-1-b2", text="Built microservices in Python"),
+                ],
+            ),
+            ExperienceEntry(
+                id="exp-2",
+                role="Software Engineer",
+                company="StartupInc",
+                start_date="2016",
+                end_date="2020",
+                bullets=[
+                    ExperienceBullet(id="exp-2-b1", text="Full-stack development with Django")
+                ],
+            ),
+        ],
+        education=[
+            EducationEntry(
+                id="edu-1",
+                degree="B.S. Computer Science",
+                school="State University",
+                start_date="2012",
+                end_date="2016",
+            )
+        ],
+        skills=["Python", "Django", "AWS"],
+        certifications=["AWS Solutions Architect"],
+    )
+
+
+@pytest.fixture
+def sample_state(
+    sample_resume: ResumeData,
+    sample_job: JobDescription,
+    sample_master: ResumeMaster,
+) -> ResumeOptimizerState:
+    """Full ResumeOptimizerState with resume + master + job data populated."""
     return ResumeOptimizerState(
         resume_path="test_resume.pdf",
         job_description_path="test_job.txt",
         resume=sample_resume,
+        master=sample_master,
         job_description=sample_job,
         ats_score=ATSScore(
             score=0.72,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 from resume_operator.graph import build_graph
 from resume_operator.nodes.analyze_gaps import GapAnalysisLLMOutput
 from resume_operator.nodes.ats_score import ATSScoreLLMOutput
-from resume_operator.nodes.optimize_content import OptimizedResumeLLMOutput, OptimizedSections
+from resume_operator.nodes.optimize_content import TailoredItemLLM, TailoredResumeLLMOutput
 from resume_operator.nodes.parse_resume import (
     ResumeEducationLLM,
     ResumeExperienceLLM,
@@ -50,14 +50,14 @@ GAPS_OUT = GapAnalysisLLMOutput(
     suggestions=["Add K8s projects", "Mention CI/CD pipelines"],
 )
 
-OPTIMIZED_OUT = OptimizedResumeLLMOutput(
-    sections=OptimizedSections(
-        summary="Senior Python engineer with cloud and container expertise",
-        experience="Built APIs and CI/CD pipelines at Corp",
-        skills="Python, AWS, Docker, Kubernetes, CI/CD",
-        education="BS CS, State U, 2016",
-    ),
-    changes_made=["Added Kubernetes to skills", "Mentioned CI/CD in experience"],
+OPTIMIZED_OUT = TailoredResumeLLMOutput(
+    items=[
+        TailoredItemLLM(source_id="master:summary", action="keep"),
+        TailoredItemLLM(source_id="master:exp-1-b1", action="keep"),
+        TailoredItemLLM(source_id="master:skill:Python", action="keep"),
+        TailoredItemLLM(source_id="master:skill:AWS", action="keep"),
+    ],
+    notes=["Emphasized Python and AWS for the backend role."],
 )
 
 
@@ -123,8 +123,9 @@ class TestFullPipeline:
         assert len(result["gap_analysis"].strengths) == 2
         assert len(result["gap_analysis"].suggestions) == 2
 
-        assert "summary" in result["optimized_resume"].sections
-        assert len(result["optimized_resume"].changes_made) == 2
+        # Item-level tailored output is the new source of truth.
+        assert len(result["tailored_resume"].items) == 4
+        assert result["tailored_resume"].notes
 
         assert result["output_path"] == "output/resume.pdf"
         assert isinstance(result["report"], dict)
@@ -174,5 +175,5 @@ class TestFullPipeline:
         assert len(result["errors"]) > 0
         assert any("ats_score" in e for e in result["errors"])
         assert len(result["gap_analysis"].gaps) > 0
-        assert len(result["optimized_resume"].sections) > 0
+        assert result["tailored_resume"].items
         assert isinstance(result["report"], dict)

--- a/tests/test_optimize_content.py
+++ b/tests/test_optimize_content.py
@@ -1,28 +1,32 @@
-"""Tests for the optimize_content node."""
+"""Tests for the optimize_content node — per-item tailoring with fabrication guard."""
 
 from unittest.mock import MagicMock, patch
 
 from pydantic import ValidationError
 
 from resume_operator.nodes.optimize_content import (
-    OptimizedResumeLLMOutput,
-    OptimizedSections,
+    TailoredItemLLM,
+    TailoredResumeLLMOutput,
     optimize_content,
 )
 from resume_operator.state import ResumeOptimizerState
 
-VALID_OUTPUT = OptimizedResumeLLMOutput(
-    sections=OptimizedSections(
-        summary="Senior engineer with 8 years of Python and cloud experience.",
-        experience="Led backend team building microservices in Python on AWS.",
-        skills="Python, Django, AWS, Docker, PostgreSQL, Kubernetes, CI/CD",
-        education="B.S. Computer Science, State University, 2012-2016",
-    ),
-    changes_made=[
-        "Added Kubernetes to skills section",
-        "Emphasized CI/CD experience in work history",
-        "Incorporated microservices keywords in summary",
+VALID_OUTPUT = TailoredResumeLLMOutput(
+    items=[
+        TailoredItemLLM(source_id="master:summary", action="keep", original_text="summary text"),
+        TailoredItemLLM(
+            source_id="master:exp-1-b1",
+            action="reword",
+            original_text="Led backend team",
+            new_text="Led backend team building Kubernetes-native microservices",
+        ),
+        TailoredItemLLM(
+            source_id="master:exp-1-b2", action="keep", original_text="Built microservices"
+        ),
+        TailoredItemLLM(source_id="master:exp-2-b1", action="drop", original_text="Full-stack"),
+        TailoredItemLLM(source_id="master:skill:Python", action="keep", original_text="Python"),
     ],
+    notes=["Emphasized backend/microservices, dropped full-stack bullet."],
 )
 
 
@@ -37,17 +41,55 @@ def _make_llm(return_value: object | Exception) -> MagicMock:
 
 class TestOptimizeContent:
     @patch("resume_operator.nodes.optimize_content.get_structured_llm")
-    def test_optimizes_content_successfully(
+    def test_builds_tailored_resume(
         self, mock_get_llm: MagicMock, sample_state: ResumeOptimizerState
     ) -> None:
         mock_get_llm.return_value = _make_llm(VALID_OUTPUT)
 
         result = optimize_content(sample_state)
 
+        assert "tailored_resume" in result
+        assert len(result["tailored_resume"].items) == 5
+        assert result["tailored_resume"].items[1].action == "reword"
+        assert "Kubernetes-native" in result["tailored_resume"].items[1].new_text
+        # Legacy projection still populates sections for back-compat.
         assert "optimized_resume" in result
-        assert result["optimized_resume"].sections["summary"].startswith("Senior engineer")
-        assert len(result["optimized_resume"].changes_made) == 3
-        assert "Kubernetes" in result["optimized_resume"].changes_made[0]
+        assert result["optimized_resume"].sections["experience"].startswith("- ")
+        assert result["optimized_resume"].sections["skills"] == "Python"
+
+    @patch("resume_operator.nodes.optimize_content.get_structured_llm")
+    def test_rejects_fabricated_source_id(
+        self, mock_get_llm: MagicMock, sample_state: ResumeOptimizerState
+    ) -> None:
+        mock_get_llm.return_value = _make_llm(
+            TailoredResumeLLMOutput(
+                items=[
+                    TailoredItemLLM(source_id="master:exp-1-b1", action="keep"),
+                    # This ID does not exist in the source index — should be rejected.
+                    TailoredItemLLM(source_id="master:exp-99-b99", action="keep"),
+                ]
+            )
+        )
+
+        result = optimize_content(sample_state)
+
+        assert len(result["tailored_resume"].items) == 1
+        assert any("fabricated source_id" in e for e in result["errors"])
+
+    @patch("resume_operator.nodes.optimize_content.get_structured_llm")
+    def test_coerces_unknown_action(
+        self, mock_get_llm: MagicMock, sample_state: ResumeOptimizerState
+    ) -> None:
+        mock_get_llm.return_value = _make_llm(
+            TailoredResumeLLMOutput(
+                items=[TailoredItemLLM(source_id="master:exp-1-b1", action="delete")]
+            )
+        )
+
+        result = optimize_content(sample_state)
+
+        # Unknown action coerced to the safe default "keep".
+        assert result["tailored_resume"].items[0].action == "keep"
 
     @patch("resume_operator.nodes.optimize_content.get_structured_llm")
     def test_handles_llm_error(
@@ -59,14 +101,14 @@ class TestOptimizeContent:
 
         assert "errors" in result
         assert any("LLM call failed" in e for e in result["errors"])
-        assert "optimized_resume" not in result
+        assert "tailored_resume" not in result
 
     @patch("resume_operator.nodes.optimize_content.get_structured_llm")
     def test_handles_schema_validation_error(
         self, mock_get_llm: MagicMock, sample_state: ResumeOptimizerState
     ) -> None:
         try:
-            OptimizedResumeLLMOutput.model_validate({"changes_made": "not-a-list"})
+            TailoredResumeLLMOutput.model_validate({"items": "not-a-list"})
         except ValidationError as exc:
             mock_get_llm.return_value = _make_llm(exc)
 
@@ -74,48 +116,11 @@ class TestOptimizeContent:
 
         assert "errors" in result
         assert any("schema-invalid" in e for e in result["errors"])
-        assert "optimized_resume" not in result
+        assert "tailored_resume" not in result
 
-    @patch("resume_operator.nodes.optimize_content.get_structured_llm")
-    def test_handles_empty_fields(
-        self, mock_get_llm: MagicMock, sample_state: ResumeOptimizerState
-    ) -> None:
-        mock_get_llm.return_value = _make_llm(OptimizedResumeLLMOutput())
+    def test_skips_when_master_is_empty(self) -> None:
+        state = ResumeOptimizerState()  # empty master + facts
+        result = optimize_content(state)
 
-        result = optimize_content(sample_state)
-
-        assert "optimized_resume" in result
-        # Empty OptimizedSections dumps to {"summary": "", "experience": "", ...}
-        assert set(result["optimized_resume"].sections.keys()) == {
-            "summary",
-            "experience",
-            "skills",
-            "education",
-        }
-        assert all(v == "" for v in result["optimized_resume"].sections.values())
-        assert result["optimized_resume"].changes_made == []
-
-    @patch("resume_operator.nodes.optimize_content.get_structured_llm")
-    def test_preserves_all_section_keys(
-        self, mock_get_llm: MagicMock, sample_state: ResumeOptimizerState
-    ) -> None:
-        mock_get_llm.return_value = _make_llm(VALID_OUTPUT)
-
-        result = optimize_content(sample_state)
-
-        sections = result["optimized_resume"].sections
-        assert "summary" in sections
-        assert "experience" in sections
-        assert "skills" in sections
-        assert "education" in sections
-
-    @patch("resume_operator.nodes.optimize_content.get_structured_llm")
-    def test_returns_only_changed_fields(
-        self, mock_get_llm: MagicMock, sample_state: ResumeOptimizerState
-    ) -> None:
-        mock_get_llm.return_value = _make_llm(VALID_OUTPUT)
-
-        result = optimize_content(sample_state)
-
-        allowed_keys = {"optimized_resume", "errors"}
-        assert set(result.keys()).issubset(allowed_keys)
+        assert "errors" in result
+        assert any("source index is empty" in e for e in result["errors"])

--- a/tests/test_parse_resume.py
+++ b/tests/test_parse_resume.py
@@ -130,7 +130,7 @@ class TestParseResume:
 
         result = parse_resume(base_state)
 
-        allowed_keys = {"resume", "job_description", "errors"}
+        allowed_keys = {"resume", "master", "job_description", "errors"}
         assert set(result.keys()).issubset(allowed_keys)
 
     @patch("resume_operator.nodes.parse_resume.get_structured_llm")

--- a/tests/test_report_results.py
+++ b/tests/test_report_results.py
@@ -6,14 +6,31 @@ from pathlib import Path
 from unittest.mock import patch
 
 from resume_operator.nodes.report_results import report_results
-from resume_operator.state import OptimizedResume, ResumeOptimizerState
+from resume_operator.state import (
+    OptimizedResume,
+    ResumeOptimizerState,
+    TailoredItem,
+    TailoredResume,
+)
 
 
 def _setup_state(state: ResumeOptimizerState) -> None:
     """Populate fields not set by the sample_state fixture."""
     state.optimized_resume = OptimizedResume(
         sections={"summary": "Optimized summary.", "skills": "Python, AWS"},
-        changes_made=["Added Kubernetes to skills", "Rewrote summary"],
+        changes_made=["keep: master:summary", "reword: master:exp-1-b1"],
+    )
+    state.tailored_resume = TailoredResume(
+        items=[
+            TailoredItem(source_id="master:summary", action="keep", original_text="summary text"),
+            TailoredItem(
+                source_id="master:exp-1-b1",
+                action="reword",
+                original_text="Led backend team",
+                new_text="Led backend team on Kubernetes",
+            ),
+        ],
+        notes=["Tightened backend emphasis."],
     )
     state.output_path = "data/optimized_resume.pdf"
 
@@ -21,11 +38,14 @@ def _setup_state(state: ResumeOptimizerState) -> None:
 EXPECTED_KEYS = {
     "timestamp",
     "resume_path",
+    "master_path",
+    "facts_path",
     "job_description_path",
     "ats_score",
     "gap_analysis",
     "optimization_skipped",
     "optimization_changes",
+    "tailored_resume",
     "output_path",
     "errors",
 }
@@ -35,48 +55,74 @@ class TestReportResults:
     def test_writes_json_report(self, sample_state: ResumeOptimizerState, tmp_path: Path) -> None:
         _setup_state(sample_state)
         results_file = tmp_path / "data" / "results.json"
+        diff_file = tmp_path / "data" / "diff.md"
 
-        with patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file):
+        with (
+            patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file),
+            patch("resume_operator.nodes.report_results.DIFF_PATH", diff_file),
+        ):
             result = report_results(sample_state)
 
         assert results_file.exists()
+        assert diff_file.exists(), "diff.md should be written whenever tailored_resume has items"
         data = json.loads(results_file.read_text())
         assert isinstance(data, dict)
         assert "report" in result
+        assert "tailored_resume" in data
+
+    def test_diff_md_content(self, sample_state: ResumeOptimizerState, tmp_path: Path) -> None:
+        _setup_state(sample_state)
+        results_file = tmp_path / "data" / "results.json"
+        diff_file = tmp_path / "data" / "diff.md"
+
+        with (
+            patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file),
+            patch("resume_operator.nodes.report_results.DIFF_PATH", diff_file),
+        ):
+            report_results(sample_state)
+
+        body = diff_file.read_text(encoding="utf-8")
+        assert "# Tailoring Diff" in body
+        # The reworded item should show both before and after.
+        assert "Led backend team on Kubernetes" in body
+        assert "master:exp-1-b1" in body
 
     def test_report_contains_all_fields(
         self, sample_state: ResumeOptimizerState, tmp_path: Path
     ) -> None:
         _setup_state(sample_state)
         results_file = tmp_path / "data" / "results.json"
+        diff_file = tmp_path / "data" / "diff.md"
 
-        with patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file):
+        with (
+            patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file),
+            patch("resume_operator.nodes.report_results.DIFF_PATH", diff_file),
+        ):
             result = report_results(sample_state)
 
         report = result["report"]
         assert set(report.keys()) == EXPECTED_KEYS
         assert report["ats_score"]["score"] == 0.72
-        assert len(report["gap_analysis"]["gaps"]) > 0
-        assert report["optimization_changes"] == [
-            "Added Kubernetes to skills",
-            "Rewrote summary",
-        ]
         assert report["resume_path"] == "test_resume.pdf"
         assert report["output_path"] == "data/optimized_resume.pdf"
-        # Validate timestamp is parseable ISO format
         datetime.fromisoformat(report["timestamp"])
 
-    def test_creates_data_directory(
+    def test_skips_diff_when_no_tailored_items(
         self, sample_state: ResumeOptimizerState, tmp_path: Path
     ) -> None:
-        _setup_state(sample_state)
-        results_file = tmp_path / "nonexistent" / "subdir" / "results.json"
+        sample_state.output_path = "data/optimized_resume.pdf"
+        # deliberately leave tailored_resume empty
+        results_file = tmp_path / "data" / "results.json"
+        diff_file = tmp_path / "data" / "diff.md"
 
-        with patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file):
+        with (
+            patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file),
+            patch("resume_operator.nodes.report_results.DIFF_PATH", diff_file),
+        ):
             report_results(sample_state)
 
-        assert results_file.parent.exists()
         assert results_file.exists()
+        assert not diff_file.exists()
 
     def test_handles_write_error(self, sample_state: ResumeOptimizerState, tmp_path: Path) -> None:
         _setup_state(sample_state)
@@ -114,11 +160,13 @@ class TestReportResults:
     ) -> None:
         _setup_state(sample_state)
         results_file = tmp_path / "data" / "results.json"
+        diff_file = tmp_path / "data" / "diff.md"
 
-        with patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file):
+        with (
+            patch("resume_operator.nodes.report_results.RESULTS_PATH", results_file),
+            patch("resume_operator.nodes.report_results.DIFF_PATH", diff_file),
+        ):
             result = report_results(sample_state)
 
         allowed_keys = {"report", "errors"}
         assert set(result.keys()).issubset(allowed_keys)
-        assert "resume" not in result
-        assert "ats_score" not in result


### PR DESCRIPTION
## Summary

- Introduce `TailoredItem` / `TailoredResume` — per-item decisions (keep/reword/drop) referencing stable source IDs from master + facts.
- `tools/source_index.py` is both the prompt menu for the LLM and the fabrication guardrail — any `source_id` the LLM returns that isn't in the index is rejected and logged.
- `tools/diff_renderer.py` writes `data/diff.md` with Additions (facts pulled in), Rewordings (before/after), Deletions.

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/52. The old `optimize_content` had the LLM write free-form section blobs with a "don't fabricate" instruction and no structural check. `changes_made: list[str]` was LLM narration, not a diff. The PDF renderer split blobs on \`\n\n\`, so spacing depended on LLM whitespace (that's #027).

With item-level references the LLM's job shrinks from "rewrite the resume" to "for each master/facts item: keep, drop, or reword." Fabrication is structurally hard — the source item has to exist in the index first.

## Changes

- `state.py` — \`TailoredItem\`, \`TailoredResume\`, \`state.tailored_resume\`
- \`tools/source_index.py\` (new) — \`build_source_index(master, facts)\` returns a \`SourceIndex\` with \`as_prompt_menu()\` for prompts and \`__contains__\` for validation
- \`tools/diff_renderer.py\` (new) — renders \`diff.md\`
- \`prompts/content_optimization.py\` — rewritten for per-item decisions
- \`nodes/optimize_content.py\` — validates every source_id, records rejections in errors, projects to legacy \`OptimizedResume.sections\` for back-compat until #027
- \`nodes/report_results.py\` — writes \`data/diff.md\` whenever tailored items exist
- \`nodes/parse_resume.py\` — also synthesizes a \`ResumeMaster\` so the legacy PDF path still has a source index

## How to Test

1. \`uv run python -m pytest -q\` — 119 tests pass
2. Real-run: \`LLM_MODEL=openai/gpt-4o-mini uv run python -m resume_operator run --master input/master_resume.example.yaml --facts input/facts_bank.example.yaml --job input/job.txt --output data/test_026.pdf\`
3. Open \`data/diff.md\` and verify Additions / Rewordings / Deletions sections are populated.

## Proof of Work

Real-run verified against OpenRouter + \`openai/gpt-4o-mini\`:

\`\`\`
optimize_content: completed — items=27 (kept=21, reworded=1, dropped=5), fabricated_rejected=0, notes=1
report_results: completed — wrote data/results.json and data/diff.md
\`\`\`

diff.md excerpt:
- Additions pulled \`facts:proj-2\`, \`facts:extra-1\`, \`facts:skill:Docker\`, \`facts:skill:AWS Lambda\`
- Reworded \`master:exp-2-b2\` with clear before/after text
- Dropped a handful of facts items the LLM judged non-relevant

When this PR is merged, \`optimize_content\` no longer produces free-form section blobs — the tailored output is a structured list of decisions the reader can diff against, and the LLM cannot synthesize text that isn't traceable back to the master resume or facts bank.