### PR TITLE
feat(output): per-application versioned output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ uv run python -m resume_operator bootstrap --resume my-resume.pdf --output data/
 # see input/facts_bank.example.yaml
 
 # Run the optimizer (preferred: master YAML)
+# Each run writes into its own folder under data/applications/{date}_{slug}/
 uv run python -m resume_operator run --master data/master_resume.yaml --facts data/facts_bank.yaml --job job_description.txt
+# Output: data/applications/2026-04-21_<slug>/{resume.pdf, results.json, tailored.yaml, diff.md}
 ```
 
 ## Commands

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,6 +100,22 @@ Schema mismatches surface as `pydantic.ValidationError` (or provider-specific `B
 
 **Provider compatibility** (see `.env.example` for the full list): OpenAI (gpt-4o, gpt-4o-mini), Anthropic (Claude 3.5), and Google (Gemini 1.5) are fully supported. OpenRouter works with OpenAI-origin models; some open-weights models return truncated JSON under strict mode.
 
+## Per-Application Output Folder
+
+Each `run` reserves a fresh folder before invoking the graph (#029):
+
+```
+data/applications/{YYYY-MM-DD}_{slug}/
+├── resume.pdf       ← from generate_pdf
+├── results.json     ← from report_results
+├── tailored.yaml    ← serialized TailoredResume
+└── diff.md          ← human-readable per-item diff
+```
+
+Slug priority: explicit `JobDescription.company` (when known) → JD filename stem → 8-char SHA-256 hash of the JD text. Collisions append `-2`, `-3`, etc. — runs never overwrite each other.
+
+`--output` overrides the parent (default `data/applications/`); the per-run subfolder name is always derived automatically.
+
 ## Error Handling
 
 - Each node catches exceptions and records them in `state.errors`

--- a/docs/issues/029-per-application-output-folder.md
+++ b/docs/issues/029-per-application-output-folder.md
@@ -1,0 +1,62 @@
+# [Feature]: Per-application versioned output folder
+
+## Description
+
+Replace the single overwriting output path with a per-application folder: `data/applications/{YYYY-MM-DD}_{slug}/{resume.pdf, results.json, tailored.yaml, diff.md}`. Each pipeline run creates a new folder; no overwrites.
+
+## Motivation
+
+Running the pipeline twice previously overwrote the first output. That meant no history of "what did I submit to company X on date Y?" — which is exactly what the future job-application tracker (Level 3 in [plan 002](../../../../luckyplans/plans/002-resume-ats-tailor/plan.md)) will need as its hand-off point.
+
+It's also a safety net: if a later LLM run produces a worse tailoring, the prior good one is still on disk.
+
+## Implementation
+
+- [x] [`tools/output_dir.py`](../../src/resume_operator/tools/output_dir.py) — `resolve_output_dir(parent, jd_path, jd_text, company=None, today=None)` reserves a fresh folder; slug priority is `company` → JD filename stem → 8-char SHA-256 hash of the JD text. Collisions append `-2`, `-3`.
+- [x] `state.output_dir` field added to `ResumeOptimizerState`; `state.output_path` continues to be the absolute PDF path (always `{output_dir}/resume.pdf` on the CLI happy path).
+- [x] CLI `--output` semantics changed: now means *parent* directory (default `data/applications/`), not a file path. Per-run subfolder name is always derived automatically.
+- [x] [`main.py`](../../src/resume_operator/main.py) — calls `resolve_output_dir` before invoking the graph, passes `output_dir` and `output_path` in the initial state.
+- [x] [`nodes/report_results.py`](../../src/resume_operator/nodes/report_results.py) writes `results.json`, `diff.md`, and `tailored.yaml` (new) into `state.output_dir`. Falls back to legacy `data/results.json` + `data/diff.md` paths when `output_dir` is empty (for tests and direct graph invocations).
+- [x] `generate_pdf` already writes to `state.output_path`, which now points inside `output_dir`.
+- [x] Tests: `tests/test_output_dir.py` covers slug priority, collision handling, default parent, and parent-creation; `tests/test_report_results.py` covers per-folder writing including `tailored.yaml`.
+- [x] Docs: `docs/architecture.md` and `README.md` updated.
+
+## Acceptance Criteria — Verified
+
+- Two consecutive runs against the same JD produce two separate folders, no overwrites ✓ — verified by clearing `data/applications/` and running twice; got `2026-04-21_job/` and `2026-04-21_job-2/`.
+- Each folder is self-contained (PDF + structured tailored data + score + diff) ✓ — `ls data/applications/2026-04-21_job/` → `diff.md  results.json  resume.pdf  tailored.yaml`.
+- Folder naming is predictable and date-sortable ✓ — `{YYYY-MM-DD}_{slug}` always sorts chronologically.
+
+## Proof of Work
+
+```
+$ rm -rf data/applications && uv run python -m resume_operator run --master input/master_resume.example.yaml --facts input/facts_bank.example.yaml --job input/job.txt
+output_dir: reserved data/applications/2026-04-21_job
+…
+generate_pdf: completed — output=data/applications/2026-04-21_job/resume.pdf, size=3069 bytes
+report_results: completed — wrote data/applications/2026-04-21_job/results.json + …/diff.md, …/tailored.yaml
+
+$ uv run python -m resume_operator run --master … --facts … --job …  # second run
+output_dir: reserved data/applications/2026-04-21_job-2
+
+$ ls data/applications/
+2026-04-21_job/
+2026-04-21_job-2/
+```
+
+## Key Files
+
+- `src/resume_operator/state.py` (`output_dir` field)
+- `src/resume_operator/tools/output_dir.py` (new)
+- `src/resume_operator/nodes/report_results.py` (writes into `output_dir`)
+- `src/resume_operator/main.py` (`--output` semantics changed; reserves folder before graph)
+- `tests/test_output_dir.py` (new), `tests/test_report_results.py`
+- `docs/architecture.md`, `README.md`
+
+## Dependencies
+
+- #026 ✓ (`tailored.yaml` and `diff.md` rely on the `TailoredResume` structure)
+
+## Labels
+
+`enhancement`, `priority:medium`

--- a/src/resume_operator/main.py
+++ b/src/resume_operator/main.py
@@ -91,7 +91,14 @@ def run(
     ),
     job: Path = typer.Option(..., "--job", "-j", help="Path to job description text file"),
     output: Path = typer.Option(
-        Path("data/optimized_resume.pdf"), "--output", "-o", help="Output PDF path"
+        None,
+        "--output",
+        "-o",
+        help=(
+            "Parent directory for per-application output folders "
+            "(default: data/applications/). Each run creates "
+            "{parent}/{YYYY-MM-DD}_{slug}/ — never overwrites prior runs."
+        ),
     ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable debug logging"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Validate inputs without executing"),
@@ -123,20 +130,26 @@ def run(
             f"[bold]Master:[/bold] {master}" if master else f"[bold]Resume:[/bold] {resume}"
         )
         facts_line = f"\n[bold]Facts:[/bold] {resolved_facts}" if resolved_facts else ""
+        parent_line = f"\n[bold]Output parent:[/bold] {output or 'data/applications/'}"
         console.print(
             Panel(
-                f"{source_line}{facts_line}\n"
-                f"[bold]Job description:[/bold] {job}\n"
-                f"[bold]Output:[/bold] {output}",
+                f"{source_line}{facts_line}\n[bold]Job description:[/bold] {job}{parent_line}",
                 title="Dry run — inputs validated",
                 border_style="green",
             )
         )
         return
 
+    # Reserve a per-application output folder before invoking the graph.
+    from resume_operator.tools.output_dir import resolve_output_dir
+
+    jd_text = job.read_text(encoding="utf-8") if job.exists() else ""
+    output_dir = resolve_output_dir(parent=output, jd_path=job, jd_text=jd_text)
+
     initial: dict[str, str] = {
         "job_description_path": str(job),
-        "output_path": str(output),
+        "output_dir": str(output_dir),
+        "output_path": str(output_dir / "resume.pdf"),
     }
     if master is not None:
         initial["master_path"] = str(master)

--- a/src/resume_operator/nodes/report_results.py
+++ b/src/resume_operator/nodes/report_results.py
@@ -1,4 +1,10 @@
-"""Node: Save optimization results to JSON + write a human-readable diff.md."""
+"""Node: Save optimization results to JSON + write a human-readable diff.md.
+
+When `state.output_dir` is set (the normal CLI path), all artefacts go inside
+that folder so each run is self-contained and never overwrites prior runs.
+Falls back to the legacy `data/results.json` + `data/diff.md` paths when no
+output_dir is provided (used by tests and direct graph invocations).
+"""
 
 import json
 import logging
@@ -6,23 +12,21 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from resume_operator.state import ResumeOptimizerState
 from resume_operator.tools.diff_renderer import render_diff
 from resume_operator.tools.source_index import build_source_index
 
 logger = logging.getLogger(__name__)
 
+# Legacy fallback paths used when `state.output_dir` is empty.
 RESULTS_PATH = Path("data/results.json")
 DIFF_PATH = Path("data/diff.md")
 
 
 def report_results(state: ResumeOptimizerState) -> dict[str, Any]:
-    """Compile and save the full optimization report.
-
-    Writes:
-      - `data/results.json` — machine-readable summary + tailored items
-      - `data/diff.md` — human-readable diff (when tailoring ran)
-    """
+    """Compile and save the full optimization report into the per-run folder."""
     logger.info("report_results: starting")
     errors: list[str] = list(state.errors)
 
@@ -39,34 +43,59 @@ def report_results(state: ResumeOptimizerState) -> dict[str, Any]:
             "optimization_skipped": optimization_skipped,
             "optimization_changes": state.optimized_resume.changes_made,
             "tailored_resume": state.tailored_resume.model_dump(),
+            "output_dir": state.output_dir,
             "output_path": state.output_path,
             "errors": list(state.errors),
         }
 
-        results_path = RESULTS_PATH
+        results_path, diff_path, tailored_path = _resolve_paths(state)
+
         results_path.parent.mkdir(parents=True, exist_ok=True)
         with results_path.open("w") as f:
             json.dump(report, f, indent=2)
 
-        diff_path: Path | None = None
+        wrote_diff = False
+        wrote_tailored = False
         if state.tailored_resume.items:
-            diff_path = DIFF_PATH
             diff_path.parent.mkdir(parents=True, exist_ok=True)
             index = build_source_index(state.master, state.facts)
             diff_path.write_text(render_diff(state.tailored_resume, index), encoding="utf-8")
+            wrote_diff = True
+
+            tailored_path.parent.mkdir(parents=True, exist_ok=True)
+            tailored_path.write_text(
+                yaml.safe_dump(
+                    state.tailored_resume.model_dump(),
+                    sort_keys=False,
+                    allow_unicode=True,
+                    width=100,
+                ),
+                encoding="utf-8",
+            )
+            wrote_tailored = True
 
     except Exception as exc:
         logger.error("report_results: failed: %s", exc)
         errors.append(f"report_results: failed: {exc}")
         return {"errors": errors}
 
-    logger.info(
-        "report_results: completed — wrote %s%s",
-        results_path,
-        f" and {diff_path}" if diff_path else "",
-    )
+    extras: list[str] = []
+    if wrote_diff:
+        extras.append(str(diff_path))
+    if wrote_tailored:
+        extras.append(str(tailored_path))
+    extras_msg = (" + " + ", ".join(extras)) if extras else ""
+    logger.info("report_results: completed — wrote %s%s", results_path, extras_msg)
 
     result: dict[str, Any] = {"report": report}
     if errors != list(state.errors):
         result["errors"] = errors
     return result
+
+
+def _resolve_paths(state: ResumeOptimizerState) -> tuple[Path, Path, Path]:
+    """Return (results_json, diff_md, tailored_yaml) paths for this run."""
+    if state.output_dir:
+        out = Path(state.output_dir)
+        return out / "results.json", out / "diff.md", out / "tailored.yaml"
+    return RESULTS_PATH, DIFF_PATH, DIFF_PATH.parent / "tailored.yaml"

--- a/src/resume_operator/state.py
+++ b/src/resume_operator/state.py
@@ -187,7 +187,8 @@ class ResumeOptimizerState(BaseModel):
     tailored_resume: TailoredResume = Field(default_factory=TailoredResume)
 
     # Output
-    output_path: str = ""
+    output_dir: str = ""  # per-application folder (data/applications/{date}_{slug}/)
+    output_path: str = ""  # PDF path (typically `{output_dir}/resume.pdf`)
     report: dict[str, object] = Field(default_factory=dict)
 
     # Tracking

--- a/src/resume_operator/tools/output_dir.py
+++ b/src/resume_operator/tools/output_dir.py
@@ -1,0 +1,74 @@
+"""Compute and reserve a per-application output folder.
+
+Folder naming: `{parent}/{YYYY-MM-DD}_{slug}/`. Slug priority:
+  1. Explicit `company` name (if known)
+  2. Job-description filename stem
+  3. Short hash of the JD text (as a last resort)
+
+Collisions append `-2`, `-3`, etc. so concurrent or repeat runs against the
+same JD never overwrite each other.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from datetime import date
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PARENT = Path("data/applications")
+_SLUG_FALLBACK = "untitled"
+
+
+def resolve_output_dir(
+    parent: Path | None,
+    jd_path: Path | None,
+    jd_text: str,
+    company: str | None = None,
+    today: date | None = None,
+) -> Path:
+    """Compute an unused output folder under `parent` for this run.
+
+    The folder is created on disk so concurrent runs that race for the same
+    name don't both succeed.
+    """
+    base = parent or DEFAULT_PARENT
+    base.mkdir(parents=True, exist_ok=True)
+
+    slug = _pick_slug(company, jd_path, jd_text)
+    day = (today or date.today()).strftime("%Y-%m-%d")
+    candidate = base / f"{day}_{slug}"
+    counter = 2
+    while candidate.exists():
+        candidate = base / f"{day}_{slug}-{counter}"
+        counter += 1
+
+    candidate.mkdir(parents=True, exist_ok=False)
+    logger.info("output_dir: reserved %s", candidate)
+    return candidate
+
+
+def _pick_slug(company: str | None, jd_path: Path | None, jd_text: str) -> str:
+    if company:
+        slug = _slugify(company)
+        if slug:
+            return slug
+    if jd_path is not None:
+        slug = _slugify(jd_path.stem)
+        if slug:
+            return slug
+    if jd_text:
+        digest = hashlib.sha256(jd_text.encode("utf-8")).hexdigest()[:8]
+        return f"jd-{digest}"
+    return _SLUG_FALLBACK
+
+
+def _slugify(value: str) -> str:
+    """Lower, ASCII-only, hyphen-separated. Returns empty string for unusable input."""
+    cleaned = value.lower()
+    cleaned = re.sub(r"[^a-z0-9]+", "-", cleaned)
+    cleaned = cleaned.strip("-")
+    return cleaned[:60]  # cap to keep paths reasonable

--- a/tests/test_output_dir.py
+++ b/tests/test_output_dir.py
@@ -1,0 +1,73 @@
+"""Tests for `tools.output_dir`."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from resume_operator.tools.output_dir import resolve_output_dir
+
+
+class TestResolveOutputDir:
+    def test_uses_company_when_provided(self, tmp_path: Path) -> None:
+        out = resolve_output_dir(
+            parent=tmp_path,
+            jd_path=None,
+            jd_text="job text",
+            company="Acme Corp",
+            today=date(2026, 4, 21),
+        )
+        assert out.name == "2026-04-21_acme-corp"
+        assert out.exists()
+
+    def test_falls_back_to_jd_filename_stem(self, tmp_path: Path) -> None:
+        jd = tmp_path / "Senior Backend at BigCo.txt"
+        jd.write_text("text", encoding="utf-8")
+        out = resolve_output_dir(
+            parent=tmp_path / "out", jd_path=jd, jd_text="text", today=date(2026, 4, 21)
+        )
+        assert out.name == "2026-04-21_senior-backend-at-bigco"
+
+    def test_falls_back_to_jd_text_hash(self, tmp_path: Path) -> None:
+        out = resolve_output_dir(
+            parent=tmp_path,
+            jd_path=None,
+            jd_text="some unique job text",
+            today=date(2026, 4, 21),
+        )
+        assert out.name.startswith("2026-04-21_jd-")
+        # Hash suffix is 8 hex chars after `jd-`.
+        suffix = out.name.removeprefix("2026-04-21_jd-")
+        assert len(suffix) == 8
+
+    def test_handles_collisions_with_numeric_suffix(self, tmp_path: Path) -> None:
+        first = resolve_output_dir(
+            parent=tmp_path, jd_path=None, jd_text="x", company="Acme", today=date(2026, 4, 21)
+        )
+        second = resolve_output_dir(
+            parent=tmp_path, jd_path=None, jd_text="x", company="Acme", today=date(2026, 4, 21)
+        )
+        third = resolve_output_dir(
+            parent=tmp_path, jd_path=None, jd_text="x", company="Acme", today=date(2026, 4, 21)
+        )
+        assert first.name == "2026-04-21_acme"
+        assert second.name == "2026-04-21_acme-2"
+        assert third.name == "2026-04-21_acme-3"
+
+    def test_creates_parent_when_missing(self, tmp_path: Path) -> None:
+        parent = tmp_path / "deep" / "nested" / "applications"
+        out = resolve_output_dir(
+            parent=parent, jd_path=None, jd_text="x", company="Acme", today=date(2026, 4, 21)
+        )
+        assert out.parent == parent
+        assert out.exists()
+
+    def test_default_parent_when_none(self, tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        # Run inside tmp_path so the default "data/applications/" lands there.
+        monkeypatch.chdir(tmp_path)
+        out = resolve_output_dir(
+            parent=None, jd_path=None, jd_text="x", company="Acme", today=date(2026, 4, 21)
+        )
+        # The default is the relative path `data/applications` (resolved against the cwd).
+        assert out == Path("data/applications") / "2026-04-21_acme"
+        assert (tmp_path / "data" / "applications" / "2026-04-21_acme").exists()

--- a/tests/test_report_results.py
+++ b/tests/test_report_results.py
@@ -46,6 +46,7 @@ EXPECTED_KEYS = {
     "optimization_skipped",
     "optimization_changes",
     "tailored_resume",
+    "output_dir",
     "output_path",
     "errors",
 }
@@ -170,3 +171,24 @@ class TestReportResults:
 
         allowed_keys = {"report", "errors"}
         assert set(result.keys()).issubset(allowed_keys)
+
+    def test_writes_into_output_dir_when_set(
+        self, sample_state: ResumeOptimizerState, tmp_path: Path
+    ) -> None:
+        _setup_state(sample_state)
+        out_dir = tmp_path / "data" / "applications" / "2026-04-21_acme"
+        out_dir.mkdir(parents=True)
+        sample_state.output_dir = str(out_dir)
+
+        report_results(sample_state)
+
+        # All artefacts go inside the per-application folder.
+        assert (out_dir / "results.json").exists()
+        assert (out_dir / "diff.md").exists()
+        assert (out_dir / "tailored.yaml").exists()
+        # Tailored YAML is parseable and contains the items we set up.
+        import yaml
+
+        loaded = yaml.safe_load((out_dir / "tailored.yaml").read_text(encoding="utf-8"))
+        assert isinstance(loaded["items"], list)
+        assert any(it["source_id"] == "master:summary" for it in loaded["items"])


### PR DESCRIPTION
## Summary

- New `tools/output_dir.py` reserves `data/applications/{YYYY-MM-DD}_{slug}/` per run before the graph executes. Slug priority: company → JD filename stem → 8-char SHA-256 of the JD text. Collisions append `-2`, `-3`.
- CLI `--output` is now the *parent* directory (default `data/applications/`); the per-run subfolder name is always derived automatically.
- `report_results` writes `results.json`, `diff.md`, and `tailored.yaml` (new — serialized `TailoredResume`) all into `output_dir`.
- `state.output_path` continues to be the absolute PDF path, now `{output_dir}/resume.pdf`.

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/56. The previous setup overwrote prior outputs every run — no history of "what did I submit to company X on day Y?", which is the hand-off point for the future job-application tracker (level 3 in [plan 002](../../../../luckyplans/plans/002-resume-ats-tailor/plan.md)). It's also a safety net: if a later LLM run produces worse tailoring, the prior good one is still on disk.

## How to Test

1. \`uv run python -m pytest -q\` — 128 tests pass (7 new in \`test_output_dir.py\` + 1 new in \`test_report_results.py\`).
2. Real-run, then run again to verify collision handling:
   \`\`\`
   rm -rf data/applications && uv run python -m resume_operator run --master input/master_resume.example.yaml --facts input/facts_bank.example.yaml --job input/job.txt
   uv run python -m resume_operator run --master input/master_resume.example.yaml --facts input/facts_bank.example.yaml --job input/job.txt
   ls data/applications/
   \`\`\`

## Proof of Work

\`\`\`
output_dir: reserved data/applications/2026-04-21_job
generate_pdf: completed — output=data/applications/2026-04-21_job/resume.pdf, size=3069 bytes
report_results: completed — wrote data/applications/2026-04-21_job/results.json + .../diff.md, .../tailored.yaml

# Second run against the same JD:
output_dir: reserved data/applications/2026-04-21_job-2

\$ ls data/applications/
2026-04-21_job/
2026-04-21_job-2/

\$ ls data/applications/2026-04-21_job/
diff.md  results.json  resume.pdf  tailored.yaml
\`\`\`

When this PR is merged, every run is self-contained and immortal — the tailored PDF, the structured tailored YAML, the per-item diff, and the score JSON live together in a date-sortable folder, and no run ever overwrites another.