### PR TITLE
refactor(bootstrap): preserve every bullet verbatim; drop full-graph side effects

### DIFF
--- a/docs/issues/031-preserve-every-bullet-on-bootstrap.md
+++ b/docs/issues/031-preserve-every-bullet-on-bootstrap.md
@@ -1,0 +1,60 @@
+# [Refactor]: Preserve every resume bullet on bootstrap (no summarization)
+
+## Description
+
+When `bootstrap` parses a PDF into `master_resume.yaml` today, the LLM collapses each role's bullets into a single dense summary sentence. That defeats the point of the master YAML: downstream tailoring (#026) has nothing to keep/reword/drop at bullet granularity, the rendered PDF looks sparse, and any prior hand-editing effort on the PDF is lost on every re-bootstrap.
+
+Change the PARSE_RESUME prompt and the LLM output schema so every bullet is preserved verbatim. Also trim `bootstrap` to only run `parse_resume` — today it accidentally invokes the full graph and burns three extra LLM calls on ats_score / analyze_gaps / optimize_content the user never asked for.
+
+## Motivation
+
+Verified end-to-end against a real resume — 13 roles came out as 13 single-bullet entries, the tailor had no meaningful per-role choices to make, and the tailored PDF rendered with 4 sparse bullets. Rebuilt masters lose whatever bullet structure existed on the source PDF.
+
+## Target State
+
+After this change:
+
+1. `ResumeExperienceLLM` exposes `bullets: list[str]` instead of the old `description: str`. The LLM fills a real list; no string-joining-with-newlines coincidence carries the data.
+2. `PARSE_RESUME` prompt explicitly instructs: preserve every bullet verbatim; do not summarize; if the source has four bullets, the output has four items in `bullets`; do not invent bullets; do not truncate.
+3. `parse_resume` node converts each LLM experience entry into a `ResumeData.experience` dict with `description` set to `"\n".join(f"- {b}" for b in bullets)`, so the existing `resume_data_to_master` conversion still works (it already splits multi-line descriptions on newlines — see `tools/master_resume.py:_parse_bullets`).
+4. `bootstrap` CLI runs only the `parse_resume` node, not the full graph — no unnecessary ats_score / analyze_gaps / optimize_content / generate_pdf / report_results calls during ingestion.
+
+## Success Metrics — Verified
+
+Real-run against `input/resume.pdf` (Takeshi Suzuki's actual resume) with
+`LLM_MODEL=openai/gpt-4o-mini`:
+
+- Before this PR: 13 roles × 1 summary bullet each = 13 total bullets.
+- After this PR: 13 roles, most with 3-4 bullets each = ~40 bullets.
+  Example — `exp-2` (Lead Software Engineer @ UrbanMix.Tech) now has 4 bullets:
+  "Built a real estate project management…", "Led and managed an agile team…",
+  "Utilized Terraform to automate configuration…", "Enhanced D3 model
+  rendering…" — exactly what appears on the source PDF.
+- `bootstrap` logs show only a single `parse_resume` call. No ats_score /
+  analyze_gaps / optimize_content / generate_pdf / report_results noise.
+- A subsequent `run` against this richer master produced a tailored PDF with
+  real backend-relevant material (AWS + CI/CD + Docker at Biblionexus,
+  RESTful APIs at TechGropse, Kotlin native integration at Hilolabs) and the
+  fabrication guard from #026 caught two hallucinated skills
+  (`master:skill:AWS`, `master:skill:SQL`) — validation working on real
+  content, not just the example YAMLs.
+
+## The Change
+
+By the end of this issue, `bootstrap` extracts structured content *as it is* on the source PDF, and `master_resume.yaml` becomes the rich source of truth #024 promised — not a compressed summary.
+
+## Key Files
+
+- `src/resume_operator/prompts/resume_parsing.py` — new prompt body
+- `src/resume_operator/nodes/parse_resume.py` — `ResumeExperienceLLM.bullets: list[str]`, join to `description` when writing `ResumeData`
+- `src/resume_operator/main.py` — `bootstrap` calls `parse_resume` directly
+- `tests/test_parse_resume.py`, `tests/test_integration.py` — fixtures updated to use `bullets: [...]`
+
+## Dependencies
+
+- #024 ✓ (bootstrap exists)
+- #028 ✓ (structured output — the schema change lives in the LLM output class)
+
+## Labels
+
+`refactor`, `priority:medium`

--- a/src/resume_operator/main.py
+++ b/src/resume_operator/main.py
@@ -263,14 +263,20 @@ def bootstrap(
     This is the only command that calls the LLM to ingest a resume. From then on,
     `run --master` uses the YAML directly.
     """
+    from resume_operator.nodes.parse_resume import parse_resume as parse_resume_node
+    from resume_operator.state import ResumeOptimizerState
     from resume_operator.tools.master_resume import resume_data_to_master, save_master
 
     _setup_logging(verbose)
     _validate_resume(resume)
 
-    graph = build_graph()
+    # Bootstrap only needs the parse_resume node — not the full graph. Invoking the
+    # graph here used to fire ats_score + analyze_gaps + optimize_content +
+    # generate_pdf + report_results as well, which wasted three extra LLM calls
+    # plus a PDF render on every bootstrap (issue #60).
     with Status("[bold cyan]Bootstrapping master resume from PDF...", console=console):
-        result = graph.invoke({"resume_path": str(resume)})
+        state = ResumeOptimizerState(resume_path=str(resume))
+        result = parse_resume_node(state)
 
     errors: list[str] = result.get("errors", [])
     if errors:

--- a/src/resume_operator/nodes/parse_resume.py
+++ b/src/resume_operator/nodes/parse_resume.py
@@ -22,7 +22,10 @@ class ResumeExperienceLLM(BaseModel):
     company: str = ""
     start_date: str = ""
     end_date: str = ""
-    description: str = ""
+    # `bullets` carries every per-role bullet verbatim. The old `description: str`
+    # field encouraged the LLM to summarize multiple bullets into one sentence,
+    # which defeated the purpose of a structured master resume (see issue #60).
+    bullets: list[str] = Field(default_factory=list)
 
 
 class ResumeEducationLLM(BaseModel):
@@ -47,6 +50,24 @@ class ResumeLLMOutput(BaseModel):
     education: list[ResumeEducationLLM] = Field(default_factory=list)
     skills: list[str] = Field(default_factory=list)
     certifications: list[str] = Field(default_factory=list)
+
+
+def _experience_to_dict(entry: ResumeExperienceLLM) -> dict[str, str]:
+    """Flatten the LLM experience entry to the legacy `dict[str, str]` shape.
+
+    Bullets collapse into a `description` string with one `- bullet` per line.
+    `tools/master_resume._parse_bullets` re-splits on newlines when building the
+    `ResumeMaster`, so this round-trip preserves every bullet as a separate item
+    with its own stable ID.
+    """
+    description = "\n".join(f"- {b.strip()}" for b in entry.bullets if b.strip())
+    return {
+        "role": entry.role,
+        "company": entry.company,
+        "start_date": entry.start_date,
+        "end_date": entry.end_date,
+        "description": description,
+    }
 
 
 def parse_resume(state: ResumeOptimizerState) -> dict[str, Any]:
@@ -96,7 +117,7 @@ def parse_resume(state: ResumeOptimizerState) -> dict[str, Any]:
         email=parsed.email,
         phone=parsed.phone,
         summary=parsed.summary,
-        experience=[e.model_dump() for e in parsed.experience],
+        experience=[_experience_to_dict(e) for e in parsed.experience],
         education=[e.model_dump() for e in parsed.education],
         skills=list(parsed.skills),
         certifications=list(parsed.certifications),

--- a/src/resume_operator/prompts/resume_parsing.py
+++ b/src/resume_operator/prompts/resume_parsing.py
@@ -1,12 +1,26 @@
 """Prompt template for resume PDF text parsing."""
 
-PARSE_RESUME = """Extract structured data from the following resume text.
+PARSE_RESUME = """Extract structured data from the following resume text. The
+goal is faithful ingestion, not summarization — preserve every bullet the source
+shows.
 
-Populate every field of the output schema. For experience, each entry should
-have `role`, `company`, `start_date`, `end_date`, and `description` (a short
-summary or bullet list). For education, each entry should have `degree`,
-`school`, `start_date`, `end_date`. Leave unknown fields empty rather than
-guessing.
+Rules:
+- Preserve every bullet verbatim. Do NOT summarize multiple bullets into one
+  sentence. If a role has four bullets on the resume, the output must have four
+  items in `bullets` for that role.
+- Do NOT invent bullets that aren't in the source text.
+- Do NOT truncate or merge bullets.
+- Keep the wording close to the source; only fix obvious OCR artifacts.
+
+For each experience entry, populate:
+- `role`, `company`
+- `start_date`, `end_date` — as they appear on the resume (e.g. "Aug 2023",
+  "Present")
+- `bullets` — one list item per source bullet
+
+For each education entry, populate `degree`, `school`, `start_date`, `end_date`.
+
+Leave unknown fields as empty strings rather than guessing.
 
 Resume text:
 {resume_text}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,7 +29,7 @@ PARSED_RESUME = ResumeLLMOutput(
             company="Corp",
             start_date="2020",
             end_date="present",
-            description="Built APIs",
+            bullets=["Built APIs", "Shipped to AWS"],
         )
     ],
     education=[ResumeEducationLLM(degree="BS CS", school="State U", end_date="2016")],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -106,6 +106,59 @@ class TestParseResumeCommand:
         assert "Missing" in result.output or "--resume" in result.output
 
 
+class TestBootstrapCommand:
+    def test_rejects_non_pdf(self, tmp_path: Path) -> None:
+        fake = tmp_path / "resume.txt"
+        fake.write_text("not a pdf")
+        result = runner.invoke(app, ["bootstrap", "--resume", str(fake)])
+        assert result.exit_code != 0
+        assert "not a PDF" in _clean_output(result.output)
+
+    @patch("resume_operator.main.build_graph")
+    @patch("resume_operator.nodes.parse_resume.parse_resume")
+    def test_calls_only_parse_resume_not_full_graph(
+        self, mock_parse: MagicMock, mock_build: MagicMock, tmp_path: Path
+    ) -> None:
+        """Bootstrap must not invoke the full graph — that would burn LLM calls on
+        ats_score / analyze_gaps / optimize_content the user never asked for."""
+        fake_pdf = tmp_path / "resume.pdf"
+        fake_pdf.touch()
+        out = tmp_path / "master.yaml"
+
+        mock_parse.return_value = {
+            "resume": ResumeData(
+                name="Jane Smith",
+                email="jane@example.com",
+                experience=[
+                    {
+                        "role": "Engineer",
+                        "company": "Corp",
+                        "start_date": "2020",
+                        "end_date": "present",
+                        "description": "- Built APIs\n- Shipped to AWS",
+                    }
+                ],
+                skills=["Python", "AWS"],
+            ),
+            "errors": [],
+        }
+
+        result = runner.invoke(app, ["bootstrap", "--resume", str(fake_pdf), "--output", str(out)])
+
+        assert result.exit_code == 0, result.output
+        mock_parse.assert_called_once()
+        # Crucial: the full graph is not invoked during bootstrap.
+        mock_build.assert_not_called()
+        assert out.exists()
+
+        import yaml
+
+        written = yaml.safe_load(out.read_text(encoding="utf-8"))
+        assert written["name"] == "Jane Smith"
+        # Bullets round-trip: dense newline description → list of ExperienceBullet entries.
+        assert len(written["experience"][0]["bullets"]) == 2
+
+
 class TestRunCommand:
     def test_file_not_found(self) -> None:
         result = runner.invoke(app, ["run", "--resume", "nope.pdf", "--job", "nope.txt"])

--- a/tests/test_parse_resume.py
+++ b/tests/test_parse_resume.py
@@ -23,7 +23,11 @@ VALID_OUTPUT = ResumeLLMOutput.model_validate(
                 "company": "TechCorp",
                 "start_date": "2020",
                 "end_date": "present",
-                "description": "Led backend team",
+                "bullets": [
+                    "Led backend team building microservices",
+                    "Designed gRPC contracts adopted by 12 teams",
+                    "Mentored 4 mid-level engineers",
+                ],
             }
         ],
         "education": [
@@ -76,6 +80,29 @@ class TestParseResume:
         assert "job_description" in result
         assert result["job_description"].raw_text == base_state.job_description_text
         mock_extract.assert_called_once_with(Path("resume.pdf"))
+
+    @patch("resume_operator.nodes.parse_resume.get_structured_llm")
+    @patch("resume_operator.nodes.parse_resume.extract_text")
+    def test_preserves_every_bullet(
+        self, mock_extract: MagicMock, mock_get_llm: MagicMock, base_state: ResumeOptimizerState
+    ) -> None:
+        """Three source bullets become three separately-addressable master bullets."""
+        mock_extract.return_value = SAMPLE_RESUME_TEXT
+        mock_get_llm.return_value = _make_llm(VALID_OUTPUT)
+
+        result = parse_resume(base_state)
+
+        # ResumeData carries them newline-joined (legacy shape).
+        description = result["resume"].experience[0]["description"]
+        assert description.count("\n") == 2  # three bullets → two newlines
+        # ResumeMaster (synthesized alongside) has them split back out with stable IDs.
+        master_bullets = result["master"].experience[0].bullets
+        assert [b.text for b in master_bullets] == [
+            "Led backend team building microservices",
+            "Designed gRPC contracts adopted by 12 teams",
+            "Mentored 4 mid-level engineers",
+        ]
+        assert [b.id for b in master_bullets] == ["exp-1-b1", "exp-1-b2", "exp-1-b3"]
 
     @patch("resume_operator.nodes.parse_resume.extract_text")
     def test_records_error_on_pdf_failure(


### PR DESCRIPTION
## Summary

- \`ResumeExperienceLLM\` now carries \`bullets: list[str]\` instead of \`description: str\` — the LLM fills a real list of preserved bullets.
- \`PARSE_RESUME\` prompt rewritten to explicitly forbid summarization: \"preserve every bullet verbatim\", \"do not invent\", \"do not truncate\".
- \`bootstrap\` CLI now calls the \`parse_resume\` node directly instead of \`build_graph().invoke()\` — no more unasked-for ats_score / analyze_gaps / optimize_content / generate_pdf / report_results calls during ingestion.

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/60. Surfaced when running against a real resume PDF: the LLM was collapsing 13 roles into 13 one-sentence summaries, which left the downstream tailor nothing to keep/reword/drop at bullet granularity, and the tailored PDF rendered with 4 sparse bullets on the whole page. Separately, bootstrap was accidentally invoking the full graph and burning three extra LLM calls plus a PDF render on every bootstrap.

## Changes

- \`src/resume_operator/nodes/parse_resume.py\` — \`ResumeExperienceLLM.bullets\` replaces \`description\`; new \`_experience_to_dict\` helper joins bullets newline-separated into \`ResumeData.experience[i][\"description\"]\` so the existing \`tools/master_resume._parse_bullets\` can split them back into \`ExperienceBullet\` entries with stable IDs.
- \`src/resume_operator/prompts/resume_parsing.py\` — new prompt body with explicit verbatim-preservation rules.
- \`src/resume_operator/main.py\` — \`bootstrap\` directly invokes \`parse_resume(state)\` instead of the full graph.
- Test fixtures in \`test_parse_resume.py\` and \`test_integration.py\` migrated to the new schema.
- New tests: \`test_preserves_every_bullet\` (3-bullet LLM output round-trips to 3 addressable \`ExperienceBullet\` entries) and \`TestBootstrapCommand.test_calls_only_parse_resume_not_full_graph\` (patches \`build_graph\` and asserts bootstrap never touches it).

## How to Test

1. \`uv run python -m pytest -q\` — 133 tests pass (2 new).
2. Real-run bootstrap: \`LLM_MODEL=openai/gpt-4o-mini uv run python -m resume_operator bootstrap --resume <your resume.pdf> --output data/master_resume.yaml\`
3. Inspect \`data/master_resume.yaml\` — verify each role has ≥ 3 bullets (matching the source PDF) instead of one summary sentence.
4. \`LLM_MODEL=openai/gpt-4o-mini uv run python -m resume_operator run --master data/master_resume.yaml --job <your job.txt>\` and open the tailored PDF.

## Proof of Work

Real-run against an actual resume PDF:

- Before: \`exp-1\` had one bullet: \"Designed and implemented user-centric pages for the trading platform, identified and resolved technical issues, and provided support to backend developers.\"
- After: \`exp-1\` has three bullets preserving the source verbatim — \"Designed and implemented user-centric pages for the trading platform…\", \"Proactively identified and resolved technical issues…\", \"Provided support to backend and smart contract developers…\"
- Bootstrap logs: single \`parse_resume: completed\` line. No ats_score / analyze_gaps / optimize_content / generate_pdf / report_results noise.
- Subsequent tailoring run pulled real backend-specific bullets into the tailored PDF (AWS + CI/CD + Docker at Biblionexus; RESTful APIs + MongoDB schema at TechGropse; Kotlin native integration at Hilolabs), and the \`optimize_content\` fabrication guard caught two hallucinated skill source_ids (\`master:skill:AWS\`, \`master:skill:SQL\`) — validation working on real content.

When this PR is merged, \`bootstrap\` does what it was always supposed to do: ingest a resume PDF into a structured YAML that preserves the source bullets, with no wasted LLM calls on the side.