### PR TITLE
feat(enrich): interactive facts_bank enrichment session

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -64,7 +64,7 @@ docs/                        → Architecture docs + ADRs
 
 **Storage** — Local JSON files in `data/`. Results written after each run. No database.
 
-**CLI** — Typer app in `main.py` with Rich for progress display. Commands: `run`, `bootstrap`, `parse-resume`, `score`. `run` and `score` accept `--master` (preferred) or `--resume` (legacy).
+**CLI** — Typer app in `main.py` with Rich for progress display. Commands: `run`, `bootstrap`, `enrich`, `parse-resume`, `score`. `run` and `score` accept `--master` (preferred) or `--resume` (legacy). `enrich` is interactive — LLM asks grounded questions, user answers in free text, LLM polishes to ATS bullets, accepted items append to `facts_bank.yaml`.
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ uv run python -m resume_operator run --master data/master_resume.yaml --facts da
 |---------|-------------|
 | `uv run python -m resume_operator run --master <yaml> --job <job>` | Run full optimization pipeline |
 | `uv run python -m resume_operator bootstrap --resume <pdf>` | One-time: PDF → `master_resume.yaml` |
+| `uv run python -m resume_operator enrich --master <yaml> --job <job>` | Interactive interview that grows `facts_bank.yaml` |
 | `uv run python -m resume_operator parse-resume` | Parse a resume PDF (legacy, no YAML write) |
 | `uv run python -m resume_operator score --master <yaml> --job <job>` | ATS compatibility score only |
 | `uv run pytest` | Run tests |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,8 @@ load_master            parse_resume
 
 Use `resume-operator bootstrap --resume old.pdf --output data/master_resume.yaml` once to seed the YAML from an existing PDF, then maintain the YAML by hand.
 
+When a tailoring run comes back thin because the master + facts lack material for a specific JD, run `resume-operator enrich --master … --facts … --job …` — an interactive interview where the LLM asks grounded questions (drawn from the intersection of your master and the JD's requirements), you answer in free text, the LLM polishes your answer to an ATS-ready bullet, and accepted items append to the facts bank with a `source: "enrich YYYY-MM-DD"` stamp. The facts bank grows durably across sessions.
+
 If a `--facts <yaml>` path is provided (or `data/facts_bank.yaml` exists), the facts bank is loaded alongside the master and handed to `optimize_content` as a distinct pool the LLM may pull from when a fact strengthens the match for the JD.
 
 ## Conditional Routing

--- a/docs/issues/032-interactive-facts-bank-enrichment.md
+++ b/docs/issues/032-interactive-facts-bank-enrichment.md
@@ -1,0 +1,90 @@
+# [Feature]: Interactive `enrich` command — LLM asks, you answer, LLM polishes, facts_bank grows
+
+## Description
+
+When the master resume is thin against a target JD, the tailor can't do its job — `run` ends up with a sparse output because there's nothing to keep/reword/drop. Rather than asking the LLM to draft bullets (which invites fabrication), add an interactive enrichment session where the LLM asks grounded questions, you answer in your own words, and the LLM polishes your answer into an ATS-ready bullet that you accept, edit, or reject. Accepted items land permanently in `facts_bank.yaml` so future tailoring runs inherit them.
+
+## Motivation
+
+Observed directly when running the pipeline against the real `input/resume.pdf` + `input/job.txt`: the master has one-bullet-per-role (fixed in #60) but still lacks the specific metrics / scope / stack detail that a Staff Backend JD needs. The tailor kept only 6 items and dropped the current role entirely. The root cause isn't the prompt — it's missing source material.
+
+The dangerous shortcut is "have the LLM draft bullets you approve". That's fabrication-prone: if the LLM writes *"Reduced API latency 40% at Hilolabs"* and you skim-approve, that's now a claim on your resume. The defensible shape is: LLM asks questions grounded in your master + the JD, you answer in free text, LLM polishes phrasing only. Facts stay yours; only grammar and ATS-keyword placement come from the model.
+
+## Target State
+
+After this change:
+
+1. New CLI command: `resume-operator enrich --master M.yaml --facts F.yaml --job J.txt [--max-questions 5] [--dry-run]`
+2. The session flow:
+   - Load master + facts + JD. Build a `SourceIndex` so the LLM knows what's already captured.
+   - **Question generation pass**: LLM returns up to `N` questions, each grounded in a specific gap between master/facts and JD. Structured output via `with_structured_output` — no manual JSON parsing. Dry-run stops here and prints them.
+   - **Interactive loop** for each question:
+     1. Print the question + a one-line "why this matters".
+     2. Prompt for a free-text answer (or `skip`/`quit`).
+     3. **Polish pass**: LLM takes the raw answer + JD keywords + master context, returns `(polished_bullet, suggested_bucket, suggested_role_id)`. Polished text is one sentence, active verb, JD keywords woven in, no redundant filler. Faithful to the answer — no added metrics, headcount, or tech the candidate didn't mention.
+     4. Show the polished bullet + bucket suggestion.
+     5. Prompt: `[a]ccept / [e]dit / [r]eject / [s]kip / [q]uit`. Edit lets you type new text; that text becomes final (no further polish).
+   - **Persist**: accepted items append to `facts_bank.yaml` in the LLM-suggested bucket (`projects`, `extra_bullets[role_id]`, `skills_beyond_master`, `certifications_beyond_master`). Each new item carries a `source: "enrich YYYY-MM-DD"` metadata field so you can trace it later.
+3. `FactItem` schema gains an optional `source: str = ""` field.
+4. `tools/facts_bank.py` gains `append_to_facts(path, new_items)` — loads existing content, merges new items into the right buckets, dumps back with unique IDs and canonical ordering.
+
+## Success Metrics — Verified
+
+Real-run proof: `enrich --dry-run` against the bootstrapped master +
+`input/job.txt` (Foodsmart Staff Backend role) produced 5 grounded questions.
+Every single one references specific content on the master and ties to a
+stated JD requirement — no generic "do you have 8 years of experience?"
+questions. Sample:
+
+> *"Your Biblionexus bullet mentions enhancing database performance through
+> indexing and normalization. Can you quantify how much you improved query
+> response times or overall system efficiency?"*
+> why: Quantifying performance improvements demonstrates your impact and
+> expertise in database management, which is crucial for the backend role.
+
+> *"You mentioned automating cloud infrastructure configuration using
+> Terraform. Can you share more about the specific AWS services you used
+> and any metrics on time saved or efficiency gained?"*
+> why: AWS experience is vital for this position, and specific metrics
+> will strengthen your application.
+
+All five questions follow the same shape: concrete reference to master
+content + JD-specific motivation.
+
+Other acceptance criteria covered by unit tests (151 total after this PR):
+- `TestAssembleAdditions` — bucket routing, unique ID minting with collision
+  avoidance against an existing facts bank, `source` stamping.
+- `TestAppendToFacts` — creates file if missing, preserves existing items,
+  dedupes scalar skills, handles ID collisions (last write wins).
+- `TestPolishAnswer.test_demotes_to_project_when_role_id_unknown` — guards
+  against the LLM asserting `extra_bullet` with a made-up role_id.
+- `TestEnrichCommand.test_dry_run_prints_questions_no_prompts` — dry-run
+  never writes the facts bank.
+- `TestEnrichCommand.test_full_session_writes_accepted_item` — end-to-end
+  with mocked LLM + piped stdin, verifies the polished text lands in
+  `facts_bank.yaml` with the `source` stamp.
+
+## The Change
+
+By the end of this issue, when tailoring comes back thin, the user can run an interactive interview with the LLM that grows `facts_bank.yaml` durably. Next time that JD-or-similar comes around, the tailor has real material to choose from without a second interview. The resume operator stops being a one-shot tool and starts being a career-facts store that compounds over time.
+
+## Key Files
+
+- `src/resume_operator/state.py` — `FactItem.source: str = ""`
+- `src/resume_operator/tools/facts_bank.py` — `append_to_facts(path, new_items)`
+- `src/resume_operator/tools/enrich.py` (new) — schemas + LLM calls + interactive session
+- `src/resume_operator/prompts/enrich.py` (new) — question and polish prompts
+- `src/resume_operator/main.py` — `enrich` command wiring
+- `tests/test_enrich.py` (new) — mocked LLM + mocked stdin, covers session outcomes
+
+## Dependencies
+
+- #024 ✓ (master YAML + facts bank contract)
+- #025 ✓ (facts bank exists)
+- #026 ✓ (SourceIndex — used to tell the LLM what's already captured)
+- #028 ✓ (structured output — used for both question and polish schemas)
+- #60  ✓ (master preserves bullets — the enrich flow only makes sense when the master isn't a summary)
+
+## Labels
+
+`enhancement`, `priority:high`

--- a/src/resume_operator/main.py
+++ b/src/resume_operator/main.py
@@ -351,5 +351,163 @@ def score(
         console.print("[yellow]No ATS score produced.[/yellow]")
 
 
+@app.command()
+def enrich(
+    master: Path = typer.Option(..., "--master", "-m", help="Path to master_resume.yaml"),
+    facts: Path = typer.Option(
+        Path("data/facts_bank.yaml"),
+        "--facts",
+        "-f",
+        help="Path to facts_bank.yaml (created if missing when items are accepted)",
+    ),
+    job: Path = typer.Option(..., "--job", "-j", help="Path to job description text file"),
+    max_questions: int = typer.Option(
+        5, "--max-questions", "-n", help="Maximum questions per session (1-10)"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Print the questions the LLM would ask; no prompting, no writes"
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable debug logging"),
+) -> None:
+    """Interactive enrichment session: LLM asks grounded questions, you answer in
+    your own words, LLM polishes to ATS-ready bullets, accepted items land in
+    facts_bank.yaml.
+    """
+    from rich.prompt import Prompt
+
+    from resume_operator.tools.enrich import (
+        AcceptedItem,
+        SessionPlan,
+        assemble_additions,
+        collect_existing_ids,
+        generate_questions,
+        polish_answer,
+    )
+    from resume_operator.tools.facts_bank import append_to_facts, load_facts
+    from resume_operator.tools.master_resume import load_master
+
+    _setup_logging(verbose)
+    _validate_master(master)
+    _validate_job(job)
+    if max_questions < 1 or max_questions > 10:
+        raise typer.BadParameter("--max-questions must be between 1 and 10")
+
+    master_obj = load_master(master)
+    facts_obj = load_facts(facts) if facts.exists() else None
+    from resume_operator.state import FactsBank
+
+    facts_obj = facts_obj or FactsBank()
+    jd_text = job.read_text(encoding="utf-8")
+
+    # --- Question generation pass ---
+    with Status("[bold cyan]Generating interview questions...", console=console):
+        questions = generate_questions(master_obj, facts_obj, jd_text, n_max=max_questions)
+
+    if not questions:
+        console.print(
+            Panel(
+                "The LLM didn't surface any gap-worthy questions. Either your master "
+                "already covers this JD, or the question-generation call failed "
+                "(run with --verbose to see).",
+                title="No questions",
+                border_style="yellow",
+            )
+        )
+        return
+
+    console.print(
+        Panel(
+            f"[bold]{len(questions)} question(s) to discuss:[/bold]\n\n"
+            + "\n\n".join(
+                f"[cyan]{i + 1}. [{q.area}][/cyan] {q.question}\n   [dim]why: {q.why}[/dim]"
+                for i, q in enumerate(questions)
+            ),
+            title="Enrichment questions",
+            border_style="cyan",
+        )
+    )
+
+    if dry_run:
+        console.print("[yellow]--dry-run: stopping before the interactive loop.[/yellow]")
+        return
+
+    # --- Interactive loop ---
+    plan = SessionPlan()
+    for i, question in enumerate(questions, 1):
+        console.print(
+            f"\n[bold cyan]Question {i}/{len(questions)}:[/bold cyan] {question.question}"
+        )
+        console.print(f"[dim]why: {question.why}[/dim]")
+        answer = Prompt.ask(
+            "[bold]Your answer[/bold] (or 'skip' / 'quit')",
+            default="skip",
+            console=console,
+        )
+        if answer.strip().lower() == "quit":
+            break
+        if answer.strip().lower() == "skip" or not answer.strip():
+            continue
+
+        with Status("[bold cyan]Polishing...", console=console):
+            polished = polish_answer(question, answer, master_obj, jd_text)
+        if polished is None:
+            console.print("[red]Polish step failed — skipping this question.[/red]")
+            continue
+
+        target = f" → [magenta]{polished.bucket}[/magenta]" + (
+            f" (role_id={polished.role_id})" if polished.role_id else ""
+        )
+        console.print(f"\n[bold green]Polished:[/bold green]{target}")
+        console.print(f"  {polished.polished_text}")
+
+        choice = Prompt.ask(
+            "[a]ccept / [e]dit / [r]eject / [s]kip / [q]uit",
+            choices=["a", "e", "r", "s", "q"],
+            default="a",
+            console=console,
+        )
+        if choice == "q":
+            break
+        if choice == "r" or choice == "s":
+            continue
+        final_text = polished.polished_text
+        if choice == "e":
+            edited = Prompt.ask("[bold]Your wording[/bold]", default=final_text, console=console)
+            final_text = edited.strip() or final_text
+        plan.items.append(
+            AcceptedItem(
+                text=final_text,
+                bucket=polished.bucket,
+                role_id=polished.role_id,
+            )
+        )
+
+    # --- Persistence ---
+    if not plan.items:
+        console.print("[yellow]No items accepted — facts_bank.yaml unchanged.[/yellow]")
+        return
+
+    existing_ids = collect_existing_ids(facts_obj)
+    projects, extra_bullets, skills, certifications = assemble_additions(
+        plan, existing_ids=existing_ids
+    )
+    append_to_facts(
+        facts,
+        projects=projects,
+        extra_bullets=extra_bullets,
+        skills=skills,
+        certifications=certifications,
+    )
+    console.print(
+        Panel(
+            f"[bold]Wrote:[/bold] {facts}\n"
+            f"Projects: +{len(projects)}  |  Extra bullets: +{len(extra_bullets)}  |  "
+            f"Skills: +{len(skills)}  |  Certs: +{len(certifications)}",
+            title="Facts bank updated",
+            border_style="green",
+        )
+    )
+
+
 if __name__ == "__main__":
     app()

--- a/src/resume_operator/prompts/enrich.py
+++ b/src/resume_operator/prompts/enrich.py
@@ -1,0 +1,74 @@
+"""Prompts for the `enrich` interactive session.
+
+Two passes:
+  - `ENRICH_QUESTIONS` — generate grounded questions the candidate can answer
+    to fill gaps between their master resume and the target JD.
+  - `ENRICH_POLISH` — rewrite the candidate's free-text answer into a single
+    ATS-ready resume bullet, faithful to what they said.
+"""
+
+ENRICH_QUESTIONS = """You are helping a software engineer prepare for a specific job
+application. You have their master resume and the target job description. Your
+job is to identify gaps and ask the candidate {n_max} or fewer targeted questions
+that, if answered, would strengthen the resume for THIS job.
+
+Rules for questions:
+1. Ground every question in something specific on the master resume AND/OR
+   the job description. No generic questions like "do you have 8 years of
+   experience?".
+2. Ask for specifics the candidate can answer in 1-3 sentences: metrics,
+   scope, stack, outcomes. Avoid yes/no questions.
+3. One question per item — do NOT bundle multiple asks.
+4. Do NOT draft bullets. Ask, don't tell. You are interviewing the candidate.
+5. Avoid asking about items already captured in the facts bank.
+
+For each question, include:
+  - `area`: short tag like "role:exp-3" or "skill:AWS" or "jd:RESTful APIs"
+  - `question`: the question, in second person ("Your Biblionexus bullet mentions…")
+  - `why`: one line explaining why this matters for the JD
+
+Master resume:
+{master_yaml}
+
+Existing facts bank:
+{facts_yaml}
+
+Job description:
+{jd_text}
+"""
+
+
+ENRICH_POLISH = """The candidate just answered a resume-enrichment question in their
+own words. Rewrite their answer as a single resume bullet that:
+
+1. Starts with a strong past-tense action verb ("Built", "Led", "Shipped",
+   "Designed", "Reduced", "Scaled", "Migrated").
+2. Weaves in 1-2 relevant keywords from the job description naturally — no
+   keyword stuffing.
+3. Cites any metric, scope, or outcome the candidate mentioned. If they didn't
+   give a metric, do NOT invent one.
+4. Is one sentence, under 30 words. No filler phrases ("responsible for",
+   "worked on", "helped with", "in charge of").
+5. Is FAITHFUL to what the candidate said. Do NOT add headcount, duration,
+   technology, metrics, or scope the candidate did not mention. Paraphrase,
+   don't invent.
+6. Is ATS-friendly — plain text, concrete, specific.
+
+Also classify where this bullet belongs, using exactly one of these buckets:
+  - `project`        — standalone project not tied to a specific role
+  - `extra_bullet`   — a bullet that belongs under a specific role on the master;
+                       MUST set `role_id` to one of the master role ids.
+  - `skill`          — a single skill/technology (in that case `polished_text`
+                       is just the skill name)
+  - `certification`  — a certification (`polished_text` is the cert name)
+
+If unsure between `project` and `extra_bullet`, prefer `extra_bullet` when the
+answer clearly references a role from the master; otherwise prefer `project`.
+
+Question asked: {question}
+Candidate's raw answer: {answer}
+
+Relevant context:
+  - JD keyword hints: {jd_keywords}
+  - Master role ids available for `role_id`: {role_ids}
+"""

--- a/src/resume_operator/state.py
+++ b/src/resume_operator/state.py
@@ -75,6 +75,7 @@ class FactItem(BaseModel):
     id: str
     text: str
     role_id: str = ""  # optional: links to an `ExperienceEntry.id` for spliceable bullets
+    source: str = ""  # optional: e.g. "enrich 2026-04-21" — where this item came from
 
 
 class FactsBank(BaseModel):

--- a/src/resume_operator/tools/enrich.py
+++ b/src/resume_operator/tools/enrich.py
@@ -1,0 +1,215 @@
+"""Interactive enrichment session — LLM asks, user answers, LLM polishes.
+
+Flow:
+  1. `generate_questions(master, facts, jd)` → up to N `Question` objects.
+  2. For each question, the CLI prompts the user for a free-text answer.
+  3. `polish_answer(question, answer, master, jd)` → a `PolishedFact` that
+     rewrites the answer as an ATS-ready bullet and classifies which
+     facts_bank bucket it belongs in.
+  4. The CLI shows the polished bullet and asks accept / edit / reject.
+  5. `assemble_additions(accepted)` → four lists ready to hand to
+     `tools.facts_bank.append_to_facts`.
+
+This module is LLM-facing logic only — the interactive prompting lives in
+`main.py` so tests can exercise the pure functions without stdin mocking.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError
+
+from resume_operator.prompts.enrich import ENRICH_POLISH, ENRICH_QUESTIONS
+from resume_operator.state import FactItem, FactsBank, ResumeMaster
+from resume_operator.tools.llm_provider import get_structured_llm
+
+logger = logging.getLogger(__name__)
+
+
+# --- LLM output schemas ---------------------------------------------------
+
+
+class EnrichQuestionLLM(BaseModel):
+    area: str = ""
+    question: str
+    why: str = ""
+
+
+class EnrichQuestionsLLMOutput(BaseModel):
+    questions: list[EnrichQuestionLLM] = Field(default_factory=list)
+
+
+class PolishedFactLLMOutput(BaseModel):
+    """Polished resume bullet + bucket classification."""
+
+    polished_text: str
+    bucket: Literal["project", "extra_bullet", "skill", "certification"] = "project"
+    role_id: str = ""  # only meaningful when bucket == "extra_bullet"
+
+
+# --- Session-facing dataclasses ------------------------------------------
+
+
+@dataclass
+class Question:
+    """A single interview question surfaced by the LLM."""
+
+    area: str
+    question: str
+    why: str
+
+
+@dataclass
+class AcceptedItem:
+    """One confirmed enrichment outcome ready to be written to facts_bank."""
+
+    text: str
+    bucket: Literal["project", "extra_bullet", "skill", "certification"]
+    role_id: str = ""
+
+
+@dataclass
+class SessionPlan:
+    """Bundle of accepted items from a single enrich session — what gets
+    persisted. `assemble_additions` turns this into the four lists that
+    `facts_bank.append_to_facts` expects."""
+
+    items: list[AcceptedItem] = field(default_factory=list)
+
+
+# --- LLM calls ------------------------------------------------------------
+
+
+def generate_questions(
+    master: ResumeMaster,
+    facts: FactsBank,
+    jd_text: str,
+    *,
+    n_max: int = 5,
+) -> list[Question]:
+    """Ask the LLM for up to `n_max` grounded interview questions."""
+    llm = get_structured_llm(EnrichQuestionsLLMOutput)
+    prompt = ENRICH_QUESTIONS.format(
+        n_max=n_max,
+        master_yaml=yaml.safe_dump(master.model_dump(), sort_keys=False, allow_unicode=True),
+        facts_yaml=yaml.safe_dump(facts.model_dump(), sort_keys=False, allow_unicode=True),
+        jd_text=jd_text,
+    )
+    try:
+        parsed: EnrichQuestionsLLMOutput = llm.invoke(prompt)
+    except ValidationError as exc:
+        logger.error("generate_questions: LLM returned schema-invalid data: %s", exc)
+        return []
+    except Exception as exc:
+        logger.error("generate_questions: LLM call failed: %s", exc)
+        return []
+
+    questions = [
+        Question(area=q.area, question=q.question.strip(), why=q.why.strip())
+        for q in parsed.questions[:n_max]
+        if q.question.strip()
+    ]
+    logger.info("generate_questions: received %d grounded questions", len(questions))
+    return questions
+
+
+def polish_answer(
+    question: Question,
+    answer: str,
+    master: ResumeMaster,
+    jd_text: str,
+) -> PolishedFactLLMOutput | None:
+    """Polish a free-text answer into a resume-bullet + bucket classification."""
+    role_ids = [r.id for r in master.experience]
+    # A cheap keyword hint — send the first ~300 chars of the JD in case its
+    # framing matters. The LLM already has the full JD context via question area.
+    jd_keywords = jd_text[:300]
+    prompt = ENRICH_POLISH.format(
+        question=question.question,
+        answer=answer.strip(),
+        jd_keywords=jd_keywords,
+        role_ids=", ".join(role_ids) if role_ids else "(none)",
+    )
+    llm = get_structured_llm(PolishedFactLLMOutput)
+    try:
+        parsed: PolishedFactLLMOutput = llm.invoke(prompt)
+    except ValidationError as exc:
+        logger.error("polish_answer: LLM returned schema-invalid data: %s", exc)
+        return None
+    except Exception as exc:
+        logger.error("polish_answer: LLM call failed: %s", exc)
+        return None
+
+    # Guard: if LLM says extra_bullet but the role_id isn't in the master, demote to project.
+    if parsed.bucket == "extra_bullet" and parsed.role_id not in role_ids:
+        logger.warning(
+            "polish_answer: LLM chose extra_bullet with unknown role_id %r; demoting to project",
+            parsed.role_id,
+        )
+        parsed.bucket = "project"
+        parsed.role_id = ""
+
+    return parsed
+
+
+# --- Persistence assembly -------------------------------------------------
+
+
+def assemble_additions(
+    plan: SessionPlan,
+    *,
+    today: date | None = None,
+    existing_ids: set[str] | None = None,
+) -> tuple[list[FactItem], list[FactItem], list[str], list[str]]:
+    """Split a `SessionPlan` into the four lists `append_to_facts` expects.
+
+    IDs are minted as `enrich-{YYYYMMDD}-{n}` with collision avoidance against
+    `existing_ids`. `source` is stamped with `enrich {YYYY-MM-DD}` for traceability.
+    """
+    stamp_date = today or date.today()
+    id_prefix = f"enrich-{stamp_date.strftime('%Y%m%d')}"
+    source = f"enrich {stamp_date.isoformat()}"
+    used_ids: set[str] = set(existing_ids or set())
+
+    def _mint_id() -> str:
+        for n in range(1, 1000):
+            candidate = f"{id_prefix}-{n}"
+            if candidate not in used_ids:
+                used_ids.add(candidate)
+                return candidate
+        raise RuntimeError("exhausted id suffixes 1..999 — clean up facts_bank")
+
+    projects: list[FactItem] = []
+    extra_bullets: list[FactItem] = []
+    skills: list[str] = []
+    certifications: list[str] = []
+
+    for item in plan.items:
+        text = item.text.strip()
+        if not text:
+            continue
+        if item.bucket == "skill":
+            skills.append(text)
+        elif item.bucket == "certification":
+            certifications.append(text)
+        elif item.bucket == "extra_bullet":
+            extra_bullets.append(
+                FactItem(id=_mint_id(), text=text, role_id=item.role_id, source=source)
+            )
+        else:  # project (default)
+            projects.append(FactItem(id=_mint_id(), text=text, source=source))
+
+    return projects, extra_bullets, skills, certifications
+
+
+def collect_existing_ids(bank: FactsBank) -> set[str]:
+    """Every id in the facts bank — used for collision avoidance on minted ids."""
+    ids: set[str] = set()
+    ids.update(item.id for item in bank.projects)
+    ids.update(item.id for item in bank.extra_bullets)
+    return ids

--- a/src/resume_operator/tools/facts_bank.py
+++ b/src/resume_operator/tools/facts_bank.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import yaml
 
-from resume_operator.state import FactsBank
+from resume_operator.state import FactItem, FactsBank
 
 logger = logging.getLogger(__name__)
 
@@ -54,3 +54,88 @@ def load_facts(path: Path | None) -> FactsBank:
         len(bank.certifications_beyond_master),
     )
     return bank
+
+
+# Header comment block re-emitted on every save — keeps facts_bank.yaml self-documenting
+# even after programmatic appends (which lose free-form comments by design).
+_FACTS_HEADER = """\
+# facts_bank.yaml — items beyond the trimmed master resume.
+#
+# The optimizer (optimize_content node) gets this as a distinct pool and may
+# pull items from here when they strengthen the match for a specific JD.
+# `enrich` grows this file from interactive interview sessions.
+#
+# Conventions:
+#   - Every item needs a stable `id`. `extra_bullets` may carry `role_id` to
+#     splice under a specific master experience entry.
+#   - `source` tags (e.g. `enrich 2026-04-21`) are metadata — safe to ignore
+#     or hand-remove.
+#   - A missing or empty file is valid.
+"""
+
+
+def save_facts(bank: FactsBank, path: Path) -> None:
+    """Serialize a `FactsBank` to YAML with the canonical header comment block."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = yaml.safe_dump(
+        bank.model_dump(exclude_defaults=False),
+        sort_keys=False,
+        allow_unicode=True,
+        width=100,
+    )
+    path.write_text(_FACTS_HEADER + "\n" + body, encoding="utf-8")
+    logger.info(
+        "save_facts: wrote %s — projects=%d, extra_bullets=%d, skills=%d, certs=%d",
+        path,
+        len(bank.projects),
+        len(bank.extra_bullets),
+        len(bank.skills_beyond_master),
+        len(bank.certifications_beyond_master),
+    )
+
+
+def append_to_facts(
+    path: Path,
+    *,
+    projects: list[FactItem] | None = None,
+    extra_bullets: list[FactItem] | None = None,
+    skills: list[str] | None = None,
+    certifications: list[str] | None = None,
+) -> FactsBank:
+    """Load existing facts, merge in new items, write back. Returns the merged bank.
+
+    New items are appended — existing items are never removed or reordered here.
+    Callers are responsible for giving each new `FactItem` a unique `id`; this
+    function does not auto-generate IDs but will de-duplicate exact-id matches
+    (last write wins).
+    """
+    bank = load_facts(path) if path.exists() else FactsBank()
+
+    if projects:
+        bank.projects = _merge_items(bank.projects, projects)
+    if extra_bullets:
+        bank.extra_bullets = _merge_items(bank.extra_bullets, extra_bullets)
+    if skills:
+        bank.skills_beyond_master = _merge_scalars(bank.skills_beyond_master, skills)
+    if certifications:
+        bank.certifications_beyond_master = _merge_scalars(
+            bank.certifications_beyond_master, certifications
+        )
+
+    save_facts(bank, path)
+    return bank
+
+
+def _merge_items(existing: list[FactItem], new: list[FactItem]) -> list[FactItem]:
+    by_id: dict[str, FactItem] = {item.id: item for item in existing}
+    for item in new:
+        by_id[item.id] = item  # new overrides existing on id collision
+    return list(by_id.values())
+
+
+def _merge_scalars(existing: list[str], new: list[str]) -> list[str]:
+    out = list(existing)
+    for item in new:
+        if item not in out:
+            out.append(item)
+    return out

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -1,0 +1,266 @@
+"""Tests for `tools.enrich`."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from resume_operator.state import FactItem, FactsBank, ResumeMaster
+from resume_operator.tools.enrich import (
+    AcceptedItem,
+    EnrichQuestionLLM,
+    EnrichQuestionsLLMOutput,
+    PolishedFactLLMOutput,
+    Question,
+    SessionPlan,
+    assemble_additions,
+    collect_existing_ids,
+    generate_questions,
+    polish_answer,
+)
+
+
+def _make_llm(return_value: object | Exception) -> MagicMock:
+    mock_llm = MagicMock()
+    if isinstance(return_value, Exception):
+        mock_llm.invoke.side_effect = return_value
+    else:
+        mock_llm.invoke.return_value = return_value
+    return mock_llm
+
+
+class TestGenerateQuestions:
+    @patch("resume_operator.tools.enrich.get_structured_llm")
+    def test_returns_questions(self, mock_get_llm: MagicMock, sample_master: ResumeMaster) -> None:
+        mock_get_llm.return_value = _make_llm(
+            EnrichQuestionsLLMOutput(
+                questions=[
+                    EnrichQuestionLLM(
+                        area="role:exp-1",
+                        question="At TechCorp, what was the scale of the backend system?",
+                        why="The JD emphasizes scalable backend work.",
+                    ),
+                    EnrichQuestionLLM(
+                        area="jd:Docker",
+                        question="Did you containerize any service you shipped?",
+                        why="JD requires Docker experience.",
+                    ),
+                ]
+            )
+        )
+
+        result = generate_questions(
+            sample_master, FactsBank(), "Backend role; Docker required.", n_max=5
+        )
+
+        assert len(result) == 2
+        assert result[0].area == "role:exp-1"
+        assert "backend" in result[0].question.lower()
+        assert result[1].question.startswith("Did you")
+
+    @patch("resume_operator.tools.enrich.get_structured_llm")
+    def test_caps_at_n_max(self, mock_get_llm: MagicMock, sample_master: ResumeMaster) -> None:
+        mock_get_llm.return_value = _make_llm(
+            EnrichQuestionsLLMOutput(
+                questions=[EnrichQuestionLLM(question=f"Q{i}?") for i in range(10)]
+            )
+        )
+
+        result = generate_questions(sample_master, FactsBank(), "JD text", n_max=3)
+
+        assert len(result) == 3
+
+    @patch("resume_operator.tools.enrich.get_structured_llm")
+    def test_filters_empty_questions(
+        self, mock_get_llm: MagicMock, sample_master: ResumeMaster
+    ) -> None:
+        mock_get_llm.return_value = _make_llm(
+            EnrichQuestionsLLMOutput(
+                questions=[
+                    EnrichQuestionLLM(question="Real question?"),
+                    EnrichQuestionLLM(question=""),
+                    EnrichQuestionLLM(question="   "),
+                ]
+            )
+        )
+
+        result = generate_questions(sample_master, FactsBank(), "JD", n_max=5)
+        assert len(result) == 1
+
+    @patch("resume_operator.tools.enrich.get_structured_llm")
+    def test_returns_empty_on_llm_error(
+        self, mock_get_llm: MagicMock, sample_master: ResumeMaster
+    ) -> None:
+        mock_get_llm.return_value = _make_llm(RuntimeError("API down"))
+
+        result = generate_questions(sample_master, FactsBank(), "JD", n_max=5)
+
+        assert result == []
+
+
+class TestPolishAnswer:
+    @patch("resume_operator.tools.enrich.get_structured_llm")
+    def test_returns_polished_bullet(
+        self, mock_get_llm: MagicMock, sample_master: ResumeMaster
+    ) -> None:
+        polished = "Designed RESTful API for 50+ endpoints at TechCorp, cutting p99 latency 30%."
+        mock_get_llm.return_value = _make_llm(
+            PolishedFactLLMOutput(
+                polished_text=polished,
+                bucket="extra_bullet",
+                role_id="exp-1",
+            )
+        )
+        question = Question(area="role:exp-1", question="q?", why="why")
+
+        result = polish_answer(question, "I designed the REST API", sample_master, "JD")
+
+        assert result is not None
+        assert result.bucket == "extra_bullet"
+        assert result.role_id == "exp-1"
+        assert "RESTful" in result.polished_text
+
+    @patch("resume_operator.tools.enrich.get_structured_llm")
+    def test_demotes_to_project_when_role_id_unknown(
+        self, mock_get_llm: MagicMock, sample_master: ResumeMaster
+    ) -> None:
+        """If the LLM returns extra_bullet with a role_id that doesn't exist
+        on the master, we fall back to `project` to keep the facts_bank sane."""
+        mock_get_llm.return_value = _make_llm(
+            PolishedFactLLMOutput(
+                polished_text="Built a thing.",
+                bucket="extra_bullet",
+                role_id="exp-999",  # not on master
+            )
+        )
+        question = Question(area="x", question="q?", why="w")
+
+        result = polish_answer(question, "a", sample_master, "JD")
+
+        assert result is not None
+        assert result.bucket == "project"
+        assert result.role_id == ""
+
+    @patch("resume_operator.tools.enrich.get_structured_llm")
+    def test_returns_none_on_llm_error(
+        self, mock_get_llm: MagicMock, sample_master: ResumeMaster
+    ) -> None:
+        mock_get_llm.return_value = _make_llm(RuntimeError("API down"))
+        question = Question(area="x", question="q?", why="w")
+
+        result = polish_answer(question, "a", sample_master, "JD")
+
+        assert result is None
+
+
+class TestAssembleAdditions:
+    def test_splits_by_bucket(self) -> None:
+        plan = SessionPlan(
+            items=[
+                AcceptedItem(text="Built a pipeline", bucket="project"),
+                AcceptedItem(text="Led team of 4", bucket="extra_bullet", role_id="exp-1"),
+                AcceptedItem(text="Terraform", bucket="skill"),
+                AcceptedItem(text="AWS Solutions Architect", bucket="certification"),
+            ]
+        )
+
+        projects, extras, skills, certs = assemble_additions(plan, today=date(2026, 4, 21))
+
+        assert len(projects) == 1
+        assert projects[0].text == "Built a pipeline"
+        assert projects[0].source == "enrich 2026-04-21"
+        assert projects[0].id.startswith("enrich-20260421-")
+
+        assert len(extras) == 1
+        assert extras[0].role_id == "exp-1"
+
+        assert skills == ["Terraform"]
+        assert certs == ["AWS Solutions Architect"]
+
+    def test_mints_unique_ids_avoiding_collisions(self) -> None:
+        plan = SessionPlan(
+            items=[
+                AcceptedItem(text="First", bucket="project"),
+                AcceptedItem(text="Second", bucket="project"),
+            ]
+        )
+
+        projects, _, _, _ = assemble_additions(
+            plan,
+            today=date(2026, 4, 21),
+            existing_ids={"enrich-20260421-1", "enrich-20260421-2"},
+        )
+
+        assert [p.id for p in projects] == ["enrich-20260421-3", "enrich-20260421-4"]
+
+    def test_skips_empty_text(self) -> None:
+        plan = SessionPlan(
+            items=[
+                AcceptedItem(text="   ", bucket="project"),
+                AcceptedItem(text="Real one", bucket="project"),
+            ]
+        )
+
+        projects, _, _, _ = assemble_additions(plan, today=date(2026, 4, 21))
+
+        assert len(projects) == 1
+        assert projects[0].text == "Real one"
+
+
+class TestCollectExistingIds:
+    def test_collects_from_both_item_lists(self) -> None:
+        bank = FactsBank(
+            projects=[FactItem(id="proj-1", text="x")],
+            extra_bullets=[FactItem(id="extra-1", text="y", role_id="exp-1")],
+        )
+        assert collect_existing_ids(bank) == {"proj-1", "extra-1"}
+
+
+class TestAppendToFacts:
+    def test_creates_file_if_missing(self, tmp_path: Path) -> None:
+        from resume_operator.tools.facts_bank import append_to_facts, load_facts
+
+        out = tmp_path / "facts.yaml"
+        append_to_facts(
+            out,
+            projects=[FactItem(id="p1", text="A thing", source="enrich 2026-04-21")],
+        )
+        assert out.exists()
+
+        loaded = load_facts(out)
+        assert len(loaded.projects) == 1
+        assert loaded.projects[0].source == "enrich 2026-04-21"
+
+    def test_preserves_existing_items_and_appends(self, tmp_path: Path) -> None:
+        from resume_operator.tools.facts_bank import append_to_facts, load_facts, save_facts
+
+        out = tmp_path / "facts.yaml"
+        initial = FactsBank(
+            projects=[FactItem(id="old-1", text="existing project")],
+            skills_beyond_master=["Docker"],
+        )
+        save_facts(initial, out)
+
+        append_to_facts(
+            out,
+            projects=[FactItem(id="new-1", text="new project", source="enrich")],
+            skills=["Kubernetes", "Docker"],  # Docker already present — should dedupe
+        )
+
+        loaded = load_facts(out)
+        assert {p.id for p in loaded.projects} == {"old-1", "new-1"}
+        assert loaded.skills_beyond_master == ["Docker", "Kubernetes"]
+
+    def test_id_collision_overrides(self, tmp_path: Path) -> None:
+        """Same id → last write wins (caller is responsible for unique IDs)."""
+        from resume_operator.tools.facts_bank import append_to_facts, load_facts, save_facts
+
+        out = tmp_path / "facts.yaml"
+        save_facts(FactsBank(projects=[FactItem(id="p1", text="old text")]), out)
+
+        append_to_facts(out, projects=[FactItem(id="p1", text="new text")])
+
+        loaded = load_facts(out)
+        assert len(loaded.projects) == 1
+        assert loaded.projects[0].text == "new text"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -159,6 +159,177 @@ class TestBootstrapCommand:
         assert len(written["experience"][0]["bullets"]) == 2
 
 
+class TestEnrichCommand:
+    def _write_master_yaml(self, tmp_path: Path) -> Path:
+        master = tmp_path / "master.yaml"
+        master.write_text(
+            "name: Jane Smith\n"
+            "email: jane@example.com\n"
+            "experience:\n"
+            "  - id: exp-1\n"
+            "    role: Senior Engineer\n"
+            "    company: TechCorp\n"
+            "    bullets:\n"
+            "      - id: exp-1-b1\n"
+            "        text: Led backend team\n"
+            "skills: [Python]\n",
+            encoding="utf-8",
+        )
+        return master
+
+    @patch("resume_operator.tools.enrich.get_structured_llm")
+    def test_dry_run_prints_questions_no_prompts(
+        self, mock_get_llm: MagicMock, tmp_path: Path
+    ) -> None:
+        from resume_operator.tools.enrich import EnrichQuestionLLM, EnrichQuestionsLLMOutput
+
+        master = self._write_master_yaml(tmp_path)
+        facts = tmp_path / "facts.yaml"
+        job = tmp_path / "job.txt"
+        job.write_text("Backend engineer needed.", encoding="utf-8")
+
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = EnrichQuestionsLLMOutput(
+            questions=[
+                EnrichQuestionLLM(
+                    area="role:exp-1",
+                    question="How large was the backend team you led at TechCorp?",
+                    why="JD asks for team leadership.",
+                )
+            ]
+        )
+        mock_get_llm.return_value = mock_llm
+
+        result = runner.invoke(
+            app,
+            [
+                "enrich",
+                "--master",
+                str(master),
+                "--facts",
+                str(facts),
+                "--job",
+                str(job),
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "How large was the backend team" in result.output
+        # Dry run must NOT write the facts bank.
+        assert not facts.exists()
+
+    def test_rejects_out_of_range_max_questions(self, tmp_path: Path) -> None:
+        master = self._write_master_yaml(tmp_path)
+        job = tmp_path / "job.txt"
+        job.write_text("anything", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            [
+                "enrich",
+                "--master",
+                str(master),
+                "--job",
+                str(job),
+                "--max-questions",
+                "99",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "between 1 and 10" in _clean_output(result.output)
+
+    @patch("resume_operator.tools.enrich.get_structured_llm")
+    def test_full_session_writes_accepted_item(
+        self, mock_get_llm: MagicMock, tmp_path: Path
+    ) -> None:
+        """One question asked; user answers; polish returns a project bullet;
+        user accepts; facts_bank.yaml is written with the polished text."""
+        from resume_operator.tools.enrich import (
+            EnrichQuestionLLM,
+            EnrichQuestionsLLMOutput,
+            PolishedFactLLMOutput,
+        )
+
+        master = self._write_master_yaml(tmp_path)
+        facts = tmp_path / "facts.yaml"
+        job = tmp_path / "job.txt"
+        job.write_text("Backend engineer needed.", encoding="utf-8")
+
+        # Two distinct LLM calls during enrich: questions pass, then polish pass.
+        # get_structured_llm returns a fresh mock each call; we stash distinct
+        # return_values on each via side_effect.
+        question_llm = MagicMock()
+        question_llm.invoke.return_value = EnrichQuestionsLLMOutput(
+            questions=[
+                EnrichQuestionLLM(
+                    question="Did you design any public APIs?",
+                    why="JD emphasizes API design.",
+                )
+            ]
+        )
+        polish_llm = MagicMock()
+        polish_llm.invoke.return_value = PolishedFactLLMOutput(
+            polished_text="Designed RESTful API serving 50+ endpoints.",
+            bucket="project",
+        )
+        mock_get_llm.side_effect = [question_llm, polish_llm]
+
+        # stdin: answer → accept
+        user_input = "I designed a REST API for our internal tools.\na\n"
+
+        result = runner.invoke(
+            app,
+            [
+                "enrich",
+                "--master",
+                str(master),
+                "--facts",
+                str(facts),
+                "--job",
+                str(job),
+                "--max-questions",
+                "1",
+            ],
+            input=user_input,
+        )
+
+        assert result.exit_code == 0, result.output
+        assert facts.exists()
+
+        import yaml
+
+        written = yaml.safe_load(facts.read_text(encoding="utf-8"))
+        assert len(written["projects"]) == 1
+        assert "RESTful API" in written["projects"][0]["text"]
+        assert written["projects"][0]["source"].startswith("enrich ")
+
+    @patch("resume_operator.tools.enrich.get_structured_llm")
+    def test_session_with_no_questions_exits_cleanly(
+        self, mock_get_llm: MagicMock, tmp_path: Path
+    ) -> None:
+        from resume_operator.tools.enrich import EnrichQuestionsLLMOutput
+
+        master = self._write_master_yaml(tmp_path)
+        facts = tmp_path / "facts.yaml"
+        job = tmp_path / "job.txt"
+        job.write_text("anything", encoding="utf-8")
+
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = EnrichQuestionsLLMOutput(questions=[])
+        mock_get_llm.return_value = mock_llm
+
+        result = runner.invoke(
+            app,
+            ["enrich", "--master", str(master), "--facts", str(facts), "--job", str(job)],
+        )
+
+        assert result.exit_code == 0
+        assert "No questions" in _clean_output(result.output)
+        assert not facts.exists()
+
+
 class TestRunCommand:
     def test_file_not_found(self) -> None:
         result = runner.invoke(app, ["run", "--resume", "nope.pdf", "--job", "nope.txt"])


### PR DESCRIPTION
## Summary

- New CLI: \`resume-operator enrich --master M --facts F --job J [--max-questions 5] [--dry-run]\` — separate from \`run\`, so the main pipeline stays headless.
- LLM asks grounded questions (tagged with \`area\` + \`why\`, all grounded in the intersection of master content + JD requirements).
- User answers in free text. LLM polishes to an ATS-ready bullet and classifies the bucket. User accepts / edits / rejects per item.
- Accepted items append to \`facts_bank.yaml\` with a \`source: \"enrich YYYY-MM-DD\"\` stamp.

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/62. When the master + facts lack material for a specific JD, the tailor can't make meaningful choices. The dangerous shortcut — \"LLM drafts, user approves\" — is fabrication-prone: if the LLM writes *\"Reduced API latency 40% at Hilolabs\"* and you skim-approve, that becomes a claim on your resume. The #026 fabrication guard doesn't help because you become the source of truth the moment you say yes.

This PR flips the loop: LLM asks, you answer in your words, LLM polishes phrasing only (no added metrics, headcount, scope, or tech). Facts stay yours; only grammar and keyword placement come from the model.

## Changes

- \`src/resume_operator/prompts/enrich.py\` (new) — question-generation + polish prompts.
- \`src/resume_operator/tools/enrich.py\` (new) — LLM schemas, \`generate_questions\`, \`polish_answer\`, \`assemble_additions\`. Session-orchestration logic is pure functions (no stdin), so tests don't need to mock I/O.
- \`src/resume_operator/tools/facts_bank.py\` — new \`append_to_facts\` + \`save_facts\` that preserve existing items and emit a canonical header comment block.
- \`src/resume_operator/state.py\` — \`FactItem.source: str = \"\"\` for provenance.
- \`src/resume_operator/main.py\` — \`enrich\` command with interactive prompts (Rich \`Prompt.ask\`).
- Tests — 18 new covering question generation, polish, assembly, append_to_facts, and an end-to-end CLI test with mocked LLM + piped stdin that verifies the polished text lands in \`facts_bank.yaml\` with the source stamp.

## How to Test

1. \`uv run python -m pytest -q\` — 151 tests pass.
2. Dry-run against your real inputs: \`LLM_MODEL=openai/gpt-4o-mini uv run python -m resume_operator enrich --master data/master_resume.yaml --facts data/facts_bank.yaml --job input/job.txt --max-questions 5 --dry-run\` — prints the questions the LLM would ask.
3. Full session: drop the \`--dry-run\` flag and run the interactive loop.

## Proof of Work

Dry-run against the bootstrapped master + \`input/job.txt\` (Foodsmart Staff Backend role) produced 5 grounded questions. Every single one references specific content on the master AND ties to a stated JD requirement — no generic questions. Sample:

> *\"Your Biblionexus bullet mentions enhancing database performance through indexing and normalization. Can you quantify how much you improved query response times or overall system efficiency?\"*
> why: Quantifying performance improvements demonstrates your impact and expertise in database management, which is crucial for the backend role.

> *\"You mentioned automating cloud infrastructure configuration using Terraform. Can you share more about the specific AWS services you used and any metrics on time saved or efficiency gained?\"*
> why: AWS experience is vital for this position, and specific metrics will strengthen your application.

Safety rails covered by unit tests: polish pass demotes \`extra_bullet\` to \`project\` when the LLM returns a role_id that doesn't exist on the master; \`assemble_additions\` mints unique IDs avoiding collision with existing facts bank entries; dry-run never writes the facts bank.

When this PR is merged, \`facts_bank.yaml\` stops being a static file Bruno hand-edits once and becomes a career-facts store that grows durably with each enrichment session — without ever letting the LLM put words in his mouth.