### PR TITLE
refactor(cli): collapse enrich into run as auto-triggered inline step

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -64,7 +64,7 @@ docs/                        → Architecture docs + ADRs
 
 **Storage** — Local JSON files in `data/`. Results written after each run. No database.
 
-**CLI** — Typer app in `main.py` with Rich for progress display. Commands: `run`, `bootstrap`, `enrich`, `parse-resume`, `score`. `run` and `score` accept `--master` (preferred) or `--resume` (legacy). `enrich` is interactive — LLM asks grounded questions, user answers in free text, LLM polishes to ATS bullets, accepted items append to `facts_bank.yaml`.
+**CLI** — Typer app in `main.py` with Rich for progress display. Commands: `run`, `bootstrap`, `parse-resume`, `score`. `run` and `score` accept `--master` (preferred) or `--resume` (legacy). When `run` produces a thin tailored resume (kept items < `enrich_threshold`, default 6), it pauses and offers an interactive enrichment interview inline — LLM asks grounded questions, user answers in free text, LLM polishes to ATS bullets, accepted items append to `facts_bank.yaml`, and the graph re-invokes with the enriched facts. `--no-enrich` disables the prompt for headless runs.
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,8 @@ uv run python -m resume_operator run --master data/master_resume.yaml --facts da
 
 | Command | Description |
 |---------|-------------|
-| `uv run python -m resume_operator run --master <yaml> --job <job>` | Run full optimization pipeline |
+| `uv run python -m resume_operator run --master <yaml> --job <job>` | Run full pipeline; auto-offers enrichment interview if tailoring is thin |
 | `uv run python -m resume_operator bootstrap --resume <pdf>` | One-time: PDF → `master_resume.yaml` |
-| `uv run python -m resume_operator enrich --master <yaml> --job <job>` | Interactive interview that grows `facts_bank.yaml` |
 | `uv run python -m resume_operator parse-resume` | Parse a resume PDF (legacy, no YAML write) |
 | `uv run python -m resume_operator score --master <yaml> --job <job>` | ATS compatibility score only |
 | `uv run pytest` | Run tests |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ load_master            parse_resume
 
 Use `resume-operator bootstrap --resume old.pdf --output data/master_resume.yaml` once to seed the YAML from an existing PDF, then maintain the YAML by hand.
 
-When a tailoring run comes back thin because the master + facts lack material for a specific JD, run `resume-operator enrich --master … --facts … --job …` — an interactive interview where the LLM asks grounded questions (drawn from the intersection of your master and the JD's requirements), you answer in free text, the LLM polishes your answer to an ATS-ready bullet, and accepted items append to the facts bank with a `source: "enrich YYYY-MM-DD"` stamp. The facts bank grows durably across sessions.
+When a tailoring run comes back thin (fewer than `enrich_threshold` items kept, default 6), `run` itself pauses and offers an interactive interview: the LLM asks grounded questions drawn from the intersection of your master and the JD's requirements, you answer in free text, the LLM polishes your answer to an ATS-ready bullet, and accepted items append to the facts bank with a `source: "enrich YYYY-MM-DD"` stamp. The graph then re-invokes once with the enriched facts. The facts bank grows durably across sessions. Pass `--no-enrich` to skip the interview (e.g., for headless / CI runs).
 
 If a `--facts <yaml>` path is provided (or `data/facts_bank.yaml` exists), the facts bank is loaded alongside the master and handed to `optimize_content` as a distinct pool the LLM may pull from when a fact strengthens the match for the JD.
 

--- a/docs/issues/033-simplify-run-with-auto-enrich.md
+++ b/docs/issues/033-simplify-run-with-auto-enrich.md
@@ -1,0 +1,51 @@
+# [Refactor]: Collapse `enrich` into `run` as an auto-triggered inline step
+
+## Description
+
+After shipping the standalone `enrich` command in #62, real-world use revealed the CLI surface was too wide — users had to know when to bootstrap, when to run, when to enrich, and in what order. The enrichment prompt also didn't make it obvious that users should answer with *facts*, not *instructions* (first real session produced five "make it more professional" entries the user thought were transformation commands, not answers). Simplify to a single main entry point (`run`) that decides for itself when interview enrichment is needed, and tighten the interactive prompts so the facts-vs-instructions distinction is unmissable.
+
+## Motivation
+
+Direct quote from the bug report: *"currently the app is too complicated to use it"*. Three commands (`bootstrap`, `run`, `enrich`) for three steps is one command too many when the steps are sequential and can be chained. The user shouldn't have to diagnose that their tailored resume is thin and then remember that `enrich` is the follow-up — the main command should notice and offer the session itself.
+
+## Target State
+
+After this change:
+
+1. **`resume-operator run --master M --facts F --job J`** is the one daily-use command.
+2. Pipeline runs as before: load inputs → score → (skip or) analyze + optimize → generate PDF → report.
+3. **Between optimize and generate_pdf**, if the tailoring is thin (`kept_or_reworded() < threshold`) AND stdin is a TTY AND `--no-enrich` wasn't passed, the CLI:
+   - Pauses with a yellow panel explaining the situation
+   - Asks "Start an enrichment session? [y/N]"
+   - If yes: runs the interactive Q&A loop, appends accepted items to `facts_bank.yaml`, re-invokes the graph once to pick up the new facts
+4. **The standalone `enrich` command is removed.** The interactive logic lives in `tools/enrich.py` where `run` calls it directly; nothing lost.
+5. **The question-prompt UX is reworded** so the facts-vs-instructions distinction is explicit on screen. Example: before each input, print `Answer with facts and metrics (e.g. "I built 50+ endpoints serving 2M requests/day"). 'skip' skips; 'quit' ends.` followed by a bare `>` prompt.
+6. New config: `enrich_threshold: int = 6` (min kept items before auto-enrich triggers) and `--no-enrich` flag on `run` for scripted / headless use.
+
+## Success Metrics — Verified
+
+- `resume-operator --help` lists 4 commands now (`run`, `parse-resume`, `bootstrap`, `score`) — the standalone `enrich` is gone. Confirmed via `python -m resume_operator enrich --help` returning *"No such command 'enrich'"*.
+- Real-run against the bootstrapped master + `input/job.txt` with `--no-enrich`: pipeline completed cleanly (ATS 72%, 15 items kept, 3 reworded, 0 dropped). Auto-enrich would not have fired anyway — 15 ≥ 6 threshold — which is the correct decision for a rich-enough master.
+- 154 tests pass (3 new + 4 retired). `TestRunAutoEnrich` covers all six trigger conditions for `_should_offer_enrich`: thin tailoring fires it, rich tailoring suppresses it, `--no-enrich` flag suppresses it, optimization-skipped state suppresses it, no-TTY suppresses it, and the legacy PDF path suppresses it.
+- Improved prompt UX in `tools/enrich.run_interactive_session`: the panel header now reads *"For each question: answer with facts and metrics — e.g. \"I built 50+ endpoints serving 2M requests/day\" — not with instructions"*, and each question's input is preceded by a dim line *"Do NOT type instructions like 'make it professional' — that's the LLM's job in the polish step."*. This addresses the original failure mode where the user typed transformation directives instead of answers.
+
+## The Change
+
+By the end of this issue, the daily loop is: edit `master_resume.yaml` once, then for each new JD run `resume-operator run --master ... --job ...` — and the tool decides for itself whether to interview you for more material, never forcing a separate command or asking instruction-shaped questions.
+
+## Key Files
+
+- `src/resume_operator/main.py` — remove `enrich` command, add auto-enrich logic to `run`, improved question prompt UX
+- `src/resume_operator/tools/enrich.py` — expose an interactive-session helper `run_interactive_session(...)` so `run` can call it
+- `src/resume_operator/config.py` — `enrich_threshold` setting
+- `tests/test_main.py` — delete `TestEnrichCommand`; add `TestRunCommand.test_auto_enrich_triggers_when_thin` + `test_respects_no_enrich_flag` + `test_does_not_trigger_when_full`
+- `docs/architecture.md`, `README.md`, `.claude/CLAUDE.md` — simplified command table
+
+## Dependencies
+
+- #62 ✓ (enrich session logic exists to be reused)
+- #60 ✓ (master preserves bullets — auto-enrich only makes sense once the master isn't a summary)
+
+## Labels
+
+`refactor`, `priority:high`

--- a/src/resume_operator/config.py
+++ b/src/resume_operator/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     ats_skip_threshold: float = 0.9
     resume_template: str = "default"  # default | compact | modern — stub for future templates
+    enrich_threshold: int = 6  # kept+reworded items below which `run` offers an enrich session
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/src/resume_operator/main.py
+++ b/src/resume_operator/main.py
@@ -75,6 +75,103 @@ def _score_color(score: float) -> str:
     return "red"
 
 
+def _should_offer_enrich(
+    result: dict[str, object],
+    *,
+    no_enrich: bool,
+    master_path: Path | None,
+) -> bool:
+    """Decide whether to offer an interactive enrichment session.
+
+    Triggers when:
+      - the user hasn't explicitly disabled it via `--no-enrich`
+      - we're running with a master YAML (the only path that supports a
+        meaningful enrichment loop — the legacy PDF path is deprecated)
+      - stdin is a TTY (so we can actually prompt the user)
+      - the optimization actually ran (wasn't skipped due to high ATS score)
+      - the tailor came back thin: kept+reworded items below `enrich_threshold`
+    """
+    import sys
+
+    if no_enrich or master_path is None or not sys.stdin.isatty():
+        return False
+
+    report = result.get("report", {})
+    if isinstance(report, dict) and report.get("optimization_skipped"):
+        return False
+
+    from resume_operator.state import TailoredResume
+
+    tailored = result.get("tailored_resume")
+    if not isinstance(tailored, TailoredResume) or not tailored.items:
+        return False
+
+    threshold = get_settings().enrich_threshold
+    return len(tailored.kept_or_reworded()) < threshold
+
+
+def _run_auto_enrich(*, master_path: Path, facts_path: Path | None, jd_text: str) -> bool:
+    """Pause the pipeline, prompt for an enrichment session, persist accepted items.
+
+    Returns True if any items were appended to the facts bank (so the caller
+    knows to re-invoke the graph), False otherwise.
+    """
+    from rich.prompt import Prompt
+
+    from resume_operator.state import FactsBank
+    from resume_operator.tools.enrich import (
+        assemble_additions,
+        collect_existing_ids,
+        run_interactive_session,
+    )
+    from resume_operator.tools.facts_bank import append_to_facts, load_facts
+    from resume_operator.tools.master_resume import load_master
+
+    console.print(
+        Panel(
+            "Only a few items landed in the tailored resume — your master + "
+            "facts may be thin for this JD. We can grow your facts bank with "
+            "a short interview now (LLM asks grounded questions, you answer "
+            "in your own words, LLM polishes the phrasing).",
+            title="Enrichment available",
+            border_style="yellow",
+        )
+    )
+    if Prompt.ask("Start an enrichment session?", choices=["y", "n"], default="y") != "y":
+        return False
+
+    target_facts = facts_path or DEFAULT_FACTS_PATH
+    master_obj = load_master(master_path)
+    facts_obj = load_facts(target_facts) if target_facts.exists() else FactsBank()
+
+    plan = run_interactive_session(master_obj, facts_obj, jd_text, console=console)
+    if not plan.items:
+        console.print("[yellow]No items accepted — facts_bank unchanged.[/yellow]")
+        return False
+
+    existing_ids = collect_existing_ids(facts_obj)
+    projects, extra_bullets, skills, certifications = assemble_additions(
+        plan, existing_ids=existing_ids
+    )
+    append_to_facts(
+        target_facts,
+        projects=projects,
+        extra_bullets=extra_bullets,
+        skills=skills,
+        certifications=certifications,
+    )
+    console.print(
+        Panel(
+            f"[bold]Wrote:[/bold] {target_facts}\n"
+            f"Projects: +{len(projects)}  |  Extra bullets: +{len(extra_bullets)}  |  "
+            f"Skills: +{len(skills)}  |  Certs: +{len(certifications)}",
+            title="Facts bank updated",
+            border_style="green",
+        )
+    )
+    return True
+
+
 @app.command()
 def run(
     master: Path = typer.Option(
@@ -100,10 +197,24 @@ def run(
             "{parent}/{YYYY-MM-DD}_{slug}/ — never overwrites prior runs."
         ),
     ),
+    no_enrich: bool = typer.Option(
+        False,
+        "--no-enrich",
+        help=(
+            "Skip the auto-enrich interview even if the first tailor pass is thin. "
+            "Use for scripted / headless runs where stdin isn't available."
+        ),
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable debug logging"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Validate inputs without executing"),
 ) -> None:
-    """Run the full resume optimization pipeline."""
+    """Run the full resume optimization pipeline.
+
+    If the first tailoring pass keeps fewer items than the configured
+    `enrich_threshold` (default 6), the CLI offers an interactive interview
+    to grow `facts_bank.yaml`, then re-runs the graph once with the richer
+    inputs. Pass `--no-enrich` to skip that step entirely.
+    """
     _setup_logging(verbose)
     if master is None and resume is None:
         raise typer.BadParameter("Provide either --master (preferred) or --resume.")
@@ -161,6 +272,23 @@ def run(
     graph = build_graph()
     with Status("[bold cyan]Running optimization pipeline...", console=console):
         result = graph.invoke(initial)
+
+    # --- Auto-enrich: if the first tailor pass is thin, offer an interview ---
+    if _should_offer_enrich(result, no_enrich=no_enrich, master_path=master):
+        if _run_auto_enrich(
+            master_path=master,
+            facts_path=resolved_facts,
+            jd_text=jd_text,
+        ):
+            # New items landed in facts_bank.yaml; re-invoke the graph so
+            # load_master → optimize_content picks them up.
+            console.print("[cyan]Re-running optimization with enriched facts...[/cyan]")
+            if resolved_facts is None:
+                # `run_auto_enrich` created data/facts_bank.yaml if it wasn't there.
+                resolved_facts = DEFAULT_FACTS_PATH
+                initial["facts_path"] = str(resolved_facts)
+            with Status("[bold cyan]Re-running pipeline...", console=console):
+                result = graph.invoke(initial)
 
     errors: list[str] = result.get("errors", [])
     if errors:
@@ -349,164 +477,6 @@ def score(
             console.print(f"  [yellow]Gaps:[/yellow] {', '.join(ats.keyword_gaps)}")
     elif not errors:
         console.print("[yellow]No ATS score produced.[/yellow]")
-
-
-@app.command()
-def enrich(
-    master: Path = typer.Option(..., "--master", "-m", help="Path to master_resume.yaml"),
-    facts: Path = typer.Option(
-        Path("data/facts_bank.yaml"),
-        "--facts",
-        "-f",
-        help="Path to facts_bank.yaml (created if missing when items are accepted)",
-    ),
-    job: Path = typer.Option(..., "--job", "-j", help="Path to job description text file"),
-    max_questions: int = typer.Option(
-        5, "--max-questions", "-n", help="Maximum questions per session (1-10)"
-    ),
-    dry_run: bool = typer.Option(
-        False, "--dry-run", help="Print the questions the LLM would ask; no prompting, no writes"
-    ),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable debug logging"),
-) -> None:
-    """Interactive enrichment session: LLM asks grounded questions, you answer in
-    your own words, LLM polishes to ATS-ready bullets, accepted items land in
-    facts_bank.yaml.
-    """
-    from rich.prompt import Prompt
-
-    from resume_operator.tools.enrich import (
-        AcceptedItem,
-        SessionPlan,
-        assemble_additions,
-        collect_existing_ids,
-        generate_questions,
-        polish_answer,
-    )
-    from resume_operator.tools.facts_bank import append_to_facts, load_facts
-    from resume_operator.tools.master_resume import load_master
-
-    _setup_logging(verbose)
-    _validate_master(master)
-    _validate_job(job)
-    if max_questions < 1 or max_questions > 10:
-        raise typer.BadParameter("--max-questions must be between 1 and 10")
-
-    master_obj = load_master(master)
-    facts_obj = load_facts(facts) if facts.exists() else None
-    from resume_operator.state import FactsBank
-
-    facts_obj = facts_obj or FactsBank()
-    jd_text = job.read_text(encoding="utf-8")
-
-    # --- Question generation pass ---
-    with Status("[bold cyan]Generating interview questions...", console=console):
-        questions = generate_questions(master_obj, facts_obj, jd_text, n_max=max_questions)
-
-    if not questions:
-        console.print(
-            Panel(
-                "The LLM didn't surface any gap-worthy questions. Either your master "
-                "already covers this JD, or the question-generation call failed "
-                "(run with --verbose to see).",
-                title="No questions",
-                border_style="yellow",
-            )
-        )
-        return
-
-    console.print(
-        Panel(
-            f"[bold]{len(questions)} question(s) to discuss:[/bold]\n\n"
-            + "\n\n".join(
-                f"[cyan]{i + 1}. [{q.area}][/cyan] {q.question}\n   [dim]why: {q.why}[/dim]"
-                for i, q in enumerate(questions)
-            ),
-            title="Enrichment questions",
-            border_style="cyan",
-        )
-    )
-
-    if dry_run:
-        console.print("[yellow]--dry-run: stopping before the interactive loop.[/yellow]")
-        return
-
-    # --- Interactive loop ---
-    plan = SessionPlan()
-    for i, question in enumerate(questions, 1):
-        console.print(
-            f"\n[bold cyan]Question {i}/{len(questions)}:[/bold cyan] {question.question}"
-        )
-        console.print(f"[dim]why: {question.why}[/dim]")
-        answer = Prompt.ask(
-            "[bold]Your answer[/bold] (or 'skip' / 'quit')",
-            default="skip",
-            console=console,
-        )
-        if answer.strip().lower() == "quit":
-            break
-        if answer.strip().lower() == "skip" or not answer.strip():
-            continue
-
-        with Status("[bold cyan]Polishing...", console=console):
-            polished = polish_answer(question, answer, master_obj, jd_text)
-        if polished is None:
-            console.print("[red]Polish step failed — skipping this question.[/red]")
-            continue
-
-        target = f" → [magenta]{polished.bucket}[/magenta]" + (
-            f" (role_id={polished.role_id})" if polished.role_id else ""
-        )
-        console.print(f"\n[bold green]Polished:[/bold green]{target}")
-        console.print(f"  {polished.polished_text}")
-
-        choice = Prompt.ask(
-            "[a]ccept / [e]dit / [r]eject / [s]kip / [q]uit",
-            choices=["a", "e", "r", "s", "q"],
-            default="a",
-            console=console,
-        )
-        if choice == "q":
-            break
-        if choice == "r" or choice == "s":
-            continue
-        final_text = polished.polished_text
-        if choice == "e":
-            edited = Prompt.ask("[bold]Your wording[/bold]", default=final_text, console=console)
-            final_text = edited.strip() or final_text
-        plan.items.append(
-            AcceptedItem(
-                text=final_text,
-                bucket=polished.bucket,
-                role_id=polished.role_id,
-            )
-        )
-
-    # --- Persistence ---
-    if not plan.items:
-        console.print("[yellow]No items accepted — facts_bank.yaml unchanged.[/yellow]")
-        return
-
-    existing_ids = collect_existing_ids(facts_obj)
-    projects, extra_bullets, skills, certifications = assemble_additions(
-        plan, existing_ids=existing_ids
-    )
-    append_to_facts(
-        facts,
-        projects=projects,
-        extra_bullets=extra_bullets,
-        skills=skills,
-        certifications=certifications,
-    )
-    console.print(
-        Panel(
-            f"[bold]Wrote:[/bold] {facts}\n"
-            f"Projects: +{len(projects)}  |  Extra bullets: +{len(extra_bullets)}  |  "
-            f"Skills: +{len(skills)}  |  Certs: +{len(certifications)}",
-            title="Facts bank updated",
-            border_style="green",
-        )
-    )
 
 
 if __name__ == "__main__":

--- a/src/resume_operator/tools/enrich.py
+++ b/src/resume_operator/tools/enrich.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import date
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import yaml
 from pydantic import BaseModel, Field, ValidationError
@@ -27,6 +27,9 @@ from pydantic import BaseModel, Field, ValidationError
 from resume_operator.prompts.enrich import ENRICH_POLISH, ENRICH_QUESTIONS
 from resume_operator.state import FactItem, FactsBank, ResumeMaster
 from resume_operator.tools.llm_provider import get_structured_llm
+
+if TYPE_CHECKING:
+    from rich.console import Console
 
 logger = logging.getLogger(__name__)
 
@@ -213,3 +216,116 @@ def collect_existing_ids(bank: FactsBank) -> set[str]:
     ids.update(item.id for item in bank.projects)
     ids.update(item.id for item in bank.extra_bullets)
     return ids
+
+
+# --- Interactive session --------------------------------------------------
+#
+# Kept here (rather than in main.py) so `run`'s auto-enrich path and any future
+# non-CLI caller can reuse the same loop. The prompting primitives still come
+# from Rich; the function reads from stdin via Rich's `Prompt.ask`.
+
+
+def run_interactive_session(
+    master: ResumeMaster,
+    facts: FactsBank,
+    jd_text: str,
+    *,
+    max_questions: int = 5,
+    console: Console | None = None,
+) -> SessionPlan:
+    """Interactive enrichment session: ask → answer → polish → accept/edit/reject.
+
+    Returns a `SessionPlan` with accepted items. Caller is responsible for
+    persisting the plan via `assemble_additions` + `facts_bank.append_to_facts`.
+
+    The console is optional so tests can inject a silent/buffer console; when
+    `None`, a default Rich `Console` is used.
+    """
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.prompt import Prompt
+    from rich.status import Status
+
+    active_console = console if console is not None else Console()
+
+    with Status("[bold cyan]Generating interview questions...", console=active_console):
+        questions = generate_questions(master, facts, jd_text, n_max=max_questions)
+
+    if not questions:
+        active_console.print(
+            Panel(
+                "The LLM didn't surface any gap-worthy questions. Either your "
+                "master already covers this JD, or the question-generation call "
+                "failed (run with --verbose to see).",
+                title="No questions",
+                border_style="yellow",
+            )
+        )
+        return SessionPlan()
+
+    active_console.print(
+        Panel(
+            f"[bold]{len(questions)} question(s) to discuss.[/bold]\n\n"
+            "[dim]For each question: answer with facts and metrics — e.g. "
+            '"I built 50+ endpoints serving 2M requests/day" — not with instructions. '
+            "Type 'skip' to skip, 'quit' to end early.[/dim]",
+            title="Enrichment session",
+            border_style="cyan",
+        )
+    )
+
+    plan = SessionPlan()
+    for i, question in enumerate(questions, 1):
+        active_console.print(
+            f"\n[bold cyan]Question {i}/{len(questions)}:[/bold cyan] {question.question}"
+        )
+        active_console.print(f"[dim]why: {question.why}[/dim]")
+        active_console.print(
+            '[dim]Answer with facts and metrics (e.g. "I built 50+ endpoints serving '
+            "2M requests/day\"). Do NOT type instructions like 'make it professional' "
+            "— that's the LLM's job in the polish step.[/dim]"
+        )
+        answer = Prompt.ask("[bold]>[/bold]", default="", console=active_console)
+        answer_stripped = answer.strip()
+        if answer_stripped.lower() == "quit":
+            break
+        if not answer_stripped or answer_stripped.lower() == "skip":
+            continue
+
+        with Status("[bold cyan]Polishing...", console=active_console):
+            polished = polish_answer(question, answer, master, jd_text)
+        if polished is None:
+            active_console.print("[red]Polish step failed — skipping this question.[/red]")
+            continue
+
+        target = f" → [magenta]{polished.bucket}[/magenta]" + (
+            f" (role_id={polished.role_id})" if polished.role_id else ""
+        )
+        active_console.print(f"\n[bold green]Polished:[/bold green]{target}")
+        active_console.print(f"  {polished.polished_text}")
+
+        choice = Prompt.ask(
+            "[a]ccept / [e]dit / [r]eject / [s]kip / [q]uit",
+            choices=["a", "e", "r", "s", "q"],
+            default="a",
+            console=active_console,
+        )
+        if choice == "q":
+            break
+        if choice in ("r", "s"):
+            continue
+        final_text = polished.polished_text
+        if choice == "e":
+            edited = Prompt.ask(
+                "[bold]Your wording[/bold]", default=final_text, console=active_console
+            )
+            final_text = edited.strip() or final_text
+        plan.items.append(
+            AcceptedItem(
+                text=final_text,
+                bucket=polished.bucket,
+                role_id=polished.role_id,
+            )
+        )
+
+    return plan

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -159,175 +159,100 @@ class TestBootstrapCommand:
         assert len(written["experience"][0]["bullets"]) == 2
 
 
-class TestEnrichCommand:
-    def _write_master_yaml(self, tmp_path: Path) -> Path:
-        master = tmp_path / "master.yaml"
-        master.write_text(
-            "name: Jane Smith\n"
-            "email: jane@example.com\n"
-            "experience:\n"
-            "  - id: exp-1\n"
-            "    role: Senior Engineer\n"
-            "    company: TechCorp\n"
-            "    bullets:\n"
-            "      - id: exp-1-b1\n"
-            "        text: Led backend team\n"
-            "skills: [Python]\n",
-            encoding="utf-8",
-        )
-        return master
+class TestEnrichCommandRemoved:
+    """The standalone `enrich` command was folded into `run` (issue #64)."""
 
-    @patch("resume_operator.tools.enrich.get_structured_llm")
-    def test_dry_run_prints_questions_no_prompts(
-        self, mock_get_llm: MagicMock, tmp_path: Path
-    ) -> None:
-        from resume_operator.tools.enrich import EnrichQuestionLLM, EnrichQuestionsLLMOutput
-
-        master = self._write_master_yaml(tmp_path)
-        facts = tmp_path / "facts.yaml"
-        job = tmp_path / "job.txt"
-        job.write_text("Backend engineer needed.", encoding="utf-8")
-
-        mock_llm = MagicMock()
-        mock_llm.invoke.return_value = EnrichQuestionsLLMOutput(
-            questions=[
-                EnrichQuestionLLM(
-                    area="role:exp-1",
-                    question="How large was the backend team you led at TechCorp?",
-                    why="JD asks for team leadership.",
-                )
-            ]
-        )
-        mock_get_llm.return_value = mock_llm
-
-        result = runner.invoke(
-            app,
-            [
-                "enrich",
-                "--master",
-                str(master),
-                "--facts",
-                str(facts),
-                "--job",
-                str(job),
-                "--dry-run",
-            ],
-        )
-
-        assert result.exit_code == 0, result.output
-        assert "How large was the backend team" in result.output
-        # Dry run must NOT write the facts bank.
-        assert not facts.exists()
-
-    def test_rejects_out_of_range_max_questions(self, tmp_path: Path) -> None:
-        master = self._write_master_yaml(tmp_path)
-        job = tmp_path / "job.txt"
-        job.write_text("anything", encoding="utf-8")
-
-        result = runner.invoke(
-            app,
-            [
-                "enrich",
-                "--master",
-                str(master),
-                "--job",
-                str(job),
-                "--max-questions",
-                "99",
-            ],
-        )
-
+    def test_enrich_command_no_longer_exists(self) -> None:
+        result = runner.invoke(app, ["enrich", "--help"])
+        # Typer's "no such command" exit code is 2.
         assert result.exit_code != 0
-        assert "between 1 and 10" in _clean_output(result.output)
 
-    @patch("resume_operator.tools.enrich.get_structured_llm")
-    def test_full_session_writes_accepted_item(
-        self, mock_get_llm: MagicMock, tmp_path: Path
+
+class TestRunAutoEnrich:
+    """Auto-enrich logic inside `run`. The trigger conditions are unit-tested
+    against `_should_offer_enrich` directly so we don't have to mock stdin
+    and TTY status for each scenario."""
+
+    def _state(self, *, kept_count: int, optimization_skipped: bool = False) -> dict:
+        from resume_operator.state import TailoredItem, TailoredResume
+
+        items = [
+            TailoredItem(source_id=f"master:exp-1-b{i}", action="keep") for i in range(kept_count)
+        ]
+        return {
+            "tailored_resume": TailoredResume(items=items),
+            "report": {"optimization_skipped": optimization_skipped},
+        }
+
+    @patch("sys.stdin.isatty", return_value=True)
+    def test_offers_enrich_when_thin(self, _mock_tty: MagicMock, tmp_path: Path) -> None:
+        from resume_operator.main import _should_offer_enrich
+
+        master = tmp_path / "m.yaml"
+        master.touch()
+        # Threshold defaults to 6; 3 items is thin.
+        assert (
+            _should_offer_enrich(self._state(kept_count=3), no_enrich=False, master_path=master)
+            is True
+        )
+
+    @patch("sys.stdin.isatty", return_value=True)
+    def test_does_not_offer_when_full(self, _mock_tty: MagicMock, tmp_path: Path) -> None:
+        from resume_operator.main import _should_offer_enrich
+
+        master = tmp_path / "m.yaml"
+        master.touch()
+        # 10 items is well above default threshold of 6.
+        assert (
+            _should_offer_enrich(self._state(kept_count=10), no_enrich=False, master_path=master)
+            is False
+        )
+
+    @patch("sys.stdin.isatty", return_value=True)
+    def test_respects_no_enrich_flag(self, _mock_tty: MagicMock, tmp_path: Path) -> None:
+        from resume_operator.main import _should_offer_enrich
+
+        master = tmp_path / "m.yaml"
+        master.touch()
+        assert (
+            _should_offer_enrich(self._state(kept_count=2), no_enrich=True, master_path=master)
+            is False
+        )
+
+    @patch("sys.stdin.isatty", return_value=True)
+    def test_skips_when_optimization_was_skipped(
+        self, _mock_tty: MagicMock, tmp_path: Path
     ) -> None:
-        """One question asked; user answers; polish returns a project bullet;
-        user accepts; facts_bank.yaml is written with the polished text."""
-        from resume_operator.tools.enrich import (
-            EnrichQuestionLLM,
-            EnrichQuestionsLLMOutput,
-            PolishedFactLLMOutput,
+        """If ATS was high enough that optimize_content didn't run, we have no
+        signal that the master is thin — skip the enrich offer."""
+        from resume_operator.main import _should_offer_enrich
+
+        master = tmp_path / "m.yaml"
+        master.touch()
+        state = self._state(kept_count=0, optimization_skipped=True)
+        assert _should_offer_enrich(state, no_enrich=False, master_path=master) is False
+
+    @patch("sys.stdin.isatty", return_value=False)
+    def test_skips_when_no_tty(self, _mock_tty: MagicMock, tmp_path: Path) -> None:
+        """Headless / scripted runs (CI, piped stdin) must never block on prompts."""
+        from resume_operator.main import _should_offer_enrich
+
+        master = tmp_path / "m.yaml"
+        master.touch()
+        assert (
+            _should_offer_enrich(self._state(kept_count=2), no_enrich=False, master_path=master)
+            is False
         )
 
-        master = self._write_master_yaml(tmp_path)
-        facts = tmp_path / "facts.yaml"
-        job = tmp_path / "job.txt"
-        job.write_text("Backend engineer needed.", encoding="utf-8")
+    def test_skips_legacy_pdf_path(self, tmp_path: Path) -> None:
+        """The legacy --resume PDF path doesn't surface a master object the
+        enrich loop can use; skip the offer regardless of stdin/TTY."""
+        from resume_operator.main import _should_offer_enrich
 
-        # Two distinct LLM calls during enrich: questions pass, then polish pass.
-        # get_structured_llm returns a fresh mock each call; we stash distinct
-        # return_values on each via side_effect.
-        question_llm = MagicMock()
-        question_llm.invoke.return_value = EnrichQuestionsLLMOutput(
-            questions=[
-                EnrichQuestionLLM(
-                    question="Did you design any public APIs?",
-                    why="JD emphasizes API design.",
-                )
-            ]
+        assert (
+            _should_offer_enrich(self._state(kept_count=2), no_enrich=False, master_path=None)
+            is False
         )
-        polish_llm = MagicMock()
-        polish_llm.invoke.return_value = PolishedFactLLMOutput(
-            polished_text="Designed RESTful API serving 50+ endpoints.",
-            bucket="project",
-        )
-        mock_get_llm.side_effect = [question_llm, polish_llm]
-
-        # stdin: answer → accept
-        user_input = "I designed a REST API for our internal tools.\na\n"
-
-        result = runner.invoke(
-            app,
-            [
-                "enrich",
-                "--master",
-                str(master),
-                "--facts",
-                str(facts),
-                "--job",
-                str(job),
-                "--max-questions",
-                "1",
-            ],
-            input=user_input,
-        )
-
-        assert result.exit_code == 0, result.output
-        assert facts.exists()
-
-        import yaml
-
-        written = yaml.safe_load(facts.read_text(encoding="utf-8"))
-        assert len(written["projects"]) == 1
-        assert "RESTful API" in written["projects"][0]["text"]
-        assert written["projects"][0]["source"].startswith("enrich ")
-
-    @patch("resume_operator.tools.enrich.get_structured_llm")
-    def test_session_with_no_questions_exits_cleanly(
-        self, mock_get_llm: MagicMock, tmp_path: Path
-    ) -> None:
-        from resume_operator.tools.enrich import EnrichQuestionsLLMOutput
-
-        master = self._write_master_yaml(tmp_path)
-        facts = tmp_path / "facts.yaml"
-        job = tmp_path / "job.txt"
-        job.write_text("anything", encoding="utf-8")
-
-        mock_llm = MagicMock()
-        mock_llm.invoke.return_value = EnrichQuestionsLLMOutput(questions=[])
-        mock_get_llm.return_value = mock_llm
-
-        result = runner.invoke(
-            app,
-            ["enrich", "--master", str(master), "--facts", str(facts), "--job", str(job)],
-        )
-
-        assert result.exit_code == 0
-        assert "No questions" in _clean_output(result.output)
-        assert not facts.exists()
 
 
 class TestRunCommand:


### PR DESCRIPTION
## Summary

- Standalone \`enrich\` CLI command removed. Interactive session loop migrated to \`tools/enrich.run_interactive_session()\` for reuse.
- \`run\` now offers the enrichment interview *inline* when the first tailor pass is thin (kept items < \`enrich_threshold\`, default 6). Accepts y/N; on yes, runs the session, appends to \`facts_bank.yaml\`, re-invokes the graph once with the enriched facts.
- Question prompt UX rewritten: makes the facts-vs-instructions distinction unmissable.
- New: \`enrich_threshold\` setting + \`--no-enrich\` flag on \`run\` for headless / CI use.

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/64. Direct quote from the bug report after #62: *\"currently the app is too complicated to use it\"*. Three commands for three sequential steps was one too many. Plus the first real session produced five \"make it more professional\" entries because the prompt didn't make it clear the user should answer with **facts**, not **transformation instructions**.

## How it works now

1. \`run --master M --facts F --job J\` — one command, headless by default behavior except where it pauses for input.
2. Pipeline runs as before: load → score → (skip or) analyze + optimize → generate PDF → report.
3. After optimize_content, if \`tailored_resume.kept_or_reworded() < threshold\` AND stdin is a TTY AND \`--no-enrich\` wasn't passed AND optimization actually ran:
   - Yellow panel explains the situation
   - Prompt: \"Start an enrichment session? [y/N]\"
   - On yes: interactive Q&A loop → append accepted items to \`facts_bank.yaml\` → re-invoke the graph once
4. Final tailored PDF + diff + tailored.yaml + results.json land in the per-application folder as usual.

## Trigger conditions

All six paths live in \`_should_offer_enrich\` and are unit-tested:

| Scenario | Auto-enrich fires? |
|---|---|
| Thin tailoring + interactive + master + opt ran | ✅ |
| Rich tailoring (≥ threshold) | ❌ |
| \`--no-enrich\` flag set | ❌ |
| ATS skipped optimization (high score) | ❌ |
| stdin not a TTY (piped / CI) | ❌ |
| Legacy --resume PDF path (no master object) | ❌ |

## Question prompt UX

Per-question display now reads:

\`\`\`
Question 1/5: Did you design any public APIs?
why: JD emphasizes API design.
Answer with facts and metrics (e.g. \"I built 50+ endpoints serving 2M
requests/day\"). Do NOT type instructions like 'make it professional' —
that's the LLM's job in the polish step.
> _
\`\`\`

The session header panel also surfaces the same guidance. The original failure mode (typing transformation directives instead of answers) should be much harder to fall into now.

## Proof of Work

- \`uv run python -m resume_operator --help\` → 4 commands, \`enrich\` gone.
- \`uv run python -m resume_operator enrich --help\` → \"No such command 'enrich'\".
- Real-run: \`LLM_MODEL=openai/gpt-4o-mini uv run python -m resume_operator run --master data/master_resume.yaml --facts data/facts_bank.yaml --job input/job.txt --no-enrich\` completed clean (ATS 72%, 15 items kept, 3 reworded). Auto-enrich would not fire here even without --no-enrich (15 ≥ 6 threshold) — correct behavior for a rich-enough master.
- 154 tests pass (3 new, 4 retired). \`TestRunAutoEnrich\` covers all 6 trigger conditions.

When this PR is merged, the daily loop is: edit \`master_resume.yaml\` once, then for each new JD run \`resume-operator run --master ... --job ...\` — the tool decides for itself whether to interview you for more material, never forcing a separate command or asking instruction-shaped questions.