### PR TITLE
feat(pdf): tailored summary, typographic hierarchy, Unicode sanitizer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,6 +92,10 @@ After `ats_score`, a routing function checks the score against `ATS_SKIP_THRESHO
 
 `generate_pdf` is a pure function of `(ResumeMaster, TailoredResume, FactsBank?, template)` (#027). The renderer groups tailored items by `kind` (summary, experience-bullet, project, education, skill, certification), splices facts-bank `extra-bullet[role-id]` items under their target role, and lays out the page deterministically — no paragraph-splitting on LLM whitespace.
 
+**Summary handling (#66)**: `TailoredResume.tailored_summary` is a dedicated JD-crafted 2-3 sentence opener the optimizer writes fresh for every run. When non-empty, the renderer uses it for the SUMMARY section instead of a kept/reworded `master:summary` item. That avoids a double-render and lets the summary pull harder toward the JD than a per-item reword would.
+
+**Unicode sanitization (#66)**: every string that reaches the renderer passes through `_sanitize_for_pdf` — a boundary-layer that translates exotic Unicode (arrows `→`, non-breaking hyphens `‑`, curly quotes `'"`, horizontal ellipsis `…`) to ASCII and strips zero-width characters. Helvetica (the built-in font) can't render those glyphs, so without sanitization they come out as black `.notdef` boxes. `tailored.yaml` and `facts_bank.yaml` keep the LLM's original text; only the PDF text stream is normalized.
+
 Templates are configured via `RESUME_TEMPLATE` (`default | compact | modern`); only `default` is implemented today, unknown values fall back to default with a warning.
 
 The `default` template targets both audiences: ATS parsers (single-column selectable text, standard fonts, no images or layout tables) and recruiters' six-second scan (name banner + thin accent rule, uppercase section labels with a pale rule underneath, role header with right-aligned dates on the same line, hanging-indent bullets, one muted deep-blue accent used sparingly).

--- a/docs/issues/034-tailored-summary-hierarchy-sanitizer.md
+++ b/docs/issues/034-tailored-summary-hierarchy-sanitizer.md
@@ -1,0 +1,66 @@
+# [Feature + Refactor]: Tailored summary, typographic hierarchy, and Unicode sanitizer
+
+## Description
+
+Three related PDF-output issues surfaced from real-world use. Bundle them into one PR because they all touch the `generate_pdf` path:
+
+1. **Per-JD summary rewrite** — the summary currently rides the same `keep/reword/drop` rails as any other item via `master:summary`, which limits how far it can pull toward the JD. A fresh 2-3 sentence JD-tailored summary, grounded in the master, is what recruiters actually scan for.
+2. **Font + size hierarchy** — current sizes are name 22pt → section 10.5pt → role 10.5pt → body 10pt. Section headers and role titles are the same size as body text; the eye reads the page flat because there's no clear tier structure. "Font doesn't look professional" is almost always a hierarchy problem, not a face problem.
+3. **Unicode sanitizer** — Helvetica uses Adobe Standard Encoding, which doesn't cover exotic Unicode (`→`, `‑`, `‑`, `…`, zero-width spaces). When the LLM emits those, ReportLab draws the `.notdef` black square. Observed in real runs already: arrows like "Node.js 14 → 18" and hidden U+200B in enrichment-polished text.
+
+## Motivation
+
+Direct user quotes: *"summary of resume should be rewritten everytime with master summary + job description"*, *"the font isn't look professional"*, *"it looks like you tried to add - for connect two words, but currently it renders square box in black filled"*. All three are one-line-feedback-able for the user but each unfixes a different failure mode on the rendered PDF.
+
+## Target State
+
+1. **`TailoredResume` gains a `tailored_summary: str` field.** `optimize_content` LLM schema gets the same field; the prompt asks for a fresh JD-tailored summary in 2-3 sentences, strictly grounded in the master (no invented metrics, years, or tech). `optimize_content` prompt also now forbids `master:summary` in the items list — the dedicated field carries the summary instead, so it doesn't get double-rendered.
+2. **PDF renderer uses `tailored_summary` when non-empty.** Falls back to the master-summary-keep-item behavior when the field is empty (e.g., older tailored.yaml from before this PR).
+3. **Typographic hierarchy**:
+   - Name: **24pt** (from 22pt) bold
+   - Section headers: **12pt** (from 10.5pt) bold — the primary visual landmark gets its own tier
+   - Role title: **11pt** (from 10.5pt) bold — sub-tier below section
+   - Role dates: 9.5pt muted grey (unchanged)
+   - Body / bullets: 10pt (unchanged)
+   - Space before section headers: 12pt (from 8pt) — clearer section breaks
+4. **`_sanitize_for_pdf(text)` helper** applied to every string the renderer converts to a Paragraph / Table cell. Translation table:
+   - Dashes: `‑` `–` `−` → `-` (em-dash `—` kept — it's in Helvetica)
+   - Arrows: `→` → `->`, `←` → `<-`, `⇒` → `=>`, `⇐` → `<=`
+   - Quotes: `'` `'` → `'`, `"` `"` → `"`
+   - Ellipsis: `…` → `...`
+   - Non-breaking space: ` ` → ` `
+   - Strip: zero-width space (U+200B), ZWNJ (U+200C), ZWJ (U+200D), BOM (U+FEFF), soft hyphen (U+00AD), word joiner (U+2060)
+   - Collapse runs of whitespace
+5. **Prompt guidance in `optimize_content` and `enrich_polish`**: "Use plain ASCII punctuation — hyphens, straight quotes, `->` instead of arrows, three periods instead of ellipsis." Reduces the sanitizer's workload and keeps `tailored.yaml` readable.
+
+## Success Metrics — Verified
+
+Real-run against the bootstrapped master + `input/job.txt` (Foodsmart Staff
+Backend) with `LLM_MODEL=openai/gpt-4o-mini --no-enrich`:
+
+- `optimize_content: completed — items=77 (kept=11, reworded=1, dropped=65), fabricated_rejected=0, notes=3, summary=yes`. The log's `summary=yes` flag is the new field (#66) reporting that `tailored_summary` was populated.
+- The rendered SUMMARY section of the PDF reads: *"Experienced lead Software Engineer with over 8 years in backend development, specializing in Node.js, TypeScript, and RESTful API design. Proficient in optimizing database performance and implementing CI/CD practices, bringing proven skills in building reliable systems and enhancing application scalability."* — backend-weighted, specific to the JD, not the generic master summary.
+- Extracted text shows plain ASCII everywhere: `"2023 - January 2024"` (hyphen, not en-dash), `"Bachelor's Degree"` (straight quote, not curly). No residual arrows, non-breaking hyphens, or zero-width characters.
+- 167 tests pass (13 new): `TestSanitizeForPdf` covers 7 translation/strip/preserve cases; `TestTypographicHierarchy` pins the tier structure so future edits can't silently flatten it; `TestTailoredSummaryRender` covers 3 paths including the "tailored summary replaces master summary" case.
+- `diff.md` now opens with a `## Tailored Summary (fresh, JD-crafted)` block so the reader can audit the summary alongside the per-item changes.
+
+## Key Files
+
+- `src/resume_operator/state.py` — `TailoredResume.tailored_summary: str`
+- `src/resume_operator/nodes/optimize_content.py` — LLM schema + projection
+- `src/resume_operator/prompts/content_optimization.py` — summary request + ASCII guidance
+- `src/resume_operator/prompts/enrich.py` — ASCII guidance in polish prompt
+- `src/resume_operator/tools/pdf_generator.py` — sanitizer + hierarchy tune + tailored_summary render path
+- `src/resume_operator/tools/diff_renderer.py` — surface the tailored summary in `diff.md` so it's reviewable
+- `tests/test_pdf_generator.py` — sanitizer + hierarchy tests
+- `tests/test_optimize_content.py` — tailored_summary round-trip
+
+## Dependencies
+
+- #026 ✓ (TailoredResume exists)
+- #027 ✓ (deterministic render — sanitizer slots in there cleanly)
+- #030 ✓ (default template — hierarchy tune extends it)
+
+## Labels
+
+`enhancement`, `refactor`, `priority:high`

--- a/src/resume_operator/nodes/optimize_content.py
+++ b/src/resume_operator/nodes/optimize_content.py
@@ -39,6 +39,7 @@ class TailoredItemLLM(BaseModel):
 
 
 class TailoredResumeLLMOutput(BaseModel):
+    tailored_summary: str = ""  # fresh JD-crafted SUMMARY text — not sourced from the items list
     items: list[TailoredItemLLM] = Field(default_factory=list)
     notes: list[str] = Field(default_factory=list)
 
@@ -81,18 +82,23 @@ def optimize_content(state: ResumeOptimizerState) -> dict[str, Any]:
         logger.error(msg)
         errors.append(msg)
 
-    tailored = TailoredResume(items=validated_items, notes=list(parsed.notes))
+    tailored = TailoredResume(
+        items=validated_items,
+        notes=list(parsed.notes),
+        tailored_summary=parsed.tailored_summary.strip(),
+    )
     optimized_legacy = _project_to_sections(tailored, index)
 
     logger.info(
         "optimize_content: completed — items=%d (kept=%d, reworded=%d, dropped=%d), "
-        "fabricated_rejected=%d, notes=%d",
+        "fabricated_rejected=%d, notes=%d, summary=%s",
         len(tailored.items),
         sum(1 for i in tailored.items if i.action == "keep"),
         sum(1 for i in tailored.items if i.action == "reword"),
         sum(1 for i in tailored.items if i.action == "drop"),
         len(rejected),
         len(tailored.notes),
+        "yes" if tailored.tailored_summary else "no",
     )
 
     result: dict[str, Any] = {
@@ -142,12 +148,18 @@ def _project_to_sections(tailored: TailoredResume, index: SourceIndex) -> Optimi
         "skills": [],
         "education": [],
     }
+    # Tailored summary wins over any kept `master:summary` item (issue #66).
+    if tailored.tailored_summary:
+        buckets["summary"].append(tailored.tailored_summary)
     for item in tailored.kept_or_reworded():
         text = item.new_text or item.original_text
         entry = index.get(item.source_id)
         if entry is None:
             continue
         if entry.kind == "summary":
+            if tailored.tailored_summary:
+                # Skip — the dedicated field already carried the summary above.
+                continue
             buckets["summary"].append(text)
         elif entry.kind in {"experience-header", "experience-bullet"} or entry.kind.startswith(
             "extra-bullet"

--- a/src/resume_operator/prompts/content_optimization.py
+++ b/src/resume_operator/prompts/content_optimization.py
@@ -2,15 +2,28 @@
 
 OPTIMIZE_CONTENT = """You are tailoring a candidate's resume for a specific job.
 
-Your job is a *per-item* decision over a menu of source items. You MAY NOT
-invent new bullets or skills — you may only keep, reword, or drop existing
-ones from the menu below.
+Your job has two parts:
+
+### Part 1 — Tailored summary
+
+Write a fresh 2-3 sentence SUMMARY opener for this resume, weighted toward
+the JD below. Rules:
+- Grounded ONLY in facts derivable from the sources menu (years of experience,
+  tech stacks, role seniority). Do NOT invent metrics, headcount, tech, or
+  scope that isn't in the menu.
+- Active voice, specific, JD-aligned. Avoid filler like "results-driven" or
+  "passionate about X".
+- Return as the `tailored_summary` field of the output.
+- Do NOT also include `master:summary` in the `items` list below — the
+  dedicated field owns the summary.
+
+### Part 2 — Per-item decisions
+
+For every other master/facts item, decide keep / reword / drop. Every item
+you reference MUST use the exact `source_id` from the menu below. An output
+item whose `source_id` is not in this menu will be rejected.
 
 === SOURCES MENU ===
-Every item you reference in your output MUST use the exact `source_id` from
-this menu. An output item whose `source_id` is not in this menu will be
-rejected.
-
 {source_menu}
 
 === JOB DESCRIPTION ===
@@ -19,24 +32,31 @@ rejected.
 === GAP ANALYSIS (from earlier pass) ===
 {gap_analysis}
 
-=== YOUR TASK ===
-Return a list of `TailoredItem` decisions covering the items that belong in
-the tailored output. Each item:
+### Output schema
 
-- `source_id` — exact match to a menu entry above
-- `action` — one of:
-  - `keep`   → include the source text unchanged
-  - `reword` → include, but rephrased for this JD; fill `new_text`
-  - `drop`   → the item was considered but excluded from the final resume
-- `original_text` — echo the source text so the diff reader has context
-- `new_text` — only when action is `reword`; otherwise leave empty
+Return a `TailoredResumeLLMOutput` with:
+- `tailored_summary` — the fresh summary from Part 1 (string)
+- `items` — list of per-item decisions (see below); do NOT include a
+  `master:summary` entry here.
+- `notes` — short free-form strategy notes explaining what you emphasized,
+  what you downplayed, and why.
 
-Include `drop` decisions for items from the master that you chose NOT to
-include — the reader wants to see what was cut, not just what was kept.
+Each `item`:
+- `source_id` — exact menu match
+- `action` — `keep` (include unchanged), `reword` (include with new phrasing),
+  or `drop` (considered but excluded from output)
+- `original_text` — echo the source for context
+- `new_text` — only when action is `reword`
 
-Pull in items from the facts bank (source_id starting with `facts:`) only
-when they strengthen the match for this specific JD.
+Pull in `facts:*` items only when they strengthen the match for this
+specific JD.
 
-Add short free-form `notes` explaining the overall strategy (what you
-emphasized, what you downplayed, and why).
+### Output style
+
+Use plain ASCII punctuation in `tailored_summary` and `new_text`:
+- Hyphens (`-`), not en-dashes or non-breaking hyphens
+- Straight quotes (`"` and `'`), not curly
+- `->` instead of `→`; `...` instead of `…`
+The rendered PDF's default font doesn't carry those exotic glyphs and would
+render them as black boxes; keep the wording portable.
 """

--- a/src/resume_operator/prompts/enrich.py
+++ b/src/resume_operator/prompts/enrich.py
@@ -53,6 +53,9 @@ own words. Rewrite their answer as a single resume bullet that:
    technology, metrics, or scope the candidate did not mention. Paraphrase,
    don't invent.
 6. Is ATS-friendly — plain text, concrete, specific.
+7. Uses plain ASCII punctuation — hyphens (`-`), straight quotes, `->`
+   instead of `→`, three periods instead of `…`. No zero-width characters
+   or placeholder ellipsis.
 
 Also classify where this bullet belongs, using exactly one of these buckets:
   - `project`        — standalone project not tied to a specific role

--- a/src/resume_operator/state.py
+++ b/src/resume_operator/state.py
@@ -154,10 +154,18 @@ class TailoredItem(BaseModel):
 
 
 class TailoredResume(BaseModel):
-    """Structured tailored output — a list of per-item decisions, not free-form text."""
+    """Structured tailored output — a list of per-item decisions, not free-form text.
+
+    `tailored_summary` is a dedicated JD-crafted 2-3 sentence opener (issue #66).
+    When non-empty, the renderer uses it for the SUMMARY section instead of a
+    kept/reworded `master:summary` item — recruiters read the summary first,
+    so it deserves a fresh pass targeted at *this* JD rather than a rephrase
+    of the generic master summary.
+    """
 
     items: list[TailoredItem] = Field(default_factory=list)
     notes: list[str] = Field(default_factory=list)
+    tailored_summary: str = ""
 
     def kept_or_reworded(self) -> list[TailoredItem]:
         return [i for i in self.items if i.action in {"keep", "reword"}]

--- a/src/resume_operator/tools/diff_renderer.py
+++ b/src/resume_operator/tools/diff_renderer.py
@@ -24,6 +24,11 @@ def render_diff(tailored: TailoredResume, index: SourceIndex) -> str:
 
     lines: list[str] = ["# Tailoring Diff", ""]
 
+    if tailored.tailored_summary:
+        lines.append("## Tailored Summary (fresh, JD-crafted)")
+        lines.append(tailored.tailored_summary)
+        lines.append("")
+
     if tailored.notes:
         lines.append("## Strategy Notes")
         lines.extend(f"- {note}" for note in tailored.notes)

--- a/src/resume_operator/tools/pdf_generator.py
+++ b/src/resume_operator/tools/pdf_generator.py
@@ -45,6 +45,71 @@ _RULE_GREY = HexColor("#CBD5E0")
 _MARGIN = 0.6 * inch
 
 
+# --- Unicode sanitization -------------------------------------------------
+#
+# Helvetica (ReportLab's built-in Type-1 font) ships with Adobe Standard
+# Encoding — roughly Latin-1 plus a handful of punctuation. When the LLM
+# emits chars outside that coverage (arrows, non-breaking hyphens, curly
+# quotes, zero-width spaces…), ReportLab renders the `.notdef` glyph — a
+# black filled box. Translate the common offenders to ASCII equivalents
+# before the text hits the renderer.
+
+_TRANSLATE: dict[int, str] = {
+    # Dashes
+    0x2011: "-",  # non-breaking hyphen
+    0x2013: "-",  # en dash
+    0x2212: "-",  # minus sign
+    # Arrows
+    0x2192: "->",  # rightwards arrow
+    0x2190: "<-",  # leftwards arrow
+    0x21D2: "=>",  # rightwards double arrow
+    0x21D0: "<=",  # leftwards double arrow
+    0x2194: "<->",  # left-right arrow
+    # Quotes
+    0x2018: "'",  # left single quote
+    0x2019: "'",  # right single quote / apostrophe
+    0x201A: "'",  # single low-9 quote
+    0x201C: '"',  # left double quote
+    0x201D: '"',  # right double quote
+    0x201E: '"',  # double low-9 quote
+    # Ellipsis + punctuation
+    0x2026: "...",  # horizontal ellipsis
+    # Whitespace
+    0x00A0: " ",  # non-breaking space
+}
+
+# Invisible chars to strip outright — they carry no rendered glyph and often
+# end up as `.notdef` boxes when the LLM slips them in.
+_STRIP_CHARS = "".join(
+    chr(c)
+    for c in (
+        0x200B,  # zero-width space
+        0x200C,  # zero-width non-joiner
+        0x200D,  # zero-width joiner
+        0x2060,  # word joiner
+        0xFEFF,  # BOM / zero-width no-break space
+        0x00AD,  # soft hyphen
+    )
+)
+_STRIP_TABLE: dict[int, None] = {ord(c): None for c in _STRIP_CHARS}
+
+
+def _sanitize_for_pdf(text: str) -> str:
+    """Translate exotic Unicode to ASCII and strip invisible/zero-width chars.
+
+    Runs at the renderer boundary. `tailored.yaml` / `facts_bank.yaml` keep the
+    LLM's original text; only the PDF text stream is normalized.
+    """
+    if not text:
+        return text
+    # Strip the invisible offenders first so subsequent whitespace collapse works.
+    cleaned = text.translate(_STRIP_TABLE).translate(_TRANSLATE)
+    # Collapse any run of whitespace (including the non-breaking space we just
+    # converted) down to a single space, without touching deliberate newlines.
+    lines = [" ".join(line.split()) for line in cleaned.splitlines()]
+    return "\n".join(lines).strip()
+
+
 def generate_pdf(
     master: ResumeMaster,
     tailored: TailoredResume,
@@ -127,12 +192,22 @@ def _build_render_plan(
     index = build_source_index(master, facts)
     plan = _RenderPlan()
 
+    # Tailored summary (issue #66) is the fresh JD-crafted opener. When set, it
+    # wins over any kept `master:summary` item — the two would otherwise render
+    # twice in the SUMMARY section.
+    if tailored.tailored_summary:
+        plan.summary = tailored.tailored_summary
+
     for item in tailored.kept_or_reworded():
         entry = index.get(item.source_id)
         kind = entry.kind if entry else _infer_kind(item)
         text = _text_for(item)
 
         if kind == "summary":
+            # If the optimizer populated `tailored_summary`, that already filled
+            # plan.summary; skip here to avoid duplicate rendering.
+            if tailored.tailored_summary:
+                continue
             plan.summary = text
         elif kind == "experience-bullet":
             role_id = _role_id_from_bullet_source(item.source_id)
@@ -185,7 +260,7 @@ def _render_default(master: ResumeMaster, plan: _RenderPlan, frame_width: float)
 
     # --- Header: name banner + accent rule + contact line ---
     if master.name:
-        flowables.append(Paragraph(escape(master.name), styles["name"]))
+        flowables.append(Paragraph(escape(_sanitize_for_pdf(master.name)), styles["name"]))
     flowables.append(
         HRFlowable(
             width="100%",
@@ -195,14 +270,16 @@ def _render_default(master: ResumeMaster, plan: _RenderPlan, frame_width: float)
             spaceAfter=4,
         )
     )
-    contact_parts = [p for p in (master.email, master.phone, master.location) if p]
+    contact_parts = [
+        _sanitize_for_pdf(p) for p in (master.email, master.phone, master.location) if p
+    ]
     if contact_parts:
         flowables.append(Paragraph(escape("  ·  ".join(contact_parts)), styles["contact"]))
 
     # --- Summary ---
     if plan.summary:
         flowables.extend(_section_header("SUMMARY", frame_width))
-        flowables.append(Paragraph(escape(plan.summary), styles["body"]))
+        flowables.append(Paragraph(escape(_sanitize_for_pdf(plan.summary)), styles["body"]))
 
     # --- Experience (roles in master order) ---
     if plan.experience_by_role:
@@ -224,7 +301,9 @@ def _render_default(master: ResumeMaster, plan: _RenderPlan, frame_width: float)
         for virtual_id, bullets in plan.experience_by_role.items():
             if virtual_id in seen:
                 continue
-            flowables.append(Paragraph(escape(virtual_id.upper()), styles["role_title"]))
+            flowables.append(
+                Paragraph(escape(_sanitize_for_pdf(virtual_id.upper())), styles["role_title"])
+            )
             for bullet in bullets:
                 flowables.append(Paragraph(_bullet(bullet), styles["bullet"]))
             flowables.append(Spacer(1, 0.05 * inch))
@@ -232,13 +311,14 @@ def _render_default(master: ResumeMaster, plan: _RenderPlan, frame_width: float)
     # --- Skills ---
     if plan.skills:
         flowables.extend(_section_header("SKILLS", frame_width))
-        flowables.append(Paragraph(escape("  ·  ".join(plan.skills)), styles["body"]))
+        sanitized_skills = [_sanitize_for_pdf(s) for s in plan.skills]
+        flowables.append(Paragraph(escape("  ·  ".join(sanitized_skills)), styles["body"]))
 
     # --- Education ---
     if plan.education:
         flowables.extend(_section_header("EDUCATION", frame_width))
         for entry in plan.education:
-            flowables.append(Paragraph(escape(entry), styles["body"]))
+            flowables.append(Paragraph(escape(_sanitize_for_pdf(entry)), styles["body"]))
 
     # --- Certifications ---
     if plan.certifications:
@@ -251,14 +331,25 @@ def _render_default(master: ResumeMaster, plan: _RenderPlan, frame_width: float)
 
 
 def _default_styles() -> dict[str, ParagraphStyle]:
+    """Typographic hierarchy for the `default` template.
+
+    Sizes create a clear tier structure so the recruiter's eye lands on
+    landmarks in the right order:
+      Name (24pt)  →  Section headers (12pt)  →  Role titles (11pt)  →
+      Body / bullets (10pt)  →  Role dates / contact (9.5pt, muted)
+
+    Issue #66 tightened this: previously section headers and role titles
+    were both 10.5pt — same size as bullets — which made the page read
+    flat. Splitting them into distinct tiers is the highest-leverage fix.
+    """
     base = getSampleStyleSheet()
     return {
         "name": ParagraphStyle(
             "Name",
             parent=base["Heading1"],
             fontName="Helvetica-Bold",
-            fontSize=22,
-            leading=24,
+            fontSize=24,
+            leading=26,
             textColor=HexColor("#1A202C"),
             spaceAfter=0,
             alignment=0,
@@ -270,26 +361,26 @@ def _default_styles() -> dict[str, ParagraphStyle]:
             fontSize=9.5,
             leading=12,
             textColor=_MUTED_GREY,
-            spaceAfter=6,
+            spaceAfter=8,
         ),
         "section": ParagraphStyle(
             "Section",
             parent=base["Heading2"],
             fontName="Helvetica-Bold",
-            fontSize=10.5,
-            leading=12,
+            fontSize=12,
+            leading=14,
             textColor=_ACCENT,
-            spaceBefore=8,
+            spaceBefore=12,
             spaceAfter=0,
         ),
         "role_title": ParagraphStyle(
             "RoleTitle",
             parent=base["BodyText"],
             fontName="Helvetica-Bold",
-            fontSize=10.5,
-            leading=13,
+            fontSize=11,
+            leading=14,
             textColor=HexColor("#1A202C"),
-            spaceBefore=0,
+            spaceBefore=2,
             spaceAfter=0,
         ),
         "role_dates": ParagraphStyle(
@@ -297,7 +388,7 @@ def _default_styles() -> dict[str, ParagraphStyle]:
             parent=base["BodyText"],
             fontName="Helvetica",
             fontSize=9.5,
-            leading=13,
+            leading=14,
             textColor=_MUTED_GREY,
             alignment=2,  # right
         ),
@@ -345,8 +436,8 @@ def _section_header(title: str, frame_width: float) -> list[object]:
 
 def _role_row(role: object, styles: dict[str, ParagraphStyle], frame_width: float) -> Table:
     """Two-column row: role + company on the left, dates/location right-aligned."""
-    left = Paragraph(escape(_role_header_text(role)), styles["role_title"])
-    right = Paragraph(escape(_role_meta_text(role)), styles["role_dates"])
+    left = Paragraph(escape(_sanitize_for_pdf(_role_header_text(role))), styles["role_title"])
+    right = Paragraph(escape(_sanitize_for_pdf(_role_meta_text(role))), styles["role_dates"])
 
     # 65 / 35 split — date strings are short, role/company is the prime real estate.
     left_w = frame_width * 0.65
@@ -368,7 +459,7 @@ def _role_row(role: object, styles: dict[str, ParagraphStyle], frame_width: floa
 
 def _bullet(text: str) -> str:
     """Format bullet content as `• <text>` so the glyph and content extract on one line."""
-    return f"• {escape(text)}"
+    return f"• {escape(_sanitize_for_pdf(text))}"
 
 
 def _role_header_text(role: object) -> str:

--- a/tests/test_optimize_content.py
+++ b/tests/test_optimize_content.py
@@ -12,8 +12,8 @@ from resume_operator.nodes.optimize_content import (
 from resume_operator.state import ResumeOptimizerState
 
 VALID_OUTPUT = TailoredResumeLLMOutput(
+    tailored_summary="Senior engineer with 8+ years shipping Python/AWS backends.",
     items=[
-        TailoredItemLLM(source_id="master:summary", action="keep", original_text="summary text"),
         TailoredItemLLM(
             source_id="master:exp-1-b1",
             action="reword",
@@ -49,11 +49,15 @@ class TestOptimizeContent:
         result = optimize_content(sample_state)
 
         assert "tailored_resume" in result
-        assert len(result["tailored_resume"].items) == 5
-        assert result["tailored_resume"].items[1].action == "reword"
-        assert "Kubernetes-native" in result["tailored_resume"].items[1].new_text
-        # Legacy projection still populates sections for back-compat.
+        assert len(result["tailored_resume"].items) == 4
+        assert result["tailored_resume"].items[0].action == "reword"
+        assert "Kubernetes-native" in result["tailored_resume"].items[0].new_text
+        # Tailored summary round-trips (issue #66).
+        assert result["tailored_resume"].tailored_summary.startswith("Senior engineer")
+        # Legacy projection still populates sections for back-compat, and the
+        # tailored_summary wins over any kept master:summary.
         assert "optimized_resume" in result
+        assert result["optimized_resume"].sections["summary"].startswith("Senior engineer")
         assert result["optimized_resume"].sections["experience"].startswith("- ")
         assert result["optimized_resume"].sections["skills"] == "Python"
 

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -13,7 +13,11 @@ from resume_operator.state import (
     TailoredItem,
     TailoredResume,
 )
-from resume_operator.tools.pdf_generator import generate_pdf
+from resume_operator.tools.pdf_generator import (
+    _default_styles,
+    _sanitize_for_pdf,
+    generate_pdf,
+)
 
 
 @pytest.fixture()
@@ -199,3 +203,130 @@ class TestGeneratePdf:
             text = "\n".join(page.get_text() for page in doc)
         assert "Kept bullet" in text
         assert "DROPPED-DO-NOT-RENDER" not in text
+
+
+class TestSanitizeForPdf:
+    def test_translates_exotic_dashes_and_arrows(self) -> None:
+        # non-breaking hyphen, en-dash, rightwards arrow, minus sign
+        assert _sanitize_for_pdf("high‑performance") == "high-performance"
+        assert _sanitize_for_pdf("Node.js 14 → 18") == "Node.js 14 -> 18"
+        assert _sanitize_for_pdf("2020 – present") == "2020 - present"
+        assert _sanitize_for_pdf("cost − 5%") == "cost - 5%"
+
+    def test_translates_curly_quotes_and_ellipsis(self) -> None:
+        assert _sanitize_for_pdf("it’s a “test”…") == 'it\'s a "test"...'
+
+    def test_strips_zero_width_characters(self) -> None:
+        # Exactly the garbage Bruno's first enrich session produced.
+        assert _sanitize_for_pdf("Designed​    ​ thing") == "Designed thing"
+        assert _sanitize_for_pdf("before­after") == "beforeafter"  # soft hyphen
+        assert _sanitize_for_pdf("﻿BOM-prefixed") == "BOM-prefixed"
+
+    def test_collapses_whitespace_runs(self) -> None:
+        assert _sanitize_for_pdf("a     b\t\tc") == "a b c"
+
+    def test_preserves_newlines(self) -> None:
+        # Intentional newlines (paragraph breaks) survive.
+        assert _sanitize_for_pdf("line one\nline two") == "line one\nline two"
+
+    def test_empty_string_passthrough(self) -> None:
+        assert _sanitize_for_pdf("") == ""
+
+    def test_preserves_standard_ascii(self) -> None:
+        assert _sanitize_for_pdf("hello, world! 50%") == "hello, world! 50%"
+
+
+class TestTypographicHierarchy:
+    """Issue #66 introduced a clearer size hierarchy — pin it so future edits
+    don't silently flatten the page again."""
+
+    def test_section_header_larger_than_body(self) -> None:
+        styles = _default_styles()
+        assert styles["section"].fontSize > styles["body"].fontSize
+
+    def test_role_title_between_section_and_body(self) -> None:
+        styles = _default_styles()
+        assert styles["section"].fontSize >= styles["role_title"].fontSize
+        assert styles["role_title"].fontSize > styles["body"].fontSize
+
+    def test_name_is_the_largest_tier(self) -> None:
+        styles = _default_styles()
+        name = styles["name"].fontSize
+        other_sizes = [
+            styles["section"].fontSize,
+            styles["role_title"].fontSize,
+            styles["body"].fontSize,
+            styles["contact"].fontSize,
+        ]
+        assert all(name > s for s in other_sizes)
+
+
+class TestTailoredSummaryRender:
+    def test_tailored_summary_rendered_when_present(
+        self, tmp_path: Path, master: ResumeMaster
+    ) -> None:
+        summary = "Backend-leaning staff engineer with 8+ years shipping Node.js on AWS."
+        tailored = TailoredResume(
+            tailored_summary=summary,
+            items=[
+                TailoredItem(
+                    source_id="master:exp-1-b1", action="keep", original_text="Led backend team"
+                ),
+            ],
+        )
+        output = tmp_path / "resume.pdf"
+        generate_pdf(master, tailored, output)
+
+        with fitz.open(output) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+
+        assert "Backend-leaning staff engineer" in text
+
+    def test_tailored_summary_replaces_master_summary(
+        self, tmp_path: Path, master: ResumeMaster
+    ) -> None:
+        """If both a tailored_summary AND a kept master:summary are present, only
+        the tailored one should render — we don't want the SUMMARY section to
+        show both."""
+        tailored = TailoredResume(
+            tailored_summary="FRESH JD-TAILORED SUMMARY.",
+            items=[
+                TailoredItem(
+                    source_id="master:summary",
+                    action="keep",
+                    original_text="OLD MASTER SUMMARY SHOULD-NOT-RENDER",
+                ),
+                TailoredItem(source_id="master:exp-1-b1", action="keep", original_text="A bullet"),
+            ],
+        )
+        output = tmp_path / "resume.pdf"
+        generate_pdf(master, tailored, output)
+
+        with fitz.open(output) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+
+        assert "FRESH JD-TAILORED SUMMARY." in text
+        assert "SHOULD-NOT-RENDER" not in text
+
+    def test_sanitizer_applied_to_tailored_summary(
+        self, tmp_path: Path, master: ResumeMaster
+    ) -> None:
+        """Even if the LLM slips an exotic char into the summary, the PDF
+        shouldn't show a black .notdef box."""
+        tailored = TailoredResume(
+            tailored_summary="High‑performance backend engineer → cloud native.",
+            items=[
+                TailoredItem(source_id="master:exp-1-b1", action="keep", original_text="A bullet"),
+            ],
+        )
+        output = tmp_path / "resume.pdf"
+        generate_pdf(master, tailored, output)
+
+        with fitz.open(output) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+
+        assert "High-performance" in text
+        assert "-> cloud" in text
+        # Raw exotic chars must not survive into the rendered text stream.
+        assert "‑" not in text
+        assert "→" not in text


### PR DESCRIPTION
## Summary

Three related PDF-output improvements in one PR (all touch the same output path):

1. **Per-JD tailored summary** — `TailoredResume.tailored_summary` is a fresh 2-3 sentence opener the optimizer writes per run, JD-weighted but grounded strictly in the sources menu (no invented metrics). Replaces the kept/reworded `master:summary` behavior in the SUMMARY section.
2. **Typographic hierarchy** — name 24pt, section 12pt, role 11pt, body 10pt. Section headers and role titles are now distinct tiers from bullets; the page reads with clear visual landmarks instead of flat.
3. **Unicode sanitizer** — `_sanitize_for_pdf(text)` runs at every text-boundary, translating exotic chars (`→`, `‑`, curly quotes, `…`) to ASCII and stripping zero-width/invisible chars. No more black `.notdef` boxes for the non-Helvetica glyphs the LLM occasionally emits.

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/66. Three direct user reports after real-world use — *"summary should be rewritten every time"*, *"the font isn't look professional"*, *"it renders square box in black filled"* — all trace to the generate_pdf path.

## Changes

- \`src/resume_operator/state.py\` — \`TailoredResume.tailored_summary: str\`
- \`src/resume_operator/nodes/optimize_content.py\` — LLM schema adds \`tailored_summary\`; legacy \`_project_to_sections\` uses it too
- \`src/resume_operator/prompts/content_optimization.py\` — two-part prompt: fresh summary + per-item decisions; explicit \"no master:summary in items\" rule; ASCII punctuation guidance
- \`src/resume_operator/prompts/enrich.py\` — same ASCII rule on the polish step
- \`src/resume_operator/tools/pdf_generator.py\` — sanitizer + hierarchy constants + \`tailored_summary\` render path
- \`src/resume_operator/tools/diff_renderer.py\` — \`## Tailored Summary\` block at the top of diff.md
- Tests — \`TestSanitizeForPdf\` (7 cases), \`TestTypographicHierarchy\` (3 cases), \`TestTailoredSummaryRender\` (3 cases). +13 net.

## Proof on real inputs

Run against the bootstrapped master + \`input/job.txt\` (Foodsmart Staff Backend):

- \`optimize_content: completed — items=77 (kept=11, reworded=1, dropped=65), fabricated_rejected=0, notes=3, summary=yes\`
- SUMMARY section now reads: *\"Experienced lead Software Engineer with over 8 years in backend development, specializing in Node.js, TypeScript, and RESTful API design. Proficient in optimizing database performance and implementing CI/CD practices, bringing proven skills in building reliable systems and enhancing application scalability.\"* — backend-weighted, specific, not the generic master summary.
- Extracted PDF text shows plain ASCII throughout: \`\"2023 - January 2024\"\`, \`\"Bachelor's Degree\"\`. No arrows, no non-breaking hyphens, no zero-width characters.
- \`diff.md\` opens with a \`## Tailored Summary (fresh, JD-crafted)\` block so the reader can audit the summary alongside the per-item changes.

When this PR is merged, the three visible complaints from real use — sparse summary, flat hierarchy, black squares — are all addressed at the PDF-output boundary without any new dependencies.