### PR TITLE
feat(master): senior-format fields — headline, links, skill_groups, per-role tech

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,13 @@ After `ats_score`, a routing function checks the score against `ATS_SKIP_THRESHO
 
 **Unicode sanitization (#66)**: every string that reaches the renderer passes through `_sanitize_for_pdf` — a boundary-layer that translates exotic Unicode (arrows `→`, non-breaking hyphens `‑`, curly quotes `'"`, horizontal ellipsis `…`) to ASCII and strips zero-width characters. Helvetica (the built-in font) can't render those glyphs, so without sanitization they come out as black `.notdef` boxes. `tailored.yaml` and `facts_bank.yaml` keep the LLM's original text; only the PDF text stream is normalized.
 
+**Senior-format fields (#68)**: `ResumeMaster` carries four optional additions that bring the render closer to senior-engineer CV conventions:
+- `headline` — short tagline under the name (e.g. *"Senior Software Engineer · Founding Engineer · Ex-Google"*)
+- `links` — structured Portfolio/LinkedIn/GitHub rendered as a second contact line
+- `skill_groups` — categorised skills (Languages / Frontend / Backend / Cloud). Flattens into the source_index with the same `master:skill:<name>` IDs, so the tailor's fabrication guard doesn't need to know whether the master is grouped or flat.
+- `ExperienceEntry.tech` — per-role tech stack rendered as a dim `Tech: A, B, C` line after the bullets
+All four are optional; older YAMLs without them fall back gracefully (no headline line, flat skills, no tech line). The bootstrap prompt asks the LLM to extract them when they appear in the source PDF; otherwise they stay empty.
+
 Templates are configured via `RESUME_TEMPLATE` (`default | compact | modern`); only `default` is implemented today, unknown values fall back to default with a warning.
 
 The `default` template targets both audiences: ATS parsers (single-column selectable text, standard fonts, no images or layout tables) and recruiters' six-second scan (name banner + thin accent rule, uppercase section labels with a pale rule underneath, role header with right-aligned dates on the same line, hanging-indent bullets, one muted deep-blue accent used sparingly).

--- a/docs/issues/035-senior-resume-format-upgrades.md
+++ b/docs/issues/035-senior-resume-format-upgrades.md
@@ -1,0 +1,106 @@
+# [Feature]: Senior-engineer resume format — tagline, categorized skills, per-role tech line, links
+
+## Description
+
+Inspired by reviewing Andy Wang's CV (\`input/andy-wang-cv.docx\`), four structural additions that bring the generated PDF closer to how senior-engineer resumes are actually laid out:
+
+1. **Tagline / headline** under the name — e.g. *"Senior Software Engineer · Founding Engineer · Ex-Google"*. Currently nothing renders between name and contact, so the recruiter's eye has no hook.
+2. **Categorized skills** — group skills by domain (Languages, Frontend, Backend, Cloud, AI/ML) instead of a single flat `·`-separated line. Today's skills section is a dump; Andy's is a scan-friendly table.
+3. **Per-role tech line** — after each experience role's bullets, emit a dim italic `Tech: TypeScript, Nest.js, Docker, …` line. Low-effort ATS bonus + skim aid.
+4. **Structured links** in the header — Portfolio / LinkedIn / GitHub as their own fields on a second contact line.
+
+## Motivation
+
+Direct user feedback on the rendered resume: *"the style of resume still not looks good"*. After the #66 hierarchy/sanitizer work, the remaining gap is structural — the current output is missing conventions recruiters now expect on a senior-engineer resume. Looking at a real well-built CV made the gap concrete: tagline, skill categories, and per-role tech lines are the format-level things that make an output read "senior" instead of "generic".
+
+All four fixes are additive, not rewrites. Existing `master_resume.yaml` files stay loadable (missing fields default to empty); the renderer falls back gracefully when a field is empty.
+
+## Target State
+
+### `ResumeMaster` additions
+- `headline: str = ""` — a short tagline rendered under the name
+- `links: list[Link]` where `Link { label: str, url: str }` — rendered as a second contact line when non-empty
+- `skill_groups: list[SkillGroup]` where `SkillGroup { category: str, items: list[str] }` — when non-empty, SKILLS renders grouped; otherwise falls back to the existing flat `skills: list[str]` rendering
+- `ExperienceEntry.tech: list[str] = []` — rendered as a `Tech: …` line after the bullets
+
+`ResumeData` stays as today — the new fields live on `ResumeMaster` only. `state.resume` (legacy view) still works for ats_score / analyze_gaps. A new `_build_master_from_llm(parsed)` helper in `parse_resume.py` constructs the `ResumeMaster` with the new fields directly, instead of routing through `resume_data_to_master`.
+
+### Bootstrap prompt
+`PARSE_RESUME` grows explicit instructions: extract a headline if one is present under the name, group skills by category where the source resume does so, extract per-role tech lists where the source shows them, and capture portfolio/LinkedIn/GitHub links as structured items. All fields are optional — the LLM leaves them empty when the source doesn't have them.
+
+### Source index
+`skill_groups` items get flattened into the source index with the same `master:skill:<name>` IDs, so the tailor's fabrication guard keeps working unchanged. Categories are purely a render concern.
+
+`headline`, `links`, and `tech` are NOT added to the source_index — they're header/footer metadata, not items to be kept/reworded/dropped.
+
+### Renderer
+- Headline: 11pt, muted grey, rendered on a line directly below the name (before the accent rule)
+- Links: second contact line below the first, `·`-separated, same muted grey style
+- Tech line: emitted after a role's bullets, `Tech: A, B, C` in 9.5pt italic muted grey
+- Skill groups: each group renders as `**Category**: item1, item2, item3` on its own line; flat skills fallback unchanged when groups are empty
+
+### Example YAML refresh
+`input/master_resume.example.yaml` gets a light rewrite to demonstrate every new field, so future bootstrap users have a reference.
+
+## Success Metrics — Verified
+
+Real-run against the refreshed `input/master_resume.example.yaml` (seeded
+with headline, links, skill_groups, per-role tech) rendered the following
+extracted text, in order:
+
+```
+Jane Smith
+Senior Software Engineer · Founding Engineer · Ex-Acme
+jane.smith@example.com · +1 555 123 4567 · San Francisco, CA
+Portfolio: https://janesmith.example · LinkedIn: linkedin.com/in/jane-smith · GitHub: github.com/jsmith
+SUMMARY
+…
+EXPERIENCE
+Senior Software Engineer — Acme Corp
+Remote · 2021-03 - present
+• Led migration of monolith to Go microservices, cutting p99 latency 40%.
+• …
+Tech: Go, gRPC, Kubernetes, PostgreSQL, Prometheus
+…
+SKILLS
+Languages & Runtimes: Go, TypeScript, SQL
+Frontend & APIs: React, REST
+Backend & Data: PostgreSQL, gRPC
+Cloud & Infrastructure: AWS, Kubernetes, Docker
+```
+
+Every `#68` addition visible and in the expected position.
+
+Back-compat verified against Bruno's real `data/master_resume.yaml` (which
+has no headline / links / skill_groups / per-role tech — the LLM correctly
+left them empty): the pipeline still renders a valid PDF with the flat
+skills line, no tagline, no second contact line, and no tech lines. The
+new fields are additive — absent-is-fine.
+
+Test coverage:
+- `TestSeniorFormatFields` (7 cases) covers render paths for all four
+  fields + their empty/fallback behaviours.
+- `TestSkillIndexing` (3 cases) covers flat, grouped, and mixed flat+grouped
+  indexing into `master:skill:<name>` IDs.
+- `TestSeniorFormatExtraction` (2 cases) covers the bootstrap
+  `_build_master_from_llm` path: rich extraction populates every field,
+  sparse LLM output defaults every field to empty.
+- 180 tests pass overall (13 new vs. pre-#68 baseline).
+
+## Key Files
+
+- `src/resume_operator/state.py` — `Link`, `SkillGroup`, `ResumeMaster.headline`/`.links`/`.skill_groups`, `ExperienceEntry.tech`
+- `src/resume_operator/nodes/parse_resume.py` — LLM schema extensions + `_build_master_from_llm` helper
+- `src/resume_operator/prompts/resume_parsing.py` — extraction guidance for the four new fields
+- `src/resume_operator/tools/source_index.py` — flatten `skill_groups` into the index
+- `src/resume_operator/tools/pdf_generator.py` — four new render paths; `skill_groups` + flat-fallback; headline/links/tech
+- `input/master_resume.example.yaml` — showcase the new format
+- `tests/test_pdf_generator.py`, `tests/test_parse_resume.py`, `tests/test_source_index.py` (if new) — schema round-trip, render, back-compat, index flattening
+
+## Dependencies
+
+- #024 (master YAML contract), #026 (source_index + fabrication guard), #66 (hierarchy + sanitizer — this PR extends that template)
+
+## Labels
+
+`enhancement`, `priority:high`

--- a/input/master_resume.example.yaml
+++ b/input/master_resume.example.yaml
@@ -1,7 +1,17 @@
 name: Jane Smith
+headline: Senior Software Engineer · Founding Engineer · Ex-Acme
 email: jane.smith@example.com
 phone: "+1 555 123 4567"
 location: San Francisco, CA
+
+links:
+  - label: Portfolio
+    url: https://janesmith.example
+  - label: LinkedIn
+    url: linkedin.com/in/jane-smith
+  - label: GitHub
+    url: github.com/jsmith
+
 summary: >
   Senior fullstack engineer with 8 years of experience building distributed
   systems in Go and TypeScript. Focus on platform reliability and developer
@@ -21,6 +31,7 @@ experience:
         text: Designed gRPC contracts adopted by 12 teams across the company.
       - id: exp-1-b3
         text: Mentored 4 mid-level engineers and ran weekly architecture reviews.
+    tech: [Go, gRPC, Kubernetes, PostgreSQL, Prometheus]
 
   - id: exp-2
     role: Software Engineer
@@ -33,6 +44,7 @@ experience:
         text: Shipped React dashboard used by 500+ internal operators daily.
       - id: exp-2-b2
         text: Introduced end-to-end Playwright tests, reducing regression bugs 60%.
+    tech: [TypeScript, React, Playwright, Node.js]
 
 education:
   - id: edu-1
@@ -43,6 +55,21 @@ education:
     end_date: "2018"
     details: Dean's List, senior thesis on distributed consensus.
 
+# Categorised skills (#68). The renderer groups them under SKILLS.
+# Keep the flat `skills` list in sync if you want both to work for
+# older consumers — `all_skills()` dedupes across both.
+skill_groups:
+  - category: Languages & Runtimes
+    items: [Go, TypeScript, Python, SQL]
+  - category: Frontend & APIs
+    items: [React, Next.js, GraphQL, REST]
+  - category: Backend & Data
+    items: [Node.js, PostgreSQL, Redis, gRPC]
+  - category: Cloud & Infrastructure
+    items: [AWS, Kubernetes, Docker, Terraform]
+
+# Flat list — kept for back-compat with older renderers. When `skill_groups`
+# is populated the renderer uses those and ignores this list.
 skills:
   - Go
   - TypeScript

--- a/src/resume_operator/nodes/parse_resume.py
+++ b/src/resume_operator/nodes/parse_resume.py
@@ -9,9 +9,18 @@ from typing import Any
 from pydantic import BaseModel, Field, ValidationError
 
 from resume_operator.prompts.resume_parsing import PARSE_RESUME
-from resume_operator.state import JobDescription, ResumeData, ResumeOptimizerState
+from resume_operator.state import (
+    EducationEntry,
+    ExperienceBullet,
+    ExperienceEntry,
+    JobDescription,
+    Link,
+    ResumeData,
+    ResumeMaster,
+    ResumeOptimizerState,
+    SkillGroup,
+)
 from resume_operator.tools.llm_provider import get_structured_llm
-from resume_operator.tools.master_resume import resume_data_to_master
 from resume_operator.tools.pdf_parser import extract_text
 
 logger = logging.getLogger(__name__)
@@ -26,6 +35,9 @@ class ResumeExperienceLLM(BaseModel):
     # field encouraged the LLM to summarize multiple bullets into one sentence,
     # which defeated the purpose of a structured master resume (see issue #60).
     bullets: list[str] = Field(default_factory=list)
+    # Optional per-role tech stack shown as a `Tech: ...` line on well-built
+    # senior-engineer resumes (#68). Empty list when the source doesn't show one.
+    tech: list[str] = Field(default_factory=list)
 
 
 class ResumeEducationLLM(BaseModel):
@@ -33,6 +45,16 @@ class ResumeEducationLLM(BaseModel):
     school: str = ""
     start_date: str = ""
     end_date: str = ""
+
+
+class ResumeLinkLLM(BaseModel):
+    label: str = ""
+    url: str = ""
+
+
+class ResumeSkillGroupLLM(BaseModel):
+    category: str = ""
+    items: list[str] = Field(default_factory=list)
 
 
 class ResumeLLMOutput(BaseModel):
@@ -43,12 +65,16 @@ class ResumeLLMOutput(BaseModel):
     """
 
     name: str = ""
+    headline: str = ""  # tagline under the name (#68)
     email: str = ""
     phone: str = ""
+    location: str = ""
+    links: list[ResumeLinkLLM] = Field(default_factory=list)  # Portfolio / LinkedIn / GitHub (#68)
     summary: str = ""
     experience: list[ResumeExperienceLLM] = Field(default_factory=list)
     education: list[ResumeEducationLLM] = Field(default_factory=list)
     skills: list[str] = Field(default_factory=list)
+    skill_groups: list[ResumeSkillGroupLLM] = Field(default_factory=list)  # categorised (#68)
     certifications: list[str] = Field(default_factory=list)
 
 
@@ -68,6 +94,62 @@ def _experience_to_dict(entry: ResumeExperienceLLM) -> dict[str, str]:
         "end_date": entry.end_date,
         "description": description,
     }
+
+
+def _build_master_from_llm(parsed: ResumeLLMOutput) -> ResumeMaster:
+    """Build a `ResumeMaster` directly from the LLM output, preserving the new
+    senior-format fields (headline, links, categorised skills, per-role tech)
+    that `resume_data_to_master` can't carry because they don't exist on the
+    legacy `ResumeData` shape (#68).
+    """
+    experience = [
+        ExperienceEntry(
+            id=f"exp-{i + 1}",
+            role=e.role,
+            company=e.company,
+            start_date=e.start_date,
+            end_date=e.end_date,
+            bullets=[
+                ExperienceBullet(id=f"exp-{i + 1}-b{j + 1}", text=b.strip())
+                for j, b in enumerate(e.bullets)
+                if b.strip()
+            ],
+            tech=[t.strip() for t in e.tech if t.strip()],
+        )
+        for i, e in enumerate(parsed.experience)
+    ]
+    education = [
+        EducationEntry(
+            id=f"edu-{i + 1}",
+            degree=ed.degree,
+            school=ed.school,
+            start_date=ed.start_date,
+            end_date=ed.end_date,
+        )
+        for i, ed in enumerate(parsed.education)
+    ]
+    links = [
+        Link(label=link.label, url=link.url) for link in parsed.links if link.url or link.label
+    ]
+    skill_groups = [
+        SkillGroup(category=g.category, items=[s for s in g.items if s])
+        for g in parsed.skill_groups
+        if g.category and g.items
+    ]
+    return ResumeMaster(
+        name=parsed.name,
+        headline=parsed.headline,
+        email=parsed.email,
+        phone=parsed.phone,
+        location=parsed.location,
+        links=links,
+        summary=parsed.summary,
+        experience=experience,
+        education=education,
+        skills=list(parsed.skills),
+        skill_groups=skill_groups,
+        certifications=list(parsed.certifications),
+    )
 
 
 def parse_resume(state: ResumeOptimizerState) -> dict[str, Any]:
@@ -124,10 +206,10 @@ def parse_resume(state: ResumeOptimizerState) -> dict[str, Any]:
         raw_text=raw_text,
     )
     result["resume"] = resume_data
-    # Also synthesize a ResumeMaster with stable IDs so optimize_content (#026) has
-    # a source index even when the user is on the legacy PDF path. `bootstrap` uses
-    # this same conversion to seed a real YAML.
-    result["master"] = resume_data_to_master(resume_data)
+    # Also build a ResumeMaster with stable IDs + the senior-format extras
+    # (headline, links, skill_groups, per-role tech — #68). This path preserves
+    # the new fields that the legacy ResumeData shape can't carry.
+    result["master"] = _build_master_from_llm(parsed)
 
     # --- Read job description ---
     job_raw_text = state.job_description_text

--- a/src/resume_operator/prompts/resume_parsing.py
+++ b/src/resume_operator/prompts/resume_parsing.py
@@ -12,11 +12,31 @@ Rules:
 - Do NOT truncate or merge bullets.
 - Keep the wording close to the source; only fix obvious OCR artifacts.
 
+Top-level fields:
+- `name`, `email`, `phone`, `location`
+- `headline` — a short tagline under the name if the resume shows one
+  (e.g. "Senior Software Engineer · Founding Engineer · Ex-Google"). Empty
+  string if the resume doesn't have a tagline.
+- `summary` — the SUMMARY / PROFILE paragraph.
+- `links` — list of {{label, url}} objects for any Portfolio / LinkedIn /
+  GitHub / personal site links shown in the header.
+
+Skills:
+- `skills` — flat list of every skill mentioned.
+- `skill_groups` — when the resume shows skills categorised (e.g.
+  "Languages & Runtimes: Python, Go" and "Cloud & Infrastructure: AWS,
+  Docker" as separate lines), extract each category as a {{category, items}}
+  group. If the resume's skills are ungrouped, leave `skill_groups` empty
+  and populate only `skills`.
+
 For each experience entry, populate:
 - `role`, `company`
 - `start_date`, `end_date` — as they appear on the resume (e.g. "Aug 2023",
   "Present")
 - `bullets` — one list item per source bullet
+- `tech` — list of technologies shown explicitly as a `Tech: ...` line
+  (or similar) at the bottom of the role's bullets. Empty list if the
+  resume doesn't show one.
 
 For each education entry, populate `degree`, `school`, `start_date`, `end_date`.
 

--- a/src/resume_operator/state.py
+++ b/src/resume_operator/state.py
@@ -36,6 +36,9 @@ class ExperienceEntry(BaseModel):
     start_date: str = ""
     end_date: str = ""
     bullets: list[ExperienceBullet] = Field(default_factory=list)
+    tech: list[str] = Field(default_factory=list)
+    # Per-role tech list rendered as a `Tech: ...` line after the bullets (issue #68).
+    # Optional — empty list means no tech line renders for this role.
 
 
 class EducationEntry(BaseModel):
@@ -50,23 +53,67 @@ class EducationEntry(BaseModel):
     details: str = ""
 
 
+class Link(BaseModel):
+    """A labeled URL on the resume header (Portfolio, LinkedIn, GitHub, …)."""
+
+    label: str
+    url: str
+
+
+class SkillGroup(BaseModel):
+    """A named group of skills rendered as a categorised SKILLS block (#68)."""
+
+    category: str
+    items: list[str] = Field(default_factory=list)
+
+
 class ResumeMaster(BaseModel):
     """Hand-maintained master resume loaded from `master_resume.yaml`.
 
     Source of truth for all downstream pipeline work. Each experience bullet
     and entry carries a stable ID so tailoring (#026) can reference items
     deterministically.
+
+    Fields added in #68 are all optional — existing `master_resume.yaml`
+    files without them still load and render:
+      - `headline` — tagline under the name
+      - `links` — portfolio / LinkedIn / GitHub, shown on a second contact line
+      - `skill_groups` — categorised skills; when non-empty it wins over the
+        flat `skills` list for rendering (but `skills` is still consulted by
+        the source_index so the tailor's fabrication guard keeps working)
     """
 
     name: str = ""
+    headline: str = ""
     email: str = ""
     phone: str = ""
     location: str = ""
+    links: list[Link] = Field(default_factory=list)
     summary: str = ""
     experience: list[ExperienceEntry] = Field(default_factory=list)
     education: list[EducationEntry] = Field(default_factory=list)
     skills: list[str] = Field(default_factory=list)
+    skill_groups: list[SkillGroup] = Field(default_factory=list)
     certifications: list[str] = Field(default_factory=list)
+
+    def all_skills(self) -> list[str]:
+        """Every skill on this master, flattened across `skills` + `skill_groups`.
+
+        Used by `source_index` so categorised skills keep producing the same
+        `master:skill:<name>` IDs the tailor already validates against.
+        """
+        seen: set[str] = set()
+        flat: list[str] = []
+        for name in self.skills:
+            if name and name not in seen:
+                seen.add(name)
+                flat.append(name)
+        for group in self.skill_groups:
+            for name in group.items:
+                if name and name not in seen:
+                    seen.add(name)
+                    flat.append(name)
+        return flat
 
 
 class FactItem(BaseModel):

--- a/src/resume_operator/tools/pdf_generator.py
+++ b/src/resume_operator/tools/pdf_generator.py
@@ -258,9 +258,12 @@ def _render_default(master: ResumeMaster, plan: _RenderPlan, frame_width: float)
     styles = _default_styles()
     flowables: list[object] = []
 
-    # --- Header: name banner + accent rule + contact line ---
+    # --- Header: name → tagline → accent rule → contact → links ---
     if master.name:
         flowables.append(Paragraph(escape(_sanitize_for_pdf(master.name)), styles["name"]))
+    # Tagline sits between name and rule so name+tagline feel like one block (#68).
+    if master.headline:
+        flowables.append(Paragraph(escape(_sanitize_for_pdf(master.headline)), styles["headline"]))
     flowables.append(
         HRFlowable(
             width="100%",
@@ -275,6 +278,15 @@ def _render_default(master: ResumeMaster, plan: _RenderPlan, frame_width: float)
     ]
     if contact_parts:
         flowables.append(Paragraph(escape("  ·  ".join(contact_parts)), styles["contact"]))
+    # Second contact line for portfolio / LinkedIn / GitHub when present (#68).
+    if master.links:
+        link_parts = [
+            _sanitize_for_pdf(f"{lk.label}: {lk.url}" if lk.label else lk.url)
+            for lk in master.links
+            if lk.url or lk.label
+        ]
+        if link_parts:
+            flowables.append(Paragraph(escape("  ·  ".join(link_parts)), styles["contact"]))
 
     # --- Summary ---
     if plan.summary:
@@ -296,6 +308,11 @@ def _render_default(master: ResumeMaster, plan: _RenderPlan, frame_width: float)
                 flowables.append(_role_row(role, styles, frame_width))
             for bullet in bullets:
                 flowables.append(Paragraph(_bullet(bullet), styles["bullet"]))
+            # Per-role tech line (#68). Sits right under the bullets as a dim italic
+            # summary — ATS keyword bonus + recruiter skim aid.
+            if role is not None and role.tech:
+                tech_str = "Tech: " + ", ".join(role.tech)
+                flowables.append(Paragraph(escape(_sanitize_for_pdf(tech_str)), styles["tech"]))
             flowables.append(Spacer(1, 0.05 * inch))
         # Virtual buckets ("projects", "extras") not tied to a master role.
         for virtual_id, bullets in plan.experience_by_role.items():
@@ -309,7 +326,31 @@ def _render_default(master: ResumeMaster, plan: _RenderPlan, frame_width: float)
             flowables.append(Spacer(1, 0.05 * inch))
 
     # --- Skills ---
-    if plan.skills:
+    # When the master has `skill_groups`, render grouped (one line per category,
+    # bolded category label + comma-separated items). Otherwise fall back to the
+    # flat `·`-separated line (#68 back-compat).
+    tailored_skills_set = {s for s in plan.skills}
+    visible_groups: list[tuple[str, list[str]]] = []
+    for group in master.skill_groups:
+        # Only include items that survived tailoring (were kept/reworded into plan.skills).
+        # If plan.skills is empty (e.g. the tailor didn't return skill items), fall
+        # through to the flat path below.
+        if tailored_skills_set:
+            filtered = [s for s in group.items if s in tailored_skills_set]
+        else:
+            filtered = list(group.items)
+        if filtered:
+            visible_groups.append((group.category, filtered))
+
+    if visible_groups:
+        flowables.extend(_section_header("SKILLS", frame_width))
+        for category, items in visible_groups:
+            sanitized_items = [_sanitize_for_pdf(i) for i in items]
+            line = f"<b>{escape(_sanitize_for_pdf(category))}:</b> " + escape(
+                ", ".join(sanitized_items)
+            )
+            flowables.append(Paragraph(line, styles["body"]))
+    elif plan.skills:
         flowables.extend(_section_header("SKILLS", frame_width))
         sanitized_skills = [_sanitize_for_pdf(s) for s in plan.skills]
         flowables.append(Paragraph(escape("  ·  ".join(sanitized_skills)), styles["body"]))
@@ -354,6 +395,15 @@ def _default_styles() -> dict[str, ParagraphStyle]:
             spaceAfter=0,
             alignment=0,
         ),
+        "headline": ParagraphStyle(
+            "Headline",
+            parent=base["BodyText"],
+            fontName="Helvetica",
+            fontSize=11,
+            leading=14,
+            textColor=_ACCENT,
+            spaceAfter=2,
+        ),
         "contact": ParagraphStyle(
             "Contact",
             parent=base["BodyText"],
@@ -361,7 +411,18 @@ def _default_styles() -> dict[str, ParagraphStyle]:
             fontSize=9.5,
             leading=12,
             textColor=_MUTED_GREY,
-            spaceAfter=8,
+            spaceAfter=2,
+        ),
+        "tech": ParagraphStyle(
+            "Tech",
+            parent=base["BodyText"],
+            fontName="Helvetica-Oblique",
+            fontSize=9,
+            leading=12,
+            textColor=_MUTED_GREY,
+            leftIndent=14,
+            spaceBefore=2,
+            spaceAfter=2,
         ),
         "section": ParagraphStyle(
             "Section",

--- a/src/resume_operator/tools/source_index.py
+++ b/src/resume_operator/tools/source_index.py
@@ -65,7 +65,9 @@ def build_source_index(master: ResumeMaster, facts: FactsBank | None) -> SourceI
         text = f"{edu.degree} — {edu.school}".strip(" —")
         _add(idx, f"master:{edu.id}", text, "education")
 
-    for skill in master.skills:
+    # #68: skill groups and the legacy flat list both get flattened into the
+    # index so tailor fabrication-guard IDs stay `master:skill:<name>` either way.
+    for skill in master.all_skills():
         _add(idx, f"master:skill:{skill}", skill, "skill")
 
     for cert in master.certifications:

--- a/tests/test_parse_resume.py
+++ b/tests/test_parse_resume.py
@@ -181,3 +181,73 @@ class TestParseResume:
 
         assert "errors" in result
         assert any("resume_path is empty" in e for e in result["errors"])
+
+
+class TestSeniorFormatExtraction:
+    """`_build_master_from_llm` must propagate the #68 optional fields
+    (headline, links, skill_groups, per-role tech) through to the
+    `ResumeMaster` instead of letting them get dropped in translation."""
+
+    @patch("resume_operator.nodes.parse_resume.get_structured_llm")
+    @patch("resume_operator.nodes.parse_resume.extract_text")
+    def test_extracts_all_senior_fields(
+        self, mock_extract: MagicMock, mock_get_llm: MagicMock, base_state: ResumeOptimizerState
+    ) -> None:
+        mock_extract.return_value = SAMPLE_RESUME_TEXT
+        rich_output = ResumeLLMOutput.model_validate(
+            {
+                "name": "Jane Smith",
+                "headline": "Senior Engineer · Founding Engineer · Ex-Google",
+                "email": "jane@example.com",
+                "location": "SF",
+                "links": [
+                    {"label": "GitHub", "url": "github.com/jsmith"},
+                    {"label": "LinkedIn", "url": "linkedin.com/in/jane"},
+                ],
+                "experience": [
+                    {
+                        "role": "Senior Engineer",
+                        "company": "Acme",
+                        "start_date": "2021",
+                        "end_date": "present",
+                        "bullets": ["Shipped it"],
+                        "tech": ["Python", "Docker"],
+                    }
+                ],
+                "skill_groups": [
+                    {"category": "Languages", "items": ["Python", "Go"]},
+                    {"category": "Cloud", "items": ["AWS"]},
+                ],
+            }
+        )
+        mock_get_llm.return_value = _make_llm(rich_output)
+
+        result = parse_resume(base_state)
+        master = result["master"]
+
+        assert master.headline.startswith("Senior Engineer")
+        assert [lk.label for lk in master.links] == ["GitHub", "LinkedIn"]
+        assert master.experience[0].tech == ["Python", "Docker"]
+        assert len(master.skill_groups) == 2
+        assert master.skill_groups[0].category == "Languages"
+        assert master.skill_groups[0].items == ["Python", "Go"]
+        # `all_skills()` flattens across flat + groups for the source_index path.
+        assert set(master.all_skills()) == {"Python", "Go", "AWS"}
+
+    @patch("resume_operator.nodes.parse_resume.get_structured_llm")
+    @patch("resume_operator.nodes.parse_resume.extract_text")
+    def test_missing_senior_fields_defaults_to_empty(
+        self, mock_extract: MagicMock, mock_get_llm: MagicMock, base_state: ResumeOptimizerState
+    ) -> None:
+        """When the source PDF doesn't have a tagline / links / tech / groups,
+        the master stays valid — fields just default to empty."""
+        mock_extract.return_value = SAMPLE_RESUME_TEXT
+        mock_get_llm.return_value = _make_llm(VALID_OUTPUT)
+
+        result = parse_resume(base_state)
+        master = result["master"]
+
+        assert master.headline == ""
+        assert master.links == []
+        assert master.skill_groups == []
+        assert all(e.tech == [] for e in master.experience)

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -9,7 +9,9 @@ from resume_operator.state import (
     EducationEntry,
     ExperienceBullet,
     ExperienceEntry,
+    Link,
     ResumeMaster,
+    SkillGroup,
     TailoredItem,
     TailoredResume,
 )
@@ -330,3 +332,150 @@ class TestTailoredSummaryRender:
         # Raw exotic chars must not survive into the rendered text stream.
         assert "‑" not in text
         assert "→" not in text
+
+
+class TestSeniorFormatFields:
+    """Coverage for the four #68 additions — headline, links, tech line, grouped skills.
+
+    All four fields are optional on `ResumeMaster`; an older YAML without any of
+    them still renders through the legacy fallbacks. The tests exercise both the
+    populated and empty paths.
+    """
+
+    def _base_master(self) -> ResumeMaster:
+        return ResumeMaster(
+            name="Jane Smith",
+            email="jane@example.com",
+            experience=[
+                ExperienceEntry(
+                    id="exp-1",
+                    role="Senior Engineer",
+                    company="Acme",
+                    bullets=[ExperienceBullet(id="exp-1-b1", text="Shipped it")],
+                )
+            ],
+            education=[EducationEntry(id="edu-1", degree="BS CS", school="State U")],
+            skills=["Python", "AWS"],
+        )
+
+    def _base_tailored(self) -> TailoredResume:
+        return TailoredResume(
+            items=[
+                TailoredItem(
+                    source_id="master:exp-1-b1", action="keep", original_text="Shipped it"
+                ),
+                TailoredItem(
+                    source_id="master:skill:Python", action="keep", original_text="Python"
+                ),
+                TailoredItem(source_id="master:skill:AWS", action="keep", original_text="AWS"),
+            ]
+        )
+
+    def test_headline_renders_under_name(self, tmp_path: Path) -> None:
+        master = self._base_master()
+        master.headline = "Senior Engineer · Founding Engineer · Ex-Google"
+        output = tmp_path / "resume.pdf"
+        generate_pdf(master, self._base_tailored(), output)
+
+        with fitz.open(output) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+        assert "Senior Engineer · Founding Engineer · Ex-Google" in text
+        # Headline sits between name and contact in the rendered text stream.
+        name_pos = text.index("Jane Smith")
+        headline_pos = text.index("Ex-Google")
+        contact_pos = text.index("jane@example.com")
+        assert name_pos < headline_pos < contact_pos
+
+    def test_empty_headline_silent(self, tmp_path: Path) -> None:
+        """No headline means no headline line rendered — not even an empty paragraph."""
+        master = self._base_master()
+        assert master.headline == ""  # default
+        output = tmp_path / "resume.pdf"
+        generate_pdf(master, self._base_tailored(), output)
+
+        with fitz.open(output) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+        # Contact line should land directly after name.
+        assert text.index("Jane Smith") < text.index("jane@example.com")
+
+    def test_links_render_as_second_contact_line(self, tmp_path: Path) -> None:
+        master = self._base_master()
+        master.links = [
+            Link(label="GitHub", url="github.com/jsmith"),
+            Link(label="LinkedIn", url="linkedin.com/in/jane-smith"),
+        ]
+        output = tmp_path / "resume.pdf"
+        generate_pdf(master, self._base_tailored(), output)
+
+        with fitz.open(output) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+        assert "GitHub: github.com/jsmith" in text
+        assert "LinkedIn: linkedin.com/in/jane-smith" in text
+
+    def test_tech_line_renders_after_bullets(self, tmp_path: Path) -> None:
+        master = self._base_master()
+        master.experience[0].tech = ["Python", "Django", "Docker"]
+        output = tmp_path / "resume.pdf"
+        generate_pdf(master, self._base_tailored(), output)
+
+        with fitz.open(output) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+        # The `Tech:` line must appear in the rendered text and come after
+        # the role bullet, not before.
+        assert "Tech: Python, Django, Docker" in text
+        bullet_pos = text.index("Shipped it")
+        tech_pos = text.index("Tech: Python, Django, Docker")
+        assert bullet_pos < tech_pos
+
+    def test_empty_tech_silent(self, tmp_path: Path) -> None:
+        master = self._base_master()
+        assert master.experience[0].tech == []
+        output = tmp_path / "resume.pdf"
+        generate_pdf(master, self._base_tailored(), output)
+
+        with fitz.open(output) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+        assert "Tech:" not in text
+
+    def test_skill_groups_render_categorised(self, tmp_path: Path) -> None:
+        master = self._base_master()
+        master.skill_groups = [
+            SkillGroup(category="Languages", items=["Python", "Go"]),
+            SkillGroup(category="Cloud", items=["AWS", "Docker"]),
+        ]
+        master.skills = ["Python", "Go", "AWS", "Docker"]  # match tailored-plan skills
+        tailored = TailoredResume(
+            items=[
+                TailoredItem(source_id="master:exp-1-b1", action="keep", original_text="x"),
+                TailoredItem(
+                    source_id="master:skill:Python", action="keep", original_text="Python"
+                ),
+                TailoredItem(source_id="master:skill:Go", action="keep", original_text="Go"),
+                TailoredItem(source_id="master:skill:AWS", action="keep", original_text="AWS"),
+                TailoredItem(
+                    source_id="master:skill:Docker", action="keep", original_text="Docker"
+                ),
+            ]
+        )
+        output = tmp_path / "resume.pdf"
+        generate_pdf(master, tailored, output)
+
+        with fitz.open(output) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+        # Categories render as labelled lines.
+        assert "Languages: Python, Go" in text
+        assert "Cloud: AWS, Docker" in text
+
+    def test_skill_groups_fallback_to_flat_when_empty(self, tmp_path: Path) -> None:
+        """Master without skill_groups falls back to the flat `·`-separated line
+        (back-compat with pre-#68 YAMLs)."""
+        master = self._base_master()
+        assert master.skill_groups == []  # default
+        output = tmp_path / "resume.pdf"
+        generate_pdf(master, self._base_tailored(), output)
+
+        with fitz.open(output) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+        assert "Python · AWS" in text
+        # No category label appears.
+        assert "Languages:" not in text

--- a/tests/test_source_index.py
+++ b/tests/test_source_index.py
@@ -1,0 +1,84 @@
+"""Tests for `tools.source_index`.
+
+The index is the tailor's fabrication-guard input — it has to keep producing
+stable `master:skill:<name>` IDs regardless of whether skills on the master
+are flat or categorised (#68).
+"""
+
+from __future__ import annotations
+
+from resume_operator.state import (
+    EducationEntry,
+    ExperienceBullet,
+    ExperienceEntry,
+    FactsBank,
+    ResumeMaster,
+    SkillGroup,
+)
+from resume_operator.tools.source_index import build_source_index
+
+
+def _minimal_master(**overrides: object) -> ResumeMaster:
+    base = ResumeMaster(
+        name="Jane",
+        experience=[
+            ExperienceEntry(
+                id="exp-1",
+                role="Engineer",
+                company="Acme",
+                bullets=[ExperienceBullet(id="exp-1-b1", text="Did things")],
+            )
+        ],
+        education=[EducationEntry(id="edu-1", degree="BS CS", school="State U")],
+    )
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+class TestSkillIndexing:
+    def test_flat_skills_indexed(self) -> None:
+        master = _minimal_master(skills=["Python", "AWS"])
+        idx = build_source_index(master, None)
+        assert "master:skill:Python" in idx
+        assert "master:skill:AWS" in idx
+
+    def test_skill_groups_flatten_to_same_ids(self) -> None:
+        """Categorised skills still index as `master:skill:<name>` — the tailor
+        shouldn't need to know whether the master is grouped or flat."""
+        master = _minimal_master(
+            skill_groups=[
+                SkillGroup(category="Languages", items=["Python", "Go"]),
+                SkillGroup(category="Cloud", items=["AWS", "Docker"]),
+            ]
+        )
+        idx = build_source_index(master, None)
+        for name in ("Python", "Go", "AWS", "Docker"):
+            assert f"master:skill:{name}" in idx
+
+    def test_flat_and_grouped_dedupe(self) -> None:
+        """A skill present in both `skills` and `skill_groups` should only index
+        once — same ID, same entry."""
+        master = _minimal_master(
+            skills=["Python", "Go"],
+            skill_groups=[SkillGroup(category="Languages", items=["Python", "Rust"])],
+        )
+        idx = build_source_index(master, None)
+        # Three unique skills total: Python, Go (flat) + Rust (group).
+        skill_ids = [i for i in idx.entries if i.startswith("master:skill:")]
+        assert sorted(skill_ids) == [
+            "master:skill:Go",
+            "master:skill:Python",
+            "master:skill:Rust",
+        ]
+
+
+class TestFactsBankPassthrough:
+    def test_facts_skills_still_indexed_separately(self) -> None:
+        """facts_bank skills continue to index under `facts:skill:<name>` —
+        unchanged by #68."""
+        master = _minimal_master(skills=["Python"])
+        facts = FactsBank(skills_beyond_master=["Docker"])
+        idx = build_source_index(master, facts)
+        assert "master:skill:Python" in idx
+        assert "facts:skill:Docker" in idx


### PR DESCRIPTION
## Summary

Four additive fields on \`ResumeMaster\` to match senior-engineer CV conventions (inspired by Andy Wang's CV in \`input/andy-wang-cv.docx\`):

1. **\`headline: str\`** — tagline under the name (e.g. \`Senior Software Engineer · Founding Engineer · Ex-Google\`). Renders in the accent colour between name and the accent rule.
2. **\`links: list[Link]\`** — structured Portfolio/LinkedIn/GitHub; renders as a second muted contact line.
3. **\`skill_groups: list[SkillGroup]\`** — categorised skills (Languages / Frontend / Backend / Cloud). When non-empty, SKILLS renders as \`<b>Category:</b> item, item, item\` per line; falls back to flat \`·\`-separated when empty.
4. **\`ExperienceEntry.tech: list[str]\`** — per-role tech stack rendered as a dim italic \`Tech: A, B, C\` line after each role's bullets.

All four optional; existing \`master_resume.yaml\` files without them render via legacy fallbacks. The bootstrap prompt asks the LLM to extract them when present in the source PDF.

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/68. After the #66 typography work, the remaining gap against a well-built senior CV was structural — no tagline hook, flat skill dump, no per-role tech keywords, no structured header links. All four are what recruiters expect on senior-engineer resumes. The tradeoff was one meatier PR (schema changes on \`ResumeMaster\` + bootstrap + render + example YAML) vs. stopping halfway and leaving the layout inconsistent. Bundled together.

## How the tailor keeps working

- \`source_index\` calls the new \`master.all_skills()\` helper that flattens flat \`skills\` + categorised \`skill_groups\` into one deduped list. Every skill still indexes as \`master:skill:<name>\` regardless of whether the master is grouped or flat — the tailor's fabrication guard doesn't need to know.
- \`state.resume\` (legacy \`ResumeData\`) is unchanged and still works for ats_score / analyze_gaps. The senior-format extras live only on \`state.master\`.
- A new \`_build_master_from_llm\` helper in \`parse_resume.py\` constructs \`ResumeMaster\` directly from the LLM output (instead of routing through \`resume_data_to_master\`), because the legacy \`ResumeData\` has no slots for the new fields.

## Proof on real inputs

Real-run against the refreshed \`input/master_resume.example.yaml\` extracted text:

\`\`\`
Jane Smith
Senior Software Engineer · Founding Engineer · Ex-Acme
jane.smith@example.com · +1 555 123 4567 · San Francisco, CA
Portfolio: https://janesmith.example · LinkedIn: linkedin.com/in/jane-smith · GitHub: github.com/jsmith
SUMMARY
…
EXPERIENCE
Senior Software Engineer — Acme Corp
Remote · 2021-03 - present
• Led migration of monolith to Go microservices, cutting p99 latency 40%.
• Designed gRPC contracts adopted by 12 teams across the company.
…
Tech: Go, gRPC, Kubernetes, PostgreSQL, Prometheus
Software Engineer — Widget Labs
San Francisco, CA · 2018-06 - 2021-02
• Shipped React dashboard used by 500+ internal operators daily.
…
Tech: TypeScript, React, Playwright, Node.js
SKILLS
Languages & Runtimes: Go, TypeScript, SQL
Frontend & APIs: React, REST
Backend & Data: PostgreSQL, gRPC
Cloud & Infrastructure: AWS, Kubernetes, Docker
EDUCATION
B.S. Computer Science — State University
CERTIFICATIONS
• AWS Certified Solutions Architect (Associate)
\`\`\`

Every #68 addition visible in the expected position. Back-compat also verified against Bruno's real \`data/master_resume.yaml\` (which has no new fields because his source PDF doesn't): the pipeline still renders a valid PDF with flat skills line, no tagline, no second contact line, no tech lines — the additive path.

## Tests

180 total (13 new):
- \`TestSeniorFormatFields\` (7): render paths for all four fields + their empty/fallback cases.
- \`TestSkillIndexing\` (3): flat, grouped, and mixed flat+grouped indexing into \`master:skill:<name>\`.
- \`TestSeniorFormatExtraction\` (2): bootstrap \`_build_master_from_llm\` rich-vs-sparse paths.
- Housekeeping fix: one existing test updated for the new skills-grouping fallback path.

When this PR is merged, the generated PDF format matches what senior-engineer resumes actually look like today — tagline, structured links, categorised skills, per-role tech — without losing back-compat with older YAMLs.