### PR TITLE
feat(bootstrap+tailor): dynamic JD-tailored headline + interactive bootstrap interview

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,11 +97,15 @@ After `ats_score`, a routing function checks the score against `ATS_SKIP_THRESHO
 **Unicode sanitization (#66)**: every string that reaches the renderer passes through `_sanitize_for_pdf` — a boundary-layer that translates exotic Unicode (arrows `→`, non-breaking hyphens `‑`, curly quotes `'"`, horizontal ellipsis `…`) to ASCII and strips zero-width characters. Helvetica (the built-in font) can't render those glyphs, so without sanitization they come out as black `.notdef` boxes. `tailored.yaml` and `facts_bank.yaml` keep the LLM's original text; only the PDF text stream is normalized.
 
 **Senior-format fields (#68)**: `ResumeMaster` carries four optional additions that bring the render closer to senior-engineer CV conventions:
-- `headline` — short tagline under the name (e.g. *"Senior Software Engineer · Founding Engineer · Ex-Google"*)
+- `headline` — static fallback tagline under the name. The renderer prefers the per-JD `TailoredResume.tailored_headline` (#70) when non-empty; `master.headline` only shows when the tailor didn't emit one (e.g. score-only runs).
 - `links` — structured Portfolio/LinkedIn/GitHub rendered as a second contact line
 - `skill_groups` — categorised skills (Languages / Frontend / Backend / Cloud). Flattens into the source_index with the same `master:skill:<name>` IDs, so the tailor's fabrication guard doesn't need to know whether the master is grouped or flat.
 - `ExperienceEntry.tech` — per-role tech stack rendered as a dim `Tech: A, B, C` line after the bullets
-All four are optional; older YAMLs without them fall back gracefully (no headline line, flat skills, no tech line). The bootstrap prompt asks the LLM to extract them when they appear in the source PDF; otherwise they stay empty.
+All four are optional; older YAMLs without them fall back gracefully (no headline line, flat skills, no tech line).
+
+**Bootstrap interview (#70)**: after the LLM parses a resume PDF, `bootstrap` runs an interactive interview asking the user for any senior-format field the LLM couldn't extract (missing headline, URLs for Portfolio/LinkedIn/GitHub, per-role tech stacks, skill categorisation). The interview skips silently when stdin isn't a TTY or when `--no-interview` is passed. For skill grouping, the interview calls a separate LLM via `tools/skill_grouping.propose_groups` that proposes categories from the flat skill list; the user accepts or rejects the whole block.
+
+**Dynamic headline (#70)**: `TailoredResume.tailored_headline` is a fresh JD-crafted tagline written by the optimizer every run, alongside `tailored_summary`. Grounded strictly in master facts (titles, years, companies, tech) — no invented "Ex-Google". Same accept/reject fabrication-safety shape as the summary. When non-empty it replaces `master.headline` in the rendered PDF.
 
 Templates are configured via `RESUME_TEMPLATE` (`default | compact | modern`); only `default` is implemented today, unknown values fall back to default with a warning.
 

--- a/docs/issues/036-dynamic-headline-bootstrap-interview.md
+++ b/docs/issues/036-dynamic-headline-bootstrap-interview.md
@@ -1,0 +1,89 @@
+# [Feature]: Dynamic JD-tailored headline + interactive bootstrap interview
+
+## Description
+
+Two related changes, shipped together:
+
+1. **Dynamic headline per JD.** `master.headline` is a static field today — every application you send gets the same tagline, which defeats the purpose. Mirror the `tailored_summary` pattern: add `TailoredResume.tailored_headline` that the `optimize_content` LLM crafts fresh per run, grounded in master facts. The renderer prefers the tailored headline when set; `master.headline` becomes an optional fallback for score-only runs or when the tailor doesn't emit one.
+
+2. **Bootstrap interview for missing fields.** Parsing a PDF often leaves the senior-format fields (headline, links, per-role tech, skill_groups) empty because the source doesn't have them. Instead of silently dropping to empty and telling the user to hand-edit the YAML, the bootstrap command should *ask* — targeted prompts per missing field, accept/skip per item, LLM-proposed grouping for flat skills with accept/edit/reject UX.
+
+## Motivation
+
+Direct feedback: *"if some fields are empty in the original resume you should ask me while getting master_resume.yaml, and also some of fields should be dynamic item with given job descriptions. for example the highlight text shouldn't be static. it should be dynamic based on the job description."*
+
+The two insights are:
+- **Static headline is wrong by design** — it's prime recruiter real estate on the tailored PDF, so it deserves per-JD crafting just like the summary. A backend JD should see *"Senior Backend Engineer · 10+ years · Node.js, AWS"*; a Web3 JD should see *"Senior Web3 Engineer · Smart Contracts, DeFi"*. Same candidate, different emphasis drawn from the same master facts.
+- **Silent empty fields are a bad UX** — the bootstrap save message says *"review the YAML, edit freely"* but users in practice don't go edit the YAML; they run `run` against the incomplete master and get a flat-looking tailored PDF. Asking at bootstrap time, once per field, gets the facts in before the first tailor.
+
+## Target State
+
+### Dynamic headline
+
+- `TailoredResume.tailored_headline: str` — fresh per-JD tagline, 10-15 words, `·`-separated identity tags.
+- `TailoredResumeLLMOutput.tailored_headline: str` — the LLM returns it alongside `tailored_summary`.
+- `content_optimization.py` prompt gains "Part 0 — Tailored headline" with explicit rules:
+  - Grounded strictly in master facts (current/past roles, years, companies, tech on the master). No invented "Ex-Google" unless Google is on the master.
+  - 10-15 words. 2-4 `·`-separated tags.
+  - ATS-friendly punctuation (the #66 sanitizer already runs at the renderer boundary).
+- PDF renderer: `plan.headline = tailored.tailored_headline or master.headline` — tailored wins when set, master is the fallback.
+- `diff.md` opens with both the tailored headline and tailored summary so the reader can audit them side-by-side.
+
+### Bootstrap interview
+
+- New `tools/bootstrap_interview.py` with `run_bootstrap_interview(master, console) -> ResumeMaster` that mutates the master in place (or returns a new one) based on the user's answers.
+- Runs after `parse_resume_node` returns, before `save_master`. Opt-out via `--no-interview` on the bootstrap command.
+- Skips silently when stdin isn't a TTY (CI / piped runs).
+- Per-field interview logic:
+  - **Headline** — if empty, prompt for a fallback tagline with skip.
+  - **Links** — for each of `Portfolio`, `LinkedIn`, `GitHub` not already present, prompt for URL with skip.
+  - **Per-role tech** — for each `ExperienceEntry` with empty `tech`, prompt *"Tech stack for Senior Engineer at Acme? (comma-separated, or skip)"*.
+  - **Skill groups** — if `skill_groups` empty and `skills` has ≥3 entries, offer LLM-proposed grouping. Accept/reject/edit. On accept, write the groups; on reject, leave flat. Edit is just re-accept after the user tweaks.
+- All prompts display *"skip"* as the default so a user hitting Enter nine times in a row moves through the interview fast.
+
+### Schema additions
+
+- New prompt `prompts/skill_grouping.py` with `PROPOSE_SKILL_GROUPS` template.
+- New tool helper `tools/skill_grouping.py` with `propose_groups(skills) -> list[SkillGroup]` using `with_structured_output`.
+
+## Success Metrics — Verified
+
+Real-run against `data/master_resume.yaml` + `input/job.txt` (Foodsmart
+Staff Backend) with `--no-enrich`:
+
+- `optimize_content: completed — items=77 (kept=71, reworded=2, dropped=4), fabricated_rejected=0, notes=1, summary=yes, headline=yes`
+- Rendered PDF's tagline reads: *"Backend Software Engineer · 8+ years · Node.js, TypeScript, AWS"* — JD-weighted (Foodsmart asks for backend; the tailor led with that), grounded in facts from the master (8+ years, Node.js, TypeScript, AWS all on the skills list). The user's static master has no `headline` at all, so this is pure tailor output.
+- Running against a different JD (e.g. a frontend role) would produce a different tagline from the same master — verified manually by varying the JD text and inspecting the output.
+
+Bootstrap interview: behaviour pinned by 13 new unit tests covering each
+branch (headline-empty vs pre-set, link prompting order, per-role tech
+prompting, skill-grouping accept/reject/too-few-skills, LLM failure
+fallback, `--no-interview` flag, no-TTY auto-skip).
+
+Test coverage: 200 total, 20 new vs pre-#70 baseline.
+
+## The Change
+
+By the end of this issue, the bootstrap command becomes a two-stage action: LLM parses the PDF into the mechanical structure, then asks the user for the things the LLM can't extract (URLs, categorisation, tech stacks). And the tailored PDF's tagline is no longer a static field the user sets once — it's rewritten per application, pulling the JD-most-relevant pieces of the master into the header.
+
+## Key Files
+
+- `src/resume_operator/state.py` — `TailoredResume.tailored_headline`
+- `src/resume_operator/nodes/optimize_content.py` — LLM schema + projection
+- `src/resume_operator/prompts/content_optimization.py` — Part 0 rules
+- `src/resume_operator/tools/pdf_generator.py` — `plan.headline` preference
+- `src/resume_operator/tools/diff_renderer.py` — surface tailored headline
+- `src/resume_operator/prompts/skill_grouping.py` (new)
+- `src/resume_operator/tools/skill_grouping.py` (new)
+- `src/resume_operator/tools/bootstrap_interview.py` (new)
+- `src/resume_operator/main.py` — bootstrap command wiring + `--no-interview`
+- `tests/test_optimize_content.py`, `tests/test_pdf_generator.py`, `tests/test_bootstrap_interview.py` (new)
+
+## Dependencies
+
+- #66 (tailored_summary — same pattern re-used)
+- #68 (senior-format fields — this PR makes the static ones interactive)
+
+## Labels
+
+`enhancement`, `priority:high`

--- a/src/resume_operator/main.py
+++ b/src/resume_operator/main.py
@@ -384,16 +384,28 @@ def bootstrap(
     output: Path = typer.Option(
         Path("data/master_resume.yaml"), "--output", "-o", help="Output master_resume.yaml path"
     ),
+    no_interview: bool = typer.Option(
+        False,
+        "--no-interview",
+        help=(
+            "Skip the post-parse interview that asks for missing senior-format "
+            "fields (headline, links, per-role tech, skill groups). Useful for "
+            "scripted or CI runs."
+        ),
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable debug logging"),
 ) -> None:
     """One-time: parse a resume PDF via LLM and write a hand-editable `master_resume.yaml`.
 
-    This is the only command that calls the LLM to ingest a resume. From then on,
-    `run --master` uses the YAML directly.
+    After the LLM parse, walks an interactive interview asking for any
+    senior-format fields the source PDF didn't carry (headline, Portfolio /
+    LinkedIn / GitHub URLs, per-role tech stacks, categorised skill groups).
+    Pass `--no-interview` to skip the interview entirely.
     """
     from resume_operator.nodes.parse_resume import parse_resume as parse_resume_node
-    from resume_operator.state import ResumeOptimizerState
-    from resume_operator.tools.master_resume import resume_data_to_master, save_master
+    from resume_operator.state import ResumeMaster, ResumeOptimizerState
+    from resume_operator.tools.bootstrap_interview import run_interview, should_run_interview
+    from resume_operator.tools.master_resume import save_master
 
     _setup_logging(verbose)
     _validate_resume(resume)
@@ -412,16 +424,25 @@ def bootstrap(
             console.print(f"[red]{error}[/red]")
         raise typer.Exit(code=1)
 
-    resume_data: ResumeData = result["resume"]
-    master = resume_data_to_master(resume_data)
+    master: ResumeMaster = result["master"]
+
+    # Interactive post-parse interview (#70) — fill in the senior-format fields
+    # the LLM couldn't extract from the source PDF (URLs, per-role tech, skill
+    # groupings, fallback headline).
+    if should_run_interview(no_interview=no_interview):
+        master = run_interview(master, console=console)
+
     save_master(master, output)
 
+    headline_status = "set" if master.headline else "empty (tailor writes one per JD)"
     console.print(
         Panel(
             f"[bold]Wrote:[/bold] {output}\n"
             f"[bold]Experience entries:[/bold] {len(master.experience)}\n"
             f"[bold]Education entries:[/bold] {len(master.education)}\n"
-            f"[bold]Skills:[/bold] {len(master.skills)}\n\n"
+            f"[bold]Skills:[/bold] {len(master.all_skills())}\n"
+            f"[bold]Links:[/bold] {len(master.links)}\n"
+            f"[bold]Headline:[/bold] {headline_status}\n\n"
             f"[yellow]Review the YAML, edit freely, and keep it under version control.[/yellow]",
             title="Master resume bootstrapped",
             border_style="green",

--- a/src/resume_operator/nodes/optimize_content.py
+++ b/src/resume_operator/nodes/optimize_content.py
@@ -40,6 +40,7 @@ class TailoredItemLLM(BaseModel):
 
 class TailoredResumeLLMOutput(BaseModel):
     tailored_summary: str = ""  # fresh JD-crafted SUMMARY text — not sourced from the items list
+    tailored_headline: str = ""  # fresh JD-crafted tagline under the name (#70)
     items: list[TailoredItemLLM] = Field(default_factory=list)
     notes: list[str] = Field(default_factory=list)
 
@@ -86,12 +87,13 @@ def optimize_content(state: ResumeOptimizerState) -> dict[str, Any]:
         items=validated_items,
         notes=list(parsed.notes),
         tailored_summary=parsed.tailored_summary.strip(),
+        tailored_headline=parsed.tailored_headline.strip(),
     )
     optimized_legacy = _project_to_sections(tailored, index)
 
     logger.info(
         "optimize_content: completed — items=%d (kept=%d, reworded=%d, dropped=%d), "
-        "fabricated_rejected=%d, notes=%d, summary=%s",
+        "fabricated_rejected=%d, notes=%d, summary=%s, headline=%s",
         len(tailored.items),
         sum(1 for i in tailored.items if i.action == "keep"),
         sum(1 for i in tailored.items if i.action == "reword"),
@@ -99,6 +101,7 @@ def optimize_content(state: ResumeOptimizerState) -> dict[str, Any]:
         len(rejected),
         len(tailored.notes),
         "yes" if tailored.tailored_summary else "no",
+        "yes" if tailored.tailored_headline else "no",
     )
 
     result: dict[str, Any] = {

--- a/src/resume_operator/prompts/content_optimization.py
+++ b/src/resume_operator/prompts/content_optimization.py
@@ -2,7 +2,21 @@
 
 OPTIMIZE_CONTENT = """You are tailoring a candidate's resume for a specific job.
 
-Your job has two parts:
+Your job has three parts:
+
+### Part 0 — Tailored headline
+
+Write a short JD-weighted tagline that sits directly under the candidate's
+name on the tailored resume. Rules:
+- 10-15 words max. 2-4 identity tags separated by ` · ` (space, middle dot,
+  space). Example shape: "Senior Backend Engineer · 10+ years · Node.js, AWS".
+- Grounded STRICTLY in master facts — titles the candidate actually held,
+  years they can show, companies they actually worked at, tech the master
+  lists. Do NOT invent "Ex-Google" unless Google is on the master. Do NOT
+  invent years or specialisations.
+- Weighted toward the JD. A backend JD should yield a backend-leaning
+  headline; an AI role should surface AI/ML tags the master supports.
+- Return as the `tailored_headline` field of the output.
 
 ### Part 1 — Tailored summary
 
@@ -35,6 +49,7 @@ item whose `source_id` is not in this menu will be rejected.
 ### Output schema
 
 Return a `TailoredResumeLLMOutput` with:
+- `tailored_headline` — the tagline from Part 0 (string)
 - `tailored_summary` — the fresh summary from Part 1 (string)
 - `items` — list of per-item decisions (see below); do NOT include a
   `master:summary` entry here.
@@ -53,10 +68,14 @@ specific JD.
 
 ### Output style
 
-Use plain ASCII punctuation in `tailored_summary` and `new_text`:
+Use plain ASCII punctuation in `tailored_headline`, `tailored_summary` and
+`new_text`:
 - Hyphens (`-`), not en-dashes or non-breaking hyphens
 - Straight quotes (`"` and `'`), not curly
 - `->` instead of `→`; `...` instead of `…`
-The rendered PDF's default font doesn't carry those exotic glyphs and would
+- The one exception: in `tailored_headline`, use the middle-dot `·` (U+00B7)
+  between tags. That character IS in the renderer's font.
+
+The rendered PDF's default font doesn't carry exotic Unicode glyphs and would
 render them as black boxes; keep the wording portable.
 """

--- a/src/resume_operator/prompts/skill_grouping.py
+++ b/src/resume_operator/prompts/skill_grouping.py
@@ -1,0 +1,25 @@
+"""Prompt template for proposing a skill-group categorization from a flat list."""
+
+PROPOSE_SKILL_GROUPS = """Given a software engineer's flat list of skills,
+propose a reasonable grouping by category. Use these canonical buckets (only
+include ones that have items):
+
+  - Languages & Runtimes
+  - Frontend & APIs
+  - Backend & Data
+  - Cloud & Infrastructure
+  - AI / ML
+  - Tools & DevOps
+
+Rules:
+- Every skill in the input MUST appear in exactly one group.
+- Do NOT invent skills that aren't in the input.
+- Drop categories that would have no items — don't emit empty groups.
+- Preserve the original capitalization of each skill (e.g. "PostgreSQL" not
+  "postgresql").
+- If a skill is ambiguous (e.g. "Docker" fits both Backend and Cloud),
+  prefer the more specific category.
+
+Flat skills list:
+{skills}
+"""

--- a/src/resume_operator/state.py
+++ b/src/resume_operator/state.py
@@ -204,15 +204,15 @@ class TailoredResume(BaseModel):
     """Structured tailored output — a list of per-item decisions, not free-form text.
 
     `tailored_summary` is a dedicated JD-crafted 2-3 sentence opener (issue #66).
-    When non-empty, the renderer uses it for the SUMMARY section instead of a
-    kept/reworded `master:summary` item — recruiters read the summary first,
-    so it deserves a fresh pass targeted at *this* JD rather than a rephrase
-    of the generic master summary.
+    `tailored_headline` is the JD-crafted tagline under the name (issue #70).
+    Both are free-form fields filled by `optimize_content` per run; the renderer
+    prefers them over the static master equivalents when non-empty.
     """
 
     items: list[TailoredItem] = Field(default_factory=list)
     notes: list[str] = Field(default_factory=list)
     tailored_summary: str = ""
+    tailored_headline: str = ""
 
     def kept_or_reworded(self) -> list[TailoredItem]:
         return [i for i in self.items if i.action in {"keep", "reword"}]

--- a/src/resume_operator/tools/bootstrap_interview.py
+++ b/src/resume_operator/tools/bootstrap_interview.py
@@ -1,0 +1,171 @@
+"""Interactive post-bootstrap interview (#70).
+
+After the LLM parses the PDF into a `ResumeMaster`, many of the senior-format
+fields (headline, links, per-role tech, skill_groups) end up empty because the
+source resume didn't carry them explicitly. Instead of silently leaving them
+empty and telling the user to hand-edit the YAML, ask — one targeted prompt
+per missing field, `skip` as the default, LLM-proposed skill grouping with
+accept/reject UX.
+
+The interview runs only when stdin is a TTY and the user hasn't opted out via
+`--no-interview`. Headless/scripted runs pass through unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import TYPE_CHECKING, Any
+
+from resume_operator.state import Link, ResumeMaster, SkillGroup
+from resume_operator.tools.skill_grouping import propose_groups
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+logger = logging.getLogger(__name__)
+
+# Standard link labels we always offer at interview time. The user's own master
+# can carry any labels; these are just the common ones we prompt for by default.
+_STANDARD_LINK_LABELS = ("Portfolio", "LinkedIn", "GitHub")
+
+# Skip the skill-grouping prompt for tiny skill lists (not worth the LLM call
+# or the user's attention).
+_SKILL_GROUPING_MIN = 3
+
+
+def should_run_interview(*, no_interview: bool) -> bool:
+    """True when the interview should actually prompt the user.
+
+    False when the user opted out explicitly, or when stdin is piped (CI,
+    `echo ... | bootstrap`, etc.) — we never block on prompts in those cases.
+    """
+    if no_interview:
+        return False
+    return sys.stdin.isatty()
+
+
+def run_interview(master: ResumeMaster, console: Console | None = None) -> ResumeMaster:
+    """Walk the user through the missing senior-format fields and fill them in.
+
+    Returns the (possibly mutated) master. Safe to call with `no-interview`
+    already filtered out upstream via `should_run_interview`.
+    """
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.prompt import Confirm, Prompt
+
+    active = console if console is not None else Console()
+    active.print(
+        Panel(
+            "Bootstrap parsed your PDF. A few fields couldn't be extracted "
+            "because the source doesn't show them explicitly. Answer the prompts "
+            "below (or hit Enter to skip each) and I'll stitch them into "
+            "your master_resume.yaml.",
+            title="Bootstrap interview",
+            border_style="cyan",
+        )
+    )
+
+    _ask_headline(master, active, Prompt)
+    _ask_links(master, active, Prompt)
+    _ask_per_role_tech(master, active, Prompt)
+    _ask_skill_groups(master, active, Prompt, Confirm)
+
+    return master
+
+
+def _ask_headline(master: ResumeMaster, console: Console, Prompt: Any) -> None:  # noqa: N803
+    if master.headline:
+        return
+    console.print("\n[bold cyan]Headline[/bold cyan] — a 10-15 word tagline under your name.")
+    console.print(
+        '[dim]Example: "Senior Backend Engineer · 10+ years · Node.js, AWS". '
+        "This is a fallback — the tailor also writes a JD-specific headline per "
+        "run. Type 'skip' to leave empty.[/dim]"
+    )
+    answer = Prompt.ask("[bold]>[/bold]", default="skip", console=console)
+    cleaned = answer.strip()
+    if cleaned and cleaned.lower() != "skip":
+        master.headline = cleaned
+
+
+def _ask_links(master: ResumeMaster, console: Console, Prompt: Any) -> None:  # noqa: N803
+    existing_labels = {lk.label.lower() for lk in master.links}
+    missing = [label for label in _STANDARD_LINK_LABELS if label.lower() not in existing_labels]
+    if not missing:
+        return
+    console.print(
+        "\n[bold cyan]Header links[/bold cyan] — Portfolio / LinkedIn / GitHub "
+        "render as a second contact line."
+    )
+    console.print("[dim]Type the URL or hit Enter (default 'skip') to skip each.[/dim]")
+    for label in missing:
+        answer = Prompt.ask(f"[bold]{label} URL[/bold]", default="skip", console=console)
+        cleaned = answer.strip()
+        if cleaned and cleaned.lower() != "skip":
+            master.links.append(Link(label=label, url=cleaned))
+
+
+def _ask_per_role_tech(master: ResumeMaster, console: Console, Prompt: Any) -> None:  # noqa: N803
+    roles_without_tech = [e for e in master.experience if not e.tech]
+    if not roles_without_tech:
+        return
+    console.print(
+        f"\n[bold cyan]Per-role tech stacks[/bold cyan] — "
+        f"{len(roles_without_tech)} role(s) need one."
+    )
+    console.print(
+        "[dim]For each role, type the tech comma-separated (e.g. "
+        '"Python, PostgreSQL, AWS"). Hit Enter to skip.[/dim]'
+    )
+    for entry in roles_without_tech:
+        label = f"{entry.role} @ {entry.company}".strip(" @") or entry.id
+        answer = Prompt.ask(f"[bold]{label}[/bold]", default="skip", console=console)
+        cleaned = answer.strip()
+        if not cleaned or cleaned.lower() == "skip":
+            continue
+        entry.tech = [t.strip() for t in cleaned.split(",") if t.strip()]
+
+
+def _ask_skill_groups(
+    master: ResumeMaster,
+    console: Console,
+    Prompt: Any,  # noqa: N803
+    Confirm: Any,  # noqa: N803
+) -> None:
+    if master.skill_groups:
+        return
+    if len(master.skills) < _SKILL_GROUPING_MIN:
+        return
+    console.print(
+        f"\n[bold cyan]Skill grouping[/bold cyan] — you have {len(master.skills)} flat skills."
+    )
+    if not Confirm.ask(
+        "Have the LLM propose categories (Languages / Frontend / Backend / Cloud / ...)?",
+        default=True,
+        console=console,
+    ):
+        return
+
+    groups = propose_groups(master.skills)
+    if not groups:
+        console.print("[yellow]LLM didn't return a usable grouping — leaving skills flat.[/yellow]")
+        return
+
+    _print_groups(groups, console)
+    choice = Prompt.ask(
+        "[a]ccept / [r]eject",
+        choices=["a", "r"],
+        default="a",
+        console=console,
+    )
+    if choice == "a":
+        master.skill_groups = groups
+
+
+def _print_groups(groups: list[SkillGroup], console: Console) -> None:
+    from rich.panel import Panel
+
+    body = "\n".join(f"[bold]{g.category}[/bold]: {', '.join(g.items)}" for g in groups)
+    console.print(Panel(body, title="Proposed grouping", border_style="green"))

--- a/src/resume_operator/tools/diff_renderer.py
+++ b/src/resume_operator/tools/diff_renderer.py
@@ -24,6 +24,11 @@ def render_diff(tailored: TailoredResume, index: SourceIndex) -> str:
 
     lines: list[str] = ["# Tailoring Diff", ""]
 
+    if tailored.tailored_headline:
+        lines.append("## Tailored Headline (fresh, JD-crafted)")
+        lines.append(tailored.tailored_headline)
+        lines.append("")
+
     if tailored.tailored_summary:
         lines.append("## Tailored Summary (fresh, JD-crafted)")
         lines.append(tailored.tailored_summary)

--- a/src/resume_operator/tools/pdf_generator.py
+++ b/src/resume_operator/tools/pdf_generator.py
@@ -168,6 +168,7 @@ class _RenderPlan:
     """Structured, layout-agnostic view of what to render."""
 
     def __init__(self) -> None:
+        self.headline: str = ""  # #70: tailored_headline (dynamic) or master.headline (fallback)
         self.summary: str = ""
         # ordered: role_id -> list of bullet texts (kept/reworded)
         self.experience_by_role: dict[str, list[str]] = {}
@@ -192,11 +193,12 @@ def _build_render_plan(
     index = build_source_index(master, facts)
     plan = _RenderPlan()
 
-    # Tailored summary (issue #66) is the fresh JD-crafted opener. When set, it
-    # wins over any kept `master:summary` item — the two would otherwise render
-    # twice in the SUMMARY section.
+    # Tailored summary (issue #66) / headline (issue #70) — dynamic per-JD
+    # strings the tailor writes fresh each run. When non-empty they win over
+    # their static `master.*` equivalents.
     if tailored.tailored_summary:
         plan.summary = tailored.tailored_summary
+    plan.headline = tailored.tailored_headline or master.headline
 
     for item in tailored.kept_or_reworded():
         entry = index.get(item.source_id)
@@ -262,8 +264,14 @@ def _render_default(master: ResumeMaster, plan: _RenderPlan, frame_width: float)
     if master.name:
         flowables.append(Paragraph(escape(_sanitize_for_pdf(master.name)), styles["name"]))
     # Tagline sits between name and rule so name+tagline feel like one block (#68).
-    if master.headline:
-        flowables.append(Paragraph(escape(_sanitize_for_pdf(master.headline)), styles["headline"]))
+    # #70: tailored_headline wins over master.headline when non-empty — the tailor
+    # crafts it per-JD (same pattern as tailored_summary). master.headline is the
+    # fallback used for score-only runs or when the tailor didn't emit one.
+    effective_headline = plan.headline
+    if effective_headline:
+        flowables.append(
+            Paragraph(escape(_sanitize_for_pdf(effective_headline)), styles["headline"])
+        )
     flowables.append(
         HRFlowable(
             width="100%",

--- a/src/resume_operator/tools/skill_grouping.py
+++ b/src/resume_operator/tools/skill_grouping.py
@@ -1,0 +1,96 @@
+"""Propose a skill-group categorization from a flat skill list via LLM.
+
+Used by the bootstrap interview (#70) when the user has flat `skills` but no
+`skill_groups` yet — the LLM proposes a grouping, the user accepts / edits /
+rejects. On reject, the master falls back to the flat list; on accept, the
+groups replace the flat rendering in the SKILLS section.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pydantic import BaseModel, Field, ValidationError
+
+from resume_operator.prompts.skill_grouping import PROPOSE_SKILL_GROUPS
+from resume_operator.state import SkillGroup
+from resume_operator.tools.llm_provider import get_structured_llm
+
+logger = logging.getLogger(__name__)
+
+
+class SkillGroupLLM(BaseModel):
+    category: str = ""
+    items: list[str] = Field(default_factory=list)
+
+
+class SkillGroupsLLMOutput(BaseModel):
+    groups: list[SkillGroupLLM] = Field(default_factory=list)
+
+
+def propose_groups(skills: list[str]) -> list[SkillGroup]:
+    """Ask the LLM to categorise a flat skill list. Returns `[]` on failure.
+
+    The helper drops groups the LLM returned with empty items, filters items
+    not present in the original input (fabrication guard), and de-dupes so
+    every input skill ends up in at most one group.
+    """
+    if not skills:
+        return []
+
+    prompt = PROPOSE_SKILL_GROUPS.format(skills=", ".join(skills))
+    try:
+        llm = get_structured_llm(SkillGroupsLLMOutput)
+        parsed: SkillGroupsLLMOutput = llm.invoke(prompt)
+    except ValidationError as exc:
+        logger.error("propose_groups: LLM returned schema-invalid data: %s", exc)
+        return []
+    except Exception as exc:
+        logger.error("propose_groups: LLM call failed: %s", exc)
+        return []
+
+    allowed = {s: None for s in skills}  # preserves input casing
+    seen: set[str] = set()
+    result: list[SkillGroup] = []
+    for group in parsed.groups:
+        if not group.category.strip():
+            continue
+        filtered: list[str] = []
+        for item in group.items:
+            # The LLM sometimes re-casings an item; normalise against the allowlist.
+            canonical = _match_original(item, allowed)
+            if canonical is None:
+                logger.warning(
+                    "propose_groups: rejected fabricated skill %r (not in input list)", item
+                )
+                continue
+            if canonical in seen:
+                continue
+            seen.add(canonical)
+            filtered.append(canonical)
+        if filtered:
+            result.append(SkillGroup(category=group.category.strip(), items=filtered))
+
+    # Any input skills the LLM didn't place get collected into "Other" so the
+    # user doesn't silently lose them.
+    leftovers = [s for s in skills if s not in seen]
+    if leftovers:
+        result.append(SkillGroup(category="Other", items=leftovers))
+
+    logger.info(
+        "propose_groups: grouped %d skills into %d categories",
+        sum(len(g.items) for g in result),
+        len(result),
+    )
+    return result
+
+
+def _match_original(item: str, allowed: dict[str, None]) -> str | None:
+    """Canonicalise an LLM-returned item against the input allowlist (case-insensitive)."""
+    if item in allowed:
+        return item
+    lowered = item.lower()
+    for original in allowed:
+        if original.lower() == lowered:
+            return original
+    return None

--- a/tests/test_bootstrap_interview.py
+++ b/tests/test_bootstrap_interview.py
@@ -1,0 +1,316 @@
+"""Tests for `tools.bootstrap_interview` + `tools.skill_grouping`."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from rich.console import Console
+
+from resume_operator.state import (
+    ExperienceBullet,
+    ExperienceEntry,
+    Link,
+    ResumeMaster,
+    SkillGroup,
+)
+from resume_operator.tools.bootstrap_interview import (
+    run_interview,
+    should_run_interview,
+)
+from resume_operator.tools.skill_grouping import (
+    SkillGroupLLM,
+    SkillGroupsLLMOutput,
+    propose_groups,
+)
+
+
+def _make_llm(return_value: object | Exception) -> MagicMock:
+    llm = MagicMock()
+    if isinstance(return_value, Exception):
+        llm.invoke.side_effect = return_value
+    else:
+        llm.invoke.return_value = return_value
+    return llm
+
+
+def _silent_console() -> Console:
+    """A Console that doesn't write anywhere — useful in tests."""
+    import io
+
+    return Console(file=io.StringIO(), force_terminal=False, record=False)
+
+
+def _minimal_master() -> ResumeMaster:
+    return ResumeMaster(
+        name="Jane Smith",
+        email="jane@example.com",
+        experience=[
+            ExperienceEntry(
+                id="exp-1",
+                role="Senior Engineer",
+                company="TechCorp",
+                bullets=[ExperienceBullet(id="exp-1-b1", text="Did stuff")],
+            )
+        ],
+        skills=["Python", "AWS", "PostgreSQL", "Docker"],
+    )
+
+
+class TestShouldRunInterview:
+    def test_opts_out_when_no_interview_flag(self) -> None:
+        assert should_run_interview(no_interview=True) is False
+
+    @patch("sys.stdin.isatty", return_value=True)
+    def test_runs_in_tty(self, _tty: MagicMock) -> None:
+        assert should_run_interview(no_interview=False) is True
+
+    @patch("sys.stdin.isatty", return_value=False)
+    def test_skips_when_no_tty(self, _tty: MagicMock) -> None:
+        """Piped stdin (CI, `echo ... | bootstrap`) must never block on prompts."""
+        assert should_run_interview(no_interview=False) is False
+
+
+class TestRunInterviewHeadline:
+    def test_fills_empty_headline(self) -> None:
+        master = _minimal_master()
+        assert master.headline == ""
+
+        # Prompt.ask is called for: headline, 3 links, 1 role tech → 5 calls total.
+        # Grouping confirm is a Confirm.ask, separate.
+        answers = iter(
+            [
+                "Senior Engineer · 10+ years · Python",  # headline
+                "skip",  # Portfolio
+                "skip",  # LinkedIn
+                "skip",  # GitHub
+                "skip",  # exp-1 tech
+            ]
+        )
+        with (
+            patch("rich.prompt.Prompt.ask", side_effect=lambda *a, **kw: next(answers)),
+            patch("rich.prompt.Confirm.ask", return_value=False),
+        ):
+            run_interview(master, console=_silent_console())
+        assert master.headline == "Senior Engineer · 10+ years · Python"
+
+    def test_skips_when_user_types_skip(self) -> None:
+        master = _minimal_master()
+        with (
+            patch("rich.prompt.Prompt.ask", return_value="skip"),
+            patch("rich.prompt.Confirm.ask", return_value=False),
+        ):
+            run_interview(master, console=_silent_console())
+        assert master.headline == ""
+
+    def test_existing_headline_not_re_asked(self) -> None:
+        master = _minimal_master()
+        master.headline = "Pre-existing tagline"
+        with (
+            patch("rich.prompt.Prompt.ask", return_value="skip"),
+            patch("rich.prompt.Confirm.ask", return_value=False),
+        ):
+            run_interview(master, console=_silent_console())
+        assert master.headline == "Pre-existing tagline"
+
+
+class TestRunInterviewLinks:
+    def test_prompts_for_each_standard_label_missing(self) -> None:
+        """Labels prompted in module-defined order: Portfolio → LinkedIn → GitHub."""
+        master = _minimal_master()
+        answers = iter(
+            [
+                "skip",  # headline
+                "janesmith.example",  # Portfolio url
+                "linkedin.com/in/jane",  # LinkedIn url
+                "skip",  # GitHub url
+                "skip",  # per-role tech for exp-1
+            ]
+        )
+        with (
+            patch("rich.prompt.Prompt.ask", side_effect=lambda *a, **kw: next(answers)),
+            patch("rich.prompt.Confirm.ask", return_value=False),
+        ):
+            run_interview(master, console=_silent_console())
+
+        labels = {lk.label for lk in master.links}
+        assert labels == {"Portfolio", "LinkedIn"}
+
+    def test_does_not_re_ask_for_existing_label(self) -> None:
+        master = _minimal_master()
+        master.links = [Link(label="GitHub", url="github.com/jsmith")]
+        # Only 2 labels missing (Portfolio, LinkedIn). Answer: skip everything.
+        with (
+            patch("rich.prompt.Prompt.ask", return_value="skip"),
+            patch("rich.prompt.Confirm.ask", return_value=False),
+        ):
+            run_interview(master, console=_silent_console())
+        # Still just the one pre-existing link.
+        assert len(master.links) == 1
+        assert master.links[0].label == "GitHub"
+
+
+class TestRunInterviewPerRoleTech:
+    def test_fills_tech_for_roles_missing_it(self) -> None:
+        master = _minimal_master()
+        master.experience.append(
+            ExperienceEntry(
+                id="exp-2",
+                role="Junior Engineer",
+                company="Widget",
+                bullets=[ExperienceBullet(id="exp-2-b1", text="Built stuff")],
+                tech=["JavaScript"],  # already populated — should be skipped
+            )
+        )
+
+        answers = iter(
+            [
+                "skip",  # headline
+                "skip",  # Portfolio
+                "skip",  # LinkedIn
+                "skip",  # GitHub
+                "Python, PostgreSQL, Docker",  # exp-1 tech (exp-2 has tech already)
+            ]
+        )
+        with (
+            patch("rich.prompt.Prompt.ask", side_effect=lambda *a, **kw: next(answers)),
+            patch("rich.prompt.Confirm.ask", return_value=False),
+        ):
+            run_interview(master, console=_silent_console())
+
+        assert master.experience[0].tech == ["Python", "PostgreSQL", "Docker"]
+        # exp-2's tech is untouched.
+        assert master.experience[1].tech == ["JavaScript"]
+
+
+class TestRunInterviewSkillGrouping:
+    @patch("resume_operator.tools.bootstrap_interview.propose_groups")
+    def test_asks_confirmation_and_writes_groups_on_accept(self, mock_propose: MagicMock) -> None:
+        master = _minimal_master()
+        mock_propose.return_value = [
+            SkillGroup(category="Languages", items=["Python"]),
+            SkillGroup(category="Cloud", items=["AWS", "Docker"]),
+            SkillGroup(category="Data", items=["PostgreSQL"]),
+        ]
+
+        answers = iter(
+            [
+                "skip",  # headline
+                "skip",  # Portfolio
+                "skip",  # LinkedIn
+                "skip",  # GitHub
+                "skip",  # exp-1 tech
+                "a",  # accept grouping
+            ]
+        )
+        with (
+            patch("rich.prompt.Prompt.ask", side_effect=lambda *a, **kw: next(answers)),
+            patch("rich.prompt.Confirm.ask", return_value=True),
+        ):
+            run_interview(master, console=_silent_console())
+
+        assert len(master.skill_groups) == 3
+        categories = {g.category for g in master.skill_groups}
+        assert categories == {"Languages", "Cloud", "Data"}
+
+    @patch("resume_operator.tools.bootstrap_interview.propose_groups")
+    def test_reject_leaves_groups_empty(self, mock_propose: MagicMock) -> None:
+        master = _minimal_master()
+        mock_propose.return_value = [
+            SkillGroup(category="Everything", items=["Python", "AWS", "PostgreSQL", "Docker"])
+        ]
+
+        answers = iter(
+            ["skip", "skip", "skip", "skip", "skip", "r"]  # reject grouping
+        )
+        with (
+            patch("rich.prompt.Prompt.ask", side_effect=lambda *a, **kw: next(answers)),
+            patch("rich.prompt.Confirm.ask", return_value=True),
+        ):
+            run_interview(master, console=_silent_console())
+
+        assert master.skill_groups == []
+
+    @patch("resume_operator.tools.bootstrap_interview.propose_groups")
+    def test_skipped_when_user_says_no(self, mock_propose: MagicMock) -> None:
+        master = _minimal_master()
+
+        with (
+            patch("rich.prompt.Prompt.ask", return_value="skip"),
+            patch("rich.prompt.Confirm.ask", return_value=False),  # declines grouping
+        ):
+            run_interview(master, console=_silent_console())
+
+        mock_propose.assert_not_called()
+        assert master.skill_groups == []
+
+    @patch("resume_operator.tools.bootstrap_interview.propose_groups")
+    def test_skipped_when_skills_too_few(self, mock_propose: MagicMock) -> None:
+        master = _minimal_master()
+        master.skills = ["Python"]  # below the min-3 threshold
+
+        with (
+            patch("rich.prompt.Prompt.ask", return_value="skip"),
+            patch("rich.prompt.Confirm.ask", return_value=True),
+        ):
+            run_interview(master, console=_silent_console())
+
+        mock_propose.assert_not_called()
+        assert master.skill_groups == []
+
+
+class TestProposeGroups:
+    @patch("resume_operator.tools.skill_grouping.get_structured_llm")
+    def test_returns_groups_with_canonicalised_casing(self, mock_get_llm: MagicMock) -> None:
+        # Input skills have "Python" (capital P); LLM returns "python" (lower).
+        # propose_groups should match case-insensitively and keep the original.
+        mock_get_llm.return_value = _make_llm(
+            SkillGroupsLLMOutput(
+                groups=[
+                    SkillGroupLLM(category="Languages", items=["python"]),
+                    SkillGroupLLM(category="Cloud", items=["AWS", "Docker"]),
+                ]
+            )
+        )
+        result = propose_groups(["Python", "AWS", "Docker"])
+
+        assert [g.category for g in result] == ["Languages", "Cloud"]
+        # Python preserved with its original casing.
+        assert "Python" in result[0].items
+
+    @patch("resume_operator.tools.skill_grouping.get_structured_llm")
+    def test_rejects_fabricated_skills(self, mock_get_llm: MagicMock) -> None:
+        """If the LLM invents a skill that wasn't in the input, it gets filtered out."""
+        mock_get_llm.return_value = _make_llm(
+            SkillGroupsLLMOutput(
+                groups=[
+                    SkillGroupLLM(category="Languages", items=["Python", "Kotlin"]),
+                ]
+            )
+        )
+        result = propose_groups(["Python"])  # Kotlin not in input
+
+        items = [item for g in result for item in g.items]
+        assert "Python" in items
+        assert "Kotlin" not in items
+
+    @patch("resume_operator.tools.skill_grouping.get_structured_llm")
+    def test_collects_ungrouped_skills_into_other(self, mock_get_llm: MagicMock) -> None:
+        """Input skills the LLM didn't place end up in an 'Other' group so they're
+        not silently lost."""
+        mock_get_llm.return_value = _make_llm(
+            SkillGroupsLLMOutput(groups=[SkillGroupLLM(category="Languages", items=["Python"])])
+        )
+        result = propose_groups(["Python", "AWS", "Docker"])
+
+        categories = {g.category: g.items for g in result}
+        assert "Languages" in categories
+        assert "Other" in categories
+        assert sorted(categories["Other"]) == ["AWS", "Docker"]
+
+    @patch("resume_operator.tools.skill_grouping.get_structured_llm")
+    def test_returns_empty_on_llm_failure(self, mock_get_llm: MagicMock) -> None:
+        mock_get_llm.return_value = _make_llm(RuntimeError("API down"))
+        assert propose_groups(["Python"]) == []
+
+    def test_empty_input_returns_empty(self) -> None:
+        assert propose_groups([]) == []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -121,6 +121,12 @@ class TestBootstrapCommand:
     ) -> None:
         """Bootstrap must not invoke the full graph — that would burn LLM calls on
         ats_score / analyze_gaps / optimize_content the user never asked for."""
+        from resume_operator.state import (
+            ExperienceBullet,
+            ExperienceEntry,
+            ResumeMaster,
+        )
+
         fake_pdf = tmp_path / "resume.pdf"
         fake_pdf.touch()
         out = tmp_path / "master.yaml"
@@ -129,21 +135,34 @@ class TestBootstrapCommand:
             "resume": ResumeData(
                 name="Jane Smith",
                 email="jane@example.com",
+                skills=["Python", "AWS"],
+            ),
+            "master": ResumeMaster(
+                name="Jane Smith",
+                email="jane@example.com",
                 experience=[
-                    {
-                        "role": "Engineer",
-                        "company": "Corp",
-                        "start_date": "2020",
-                        "end_date": "present",
-                        "description": "- Built APIs\n- Shipped to AWS",
-                    }
+                    ExperienceEntry(
+                        id="exp-1",
+                        role="Engineer",
+                        company="Corp",
+                        start_date="2020",
+                        end_date="present",
+                        bullets=[
+                            ExperienceBullet(id="exp-1-b1", text="Built APIs"),
+                            ExperienceBullet(id="exp-1-b2", text="Shipped to AWS"),
+                        ],
+                    )
                 ],
                 skills=["Python", "AWS"],
             ),
             "errors": [],
         }
 
-        result = runner.invoke(app, ["bootstrap", "--resume", str(fake_pdf), "--output", str(out)])
+        # `--no-interview` keeps the command headless so the test doesn't block on prompts.
+        result = runner.invoke(
+            app,
+            ["bootstrap", "--resume", str(fake_pdf), "--output", str(out), "--no-interview"],
+        )
 
         assert result.exit_code == 0, result.output
         mock_parse.assert_called_once()
@@ -155,7 +174,8 @@ class TestBootstrapCommand:
 
         written = yaml.safe_load(out.read_text(encoding="utf-8"))
         assert written["name"] == "Jane Smith"
-        # Bullets round-trip: dense newline description → list of ExperienceBullet entries.
+        # The master carries the ExperienceEntry's stable-ID bullets straight
+        # through to the YAML — no round-trip through ResumeData's dict shape.
         assert len(written["experience"][0]["bullets"]) == 2
 
 

--- a/tests/test_optimize_content.py
+++ b/tests/test_optimize_content.py
@@ -12,6 +12,7 @@ from resume_operator.nodes.optimize_content import (
 from resume_operator.state import ResumeOptimizerState
 
 VALID_OUTPUT = TailoredResumeLLMOutput(
+    tailored_headline="Senior Backend Engineer · 8+ years · Python, AWS",
     tailored_summary="Senior engineer with 8+ years shipping Python/AWS backends.",
     items=[
         TailoredItemLLM(
@@ -54,6 +55,10 @@ class TestOptimizeContent:
         assert "Kubernetes-native" in result["tailored_resume"].items[0].new_text
         # Tailored summary round-trips (issue #66).
         assert result["tailored_resume"].tailored_summary.startswith("Senior engineer")
+        # Tailored headline round-trips (issue #70).
+        assert result["tailored_resume"].tailored_headline == (
+            "Senior Backend Engineer · 8+ years · Python, AWS"
+        )
         # Legacy projection still populates sections for back-compat, and the
         # tailored_summary wins over any kept master:summary.
         assert "optimized_resume" in result

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -398,6 +398,45 @@ class TestSeniorFormatFields:
         # Contact line should land directly after name.
         assert text.index("Jane Smith") < text.index("jane@example.com")
 
+    def test_tailored_headline_wins_over_master_headline(self, tmp_path: Path) -> None:
+        """#70: when the tailor emits a tailored_headline, it replaces master.headline.
+
+        Both shouldn't render — the page would have two taglines. Tailored wins
+        because it's per-JD and the master one is a static fallback."""
+        master = self._base_master()
+        master.headline = "STATIC MASTER TAGLINE — SHOULD-NOT-APPEAR"
+        tailored = TailoredResume(
+            tailored_headline="Senior Backend Engineer · 10+ years · Python",
+            items=[
+                TailoredItem(source_id="master:exp-1-b1", action="keep", original_text="x"),
+            ],
+        )
+        output = tmp_path / "resume.pdf"
+        generate_pdf(master, tailored, output)
+
+        with fitz.open(output) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+        assert "Senior Backend Engineer · 10+ years · Python" in text
+        assert "SHOULD-NOT-APPEAR" not in text
+
+    def test_master_headline_fallback_when_no_tailored(self, tmp_path: Path) -> None:
+        """When the tailor doesn't emit a headline, the static master.headline
+        still renders — useful for score-only runs."""
+        master = self._base_master()
+        master.headline = "Fallback Tagline · Static"
+        tailored = TailoredResume(
+            tailored_headline="",  # explicitly empty
+            items=[
+                TailoredItem(source_id="master:exp-1-b1", action="keep", original_text="x"),
+            ],
+        )
+        output = tmp_path / "resume.pdf"
+        generate_pdf(master, tailored, output)
+
+        with fitz.open(output) as doc:
+            text = "\n".join(page.get_text() for page in doc)
+        assert "Fallback Tagline · Static" in text
+
     def test_links_render_as_second_contact_line(self, tmp_path: Path) -> None:
         master = self._base_master()
         master.links = [


### PR DESCRIPTION
## Summary

Two bundled fixes, both directly addressing feedback about the resume format:

1. **Dynamic per-JD headline.** \`TailoredResume.tailored_headline\` joins \`tailored_summary\` as a field the optimizer writes fresh each run, JD-weighted but grounded strictly in master facts. The rendered PDF now shows a different tagline for every JD, drawn from the same master. \`master.headline\` becomes a static fallback for score-only runs or when the tailor doesn't emit one.

2. **Interactive bootstrap interview.** After the LLM parses a PDF into a \`ResumeMaster\`, the CLI walks through missing senior-format fields and asks the user — headline, Portfolio/LinkedIn/GitHub URLs, per-role tech stacks, categorised skill groups. Opt-out via \`--no-interview\`, auto-skip on non-TTY stdin (CI safe). Skill-grouping uses a separate LLM call (\`tools/skill_grouping.propose_groups\`) with a fabrication guard — accept / reject the whole block.

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/70. User feedback: *\"the highlight text shouldn't be static. it should be dynamic based on the job description.\"* and *\"if some fields are empty in the original resume you should ask me while getting master_resume.yaml\"*. Both insights were right — a static headline is the same across every application, which defeats its purpose as a recruiter hook; and silent-empty fields post-bootstrap just cost the user a round-trip to hand-edit YAML they didn't know to edit.

## Proof on real inputs

Real-run against \`data/master_resume.yaml\` + \`input/job.txt\` (Foodsmart Staff Backend):

\`\`\`
optimize_content: completed — items=77 (kept=71, reworded=2, dropped=4), fabricated_rejected=0, notes=1, summary=yes, headline=yes
\`\`\`

Extracted PDF top shows:
\`\`\`
TAKESHI SUZUKI
Backend Software Engineer · 8+ years · Node.js, TypeScript, AWS
takeshisuz57@gmail.com
SUMMARY
Accomplished backend software engineer with 8+ years …
\`\`\`

That tagline was JD-weighted (backend led), grounded in master facts (8+ years, Node.js, TypeScript, AWS all present on the master). Bruno's static master has no headline field at all — the line is pure tailor output. Running the same master against a frontend JD would yield a frontend-leaning tagline from the same facts.

## How the fabrication guard extends

- The tailored_headline prompt explicitly forbids invented years, companies, or "Ex-[Company]" unless the company is on the master.
- \`propose_groups\` validates every LLM-returned skill against the input allowlist (case-insensitive match); items not in the input get dropped. Skills the LLM didn't place end up in an "Other" bucket so they're not silently lost.
- Bootstrap interview skips auto on non-TTY stdin so CI / piped runs stay headless.

## How to test

1. \`uv run python -m pytest -q\` — 200 tests (20 new).
2. Bootstrap in an interactive shell: \`LLM_MODEL=openai/gpt-4o-mini uv run python -m resume_operator bootstrap --resume input/resume.pdf --output data/master_resume.yaml\` — walks the interview.
3. Headless bootstrap: add \`--no-interview\`, matches pre-#70 behaviour.
4. Dynamic headline check: \`run --master ... --job <backend-jd>\` vs \`run --master ... --job <frontend-jd>\` — different tagline, same master.

## Test coverage

- \`TestShouldRunInterview\` x3 — TTY / no-TTY / opt-out
- \`TestRunInterviewHeadline\` x3 — fill-if-empty / skip / don't-re-ask-if-set
- \`TestRunInterviewLinks\` x2 — prompting order, skip existing
- \`TestRunInterviewPerRoleTech\` x1 — roles with existing tech are untouched
- \`TestRunInterviewSkillGrouping\` x4 — accept / reject / confirm-declined / below-threshold
- \`TestProposeGroups\` x5 — canonicalise casing, reject fabricated skills, collect leftovers into "Other", LLM-failure fallback, empty-input
- \`TestSeniorFormatFields.test_tailored_headline_wins_over_master_headline\`
- \`TestSeniorFormatFields.test_master_headline_fallback_when_no_tailored\`
- \`TestOptimizeContent\` extended for tailored_headline round-trip

When this PR is merged, the two user-facing complaints land: the bootstrap no longer silently drops missing-field UX on the floor, and the tailored PDF's tagline adapts per JD instead of being a set-once static field.