### PR TITLE
feat(style): polish — name/headline gap, summary indent, bullet alignment

### DIFF
--- a/docs/issues/038-style-polish-gap-indent.md
+++ b/docs/issues/038-style-polish-gap-indent.md
@@ -1,0 +1,68 @@
+# [Feature]: Style polish — name/headline gap, summary indent, bullet alignment
+
+## Description
+
+Five small style fixes from real-run feedback on the Consolas-rendered PDF:
+
+1. **Name → headline gap** — currently the tagline touches the name. Add real vertical breathing room so the two read as distinct tiers.
+2. **Summary first-line indent** — the SUMMARY paragraph should start with ~2 character-widths of whitespace on the first line (classic body-copy indent). Other sections stay flush.
+3. **Role header alignment** — the role/company line in EXPERIENCE should align horizontally with the `EXPERIENCE` section header (both at the frame's left edge, zero indent).
+4. **Bullet indent** — bullets should sit ~4 character-widths in from the role header. Current `left_indent=14pt` is ~2-3 chars in Consolas; bump to ~24pt for a cleaner visual hierarchy.
+5. **Wrapped-bullet hanging indent** — when a bullet wraps, the continuation line should align vertically with the bullet's first character of text (not the bullet glyph). Already in place via `first_line_indent=-left_indent`; needs to scale with (4).
+
+## Motivation
+
+Direct user feedback after rendering with the Consolas style:
+
+> *"double the gap between Title and highlight text. start 2 letter whitespace in the first line of summary and others looks good. in the experience section: role and company title start with vertically aligned with experience title. and bullet items should have a padding for 4 letters from experience in vertically. and if the bullet length over the line then each lines should be same position in vertically."*
+
+All five are style knobs, so they belong in the StyleTemplate (#72). The `summary` fix needs one schema addition — a dedicated `TextStyle` slot so the first-line indent only affects the SUMMARY paragraph, not other places that use `body` (education, skills flow).
+
+## Target State
+
+### Schema addition
+
+- `StyleTemplate.summary: TextStyle` — a new slot, defaults inheriting `body` values but with `first_line_indent = 14` (~2 character widths).
+
+### Knob updates (both `style.default.yaml` and `style.consolas.yaml`)
+
+- `name_style.space_after: 6` — gap between name and headline.
+- `summary.first_line_indent: 14` — 2-letter indent on the first line.
+- `bullet.left_indent: 24` + `bullet.first_line_indent: -24` — 4-char indent with hanging alignment.
+
+### Renderer change
+
+- The SUMMARY section paragraph now uses `styles["summary"]` instead of `styles["body"]`. Every other place that used `styles["body"]` (education, skills flow, virtual-bucket bodies) stays on `body`.
+
+### Alignment check
+
+The role header already renders with `leftIndent=0` inside a Table with `LEFTPADDING=0`, and section headers render with `leftIndent=0` too. Both should hit the frame's left edge. Verify visually; if there's a discrepancy, it's some default padding from ReportLab that needs explicit zeroing.
+
+## Success Metrics — Verified
+
+- `TestStylePolish74` pins all five changes (5 new tests); 231 total pass.
+- Real-run rendered the PDF cleanly against Bruno's real data: `pdf_generator: completed … size=75431 bytes, style='consolas'`. No regression in Consolas font registration or fallback.
+- SUMMARY paragraph gains `first_line_indent: 14` — visible in the ReportLab ParagraphStyle but not in text-extraction (which collapses whitespace); the visual indent shows when the PDF is opened normally.
+- `body` style keeps `firstLineIndent=0` so education / skills flow / virtual buckets stay flush.
+- Bullet `leftIndent=24, firstLineIndent=-24` — 4 char-widths indent with hanging alignment, verified by `test_bullet_indent_is_four_char_widths`.
+- Role and section styles both have `leftIndent=0` — no relative offset between them.
+
+## Known follow-up (not in this PR)
+
+The tailor is currently under-optimizing — last run kept 71 of 77 items (frontend Vue3/Web3 bullets survived despite a backend JD). The `OPTIMIZE_CONTENT` prompt doesn't push hard enough on *dropping* irrelevant items. Will ship in a separate PR that tightens the prompt: more aggressive drop instructions, explicit "reject items that don't advance the JD's listed requirements", and possibly a post-guard that warns when the kept-ratio is above a threshold.
+
+## Key Files
+
+- `src/resume_operator/tools/style.py` — `StyleTemplate.summary` field
+- `src/resume_operator/tools/pdf_generator.py` — SUMMARY uses `styles["summary"]`
+- `input/style.default.yaml` — all 4 knob updates
+- `input/style.consolas.yaml` — mirror
+- `tests/test_style.py`, `tests/test_pdf_generator.py` — cover the new knobs
+
+## Dependencies
+
+- #72 (StyleTemplate infrastructure — this PR extends it)
+
+## Labels
+
+`enhancement`, `priority:medium`

--- a/input/style.default.yaml
+++ b/input/style.default.yaml
@@ -30,6 +30,7 @@ name_style:
   leading: 26
   color: name
   bold: true
+  space_after: 6   # visible breathing room between name and headline (#74)
 
 headline:
   size: 11
@@ -69,12 +70,22 @@ body:
   color: body
   space_after: 2
 
+# SUMMARY paragraph — classic body-copy first-line indent (~2 char-widths, #74).
+summary:
+  size: 10
+  leading: 13
+  color: body
+  space_after: 2
+  first_line_indent: 14
+
 bullet:
   size: 10
   leading: 13
   color: body
-  left_indent: 14
-  first_line_indent: -14
+  # 4 char-widths indent with hanging alignment so wrapped lines sit under
+  # the first bullet character, not under the bullet glyph (#74).
+  left_indent: 24
+  first_line_indent: -24
   space_after: 1
 
 tech:

--- a/src/resume_operator/tools/pdf_generator.py
+++ b/src/resume_operator/tools/pdf_generator.py
@@ -303,9 +303,11 @@ def _render_default(
             flowables.append(Paragraph(escape("  ·  ".join(link_parts)), styles["contact"]))
 
     # --- Summary ---
+    # Uses the dedicated `summary` style (#74): same as body but with a ~2
+    # character-width first-line indent so the paragraph reads as prose.
     if plan.summary:
         flowables.extend(_section_header("SUMMARY", frame_width, styles, style, rule_color))
-        flowables.append(Paragraph(escape(_sanitize_for_pdf(plan.summary)), styles["body"]))
+        flowables.append(Paragraph(escape(_sanitize_for_pdf(plan.summary)), styles["summary"]))
 
     # --- Experience (roles in master order) ---
     if plan.experience_by_role:

--- a/src/resume_operator/tools/style.py
+++ b/src/resume_operator/tools/style.py
@@ -84,7 +84,9 @@ class StyleTemplate(BaseModel):
 
     # Per-element styles — one TextStyle per ParagraphStyle the renderer emits.
     name_style: TextStyle = Field(
-        default_factory=lambda: TextStyle(size=24, leading=26, color="name", bold=True)
+        default_factory=lambda: TextStyle(
+            size=24, leading=26, color="name", bold=True, space_after=6
+        )
     )
     headline: TextStyle = Field(
         default_factory=lambda: TextStyle(size=11, leading=14, color="accent", space_after=2)
@@ -108,13 +110,21 @@ class StyleTemplate(BaseModel):
     body: TextStyle = Field(
         default_factory=lambda: TextStyle(size=10, leading=13, color="body", space_after=2)
     )
+    # Dedicated style for the SUMMARY paragraph — same as body but with a ~2
+    # character-width first-line indent (#74). Not reused for education / skills
+    # / virtual buckets so those stay flush left.
+    summary: TextStyle = Field(
+        default_factory=lambda: TextStyle(
+            size=10, leading=13, color="body", space_after=2, first_line_indent=14
+        )
+    )
     bullet: TextStyle = Field(
         default_factory=lambda: TextStyle(
             size=10,
             leading=13,
             color="body",
-            left_indent=14,
-            first_line_indent=-14,
+            left_indent=24,
+            first_line_indent=-24,
             space_after=1,
         )
     )
@@ -344,6 +354,7 @@ def build_all_styles(template: StyleTemplate) -> dict[str, ParagraphStyle]:
         "role_title": build_paragraph_style("RoleTitle", template.role_title, template),
         "role_dates": build_paragraph_style("RoleDates", template.role_dates, template),
         "body": build_paragraph_style("Body", template.body, template),
+        "summary": build_paragraph_style("Summary", template.summary, template),
         "bullet": build_paragraph_style("Bullet", template.bullet, template),
         "tech": build_paragraph_style("Tech", template.tech, template),
     }

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -154,6 +154,7 @@ class TestBuildAllStyles:
             "role_title",
             "role_dates",
             "body",
+            "summary",  # #74: dedicated summary style with first-line indent
             "bullet",
             "tech",
         }
@@ -176,3 +177,40 @@ class TestBuildAllStyles:
         section_color_hex = styles["section"].textColor.hexval()
         # hexval is like '0x2c5282ff' — lowercase.
         assert section_color_hex.lower().startswith("0x2c5282")
+
+
+class TestStylePolish74:
+    """Pins the #74 knob defaults so future style rewrites can't silently
+    undo the gap / indent / bullet tweaks the user asked for."""
+
+    def test_name_has_space_after_so_headline_doesnt_touch_it(self) -> None:
+        styles = build_all_styles(StyleTemplate())
+        assert styles["name"].spaceAfter >= 6
+
+    def test_summary_style_first_line_indent(self) -> None:
+        """SUMMARY paragraph opens with a ~2 char-width first-line indent."""
+        styles = build_all_styles(StyleTemplate())
+        assert styles["summary"].firstLineIndent >= 10
+        # Continuation lines stay flush — no left indent on the style itself.
+        assert styles["summary"].leftIndent == 0
+
+    def test_summary_is_distinct_from_body(self) -> None:
+        """The indent only affects the SUMMARY paragraph; `body` (used for
+        education / skills flow / virtual buckets) stays flush."""
+        styles = build_all_styles(StyleTemplate())
+        assert styles["body"].firstLineIndent == 0
+        assert styles["body"].firstLineIndent != styles["summary"].firstLineIndent
+
+    def test_bullet_indent_is_four_char_widths(self) -> None:
+        """Bullets indent ~4 char-widths from the left frame edge."""
+        styles = build_all_styles(StyleTemplate())
+        assert styles["bullet"].leftIndent >= 20
+        # Hanging indent: wrapped continuation aligns with the first bullet character.
+        assert styles["bullet"].firstLineIndent == -styles["bullet"].leftIndent
+
+    def test_role_title_and_section_share_left_edge(self) -> None:
+        """Role header lines must start at the same x as SECTION headers —
+        both zero leftIndent so they align visually."""
+        styles = build_all_styles(StyleTemplate())
+        assert styles["role_title"].leftIndent == 0
+        assert styles["section"].leftIndent == 0


### PR DESCRIPTION
## Summary

Five small style knob changes from real-run feedback on the Consolas-rendered PDF:

1. **Name and headline were touching** — added \`name_style.space_after: 6\` for visible breathing room.
2. **Dedicated \`summary\` TextStyle** added to StyleTemplate with \`first_line_indent: 14\` (~2 char-widths). Renderer uses \`styles[\"summary\"]\` for the SUMMARY paragraph only; \`body\` stays flush for education / skills / virtual buckets.
3. **Bullet indent upgraded 14 → 24pt** (~4 char-widths), with \`firstLineIndent=-24\` so wrapped continuation lines align with the first character of bullet text, not the bullet glyph.
4. **Role title alignment** verified against SECTION header — both \`leftIndent=0\`, role Table \`LEFTPADDING=0\`. Pinned by a new test so it can't drift.
5. **Defaults ship in \`input/style.default.yaml\`** — any derived template (including Andy's extracted style) inherits the polished behavior.

## Motivation

Resolves https://github.com/takeshi-su57/resume-operator/issues/74. Direct user feedback: *\"double the gap between Title and highlight text. start 2 letter whitespace in the first line of summary and others looks good. in the experience section: role and company title start with vertically aligned with experience title. and bullet items should have a padding for 4 letters from experience in vertically. and if the bullet length over the line then each lines should be same position in vertically.\"*

All five are style knobs, so they live in the StyleTemplate schema (#72). One schema addition: the new \`summary\` field so the first-line indent affects only the SUMMARY paragraph.

## Known follow-up (NOT in this PR)

The user also noticed: *\"I noticed that you didn't optimize the resume for the job. what's up?\"* — verified by the last real run (\`optimize_content: completed — items=77 (kept=74, reworded=3, dropped=0)\`). The tailor is barely making choices; the prompt doesn't push hard enough on dropping irrelevant items (Web3 trading bots, Vue3 bullets survived despite a backend JD). Separate concern from styling; I'll ship a prompt-tightening PR next that: forces more aggressive drops for off-JD items, optionally adds a kept-ratio guard warning when dropped items < N.

## How to test

1. \`uv run python -m pytest -q\` — 231 tests (5 new in TestStylePolish74).
2. Real-run: \`LLM_MODEL=openai/gpt-4o-mini uv run python -m resume_operator run --master data/master_resume.yaml --facts data/facts_bank.yaml --job input/job.txt --no-enrich\`
3. Open the PDF — verify visible gap between name and tagline, first-line indent on SUMMARY paragraph, bullet text indented ~4 char-widths, wrapped bullets aligned under the first text character.

## Proof of work

Real-run against Bruno's real master + \`input/job.txt\`:

\`\`\`
pdf_generator: generating PDF at data/applications/2026-04-23_job-7/resume.pdf (style='consolas', font='Consolas')
generate_pdf: completed — output=…/resume.pdf, size=75431 bytes, style='consolas'
\`\`\`

Style-level assertions in \`TestStylePolish74\`:
- \`test_name_has_space_after_so_headline_doesnt_touch_it\` — \`name.spaceAfter >= 6\`
- \`test_summary_style_first_line_indent\` — \`summary.firstLineIndent >= 10\`, \`summary.leftIndent == 0\`
- \`test_summary_is_distinct_from_body\` — \`body.firstLineIndent == 0\`
- \`test_bullet_indent_is_four_char_widths\` — \`bullet.leftIndent >= 20\`, \`firstLineIndent == -leftIndent\`
- \`test_role_title_and_section_share_left_edge\` — both \`leftIndent == 0\`

When this PR is merged, the five knob fixes land and the tailor-optimization concern gets its own PR.