### PR TITLE
feat(server): FastAPI + WebSocket server for desktop GUI consumption (Phase 1, #84)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ dependencies = [
     "python-dotenv>=1.0",
     "pyyaml>=6.0",
     "python-docx>=1.1",
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.32",
+    "python-multipart>=0.0.18",
+    "websockets>=13.0",
 ]
 
 [dependency-groups]
@@ -37,6 +41,7 @@ dev = [
 
 [project.scripts]
 resume-operator = "resume_operator.main:app"
+resume-operator-server = "resume_operator.server.main:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/resume_operator"]
@@ -67,6 +72,8 @@ module = [
     "reportlab.*",
     "docx",
     "docx.*",
+    "uvicorn",
+    "uvicorn.*",
 ]
 ignore_missing_imports = true
 

--- a/src/resume_operator/events.py
+++ b/src/resume_operator/events.py
@@ -1,0 +1,71 @@
+"""Structured event emission hook for nodes and flows.
+
+Nodes and flows that want to surface progress to a UI call
+`emit(NodeEvent(...))`. If no sink is bound to the current context (the
+CLI case), the call is a no-op — zero overhead. The FastAPI server
+(Phase 1) binds a sink that forwards events over a websocket so the React
+frontend can render a live node timeline.
+
+The sink is stored in a `contextvars.ContextVar` so multiple concurrent
+sessions (one per websocket connection) never cross-contaminate each
+other's event streams.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from time import time
+from typing import Any, Literal, Protocol
+
+EventPhase = Literal["start", "end", "progress", "error"]
+
+
+@dataclass
+class NodeEvent:
+    """One structured event emitted from a node, flow, or LLM call.
+
+    `node` is the emitter's name (e.g. `"ats_score"`, `"approval_loop"`).
+    `phase` is `"start"` / `"end"` for lifecycle, `"progress"` for
+    incremental updates, `"error"` for failures. `data` is free-form JSON
+    the frontend can render (score values, proposal counts, file paths,
+    etc.).
+    """
+
+    node: str
+    phase: EventPhase
+    data: dict[str, Any] = field(default_factory=dict)
+    timestamp: float = field(default_factory=time)
+
+
+class EventSink(Protocol):
+    """Target an event flows to. Server binds a websocket-backed sink."""
+
+    def emit(self, event: NodeEvent) -> None: ...
+
+
+_current_sink: ContextVar[EventSink | None] = ContextVar("resume_operator_event_sink", default=None)
+
+
+def emit(event: NodeEvent) -> None:
+    """Publish `event` to the current sink if one is bound, else no-op."""
+    sink = _current_sink.get()
+    if sink is not None:
+        sink.emit(event)
+
+
+@contextmanager
+def bind_sink(sink: EventSink):  # type: ignore[no-untyped-def]
+    """Bind `sink` as the active sink for the duration of the `with` block.
+
+    Server route handlers wrap their graph invocation with this so the
+    per-request websocket gets its own isolated event stream. The
+    `ContextVar` token is reset on exit to prevent leaks across
+    concurrent requests.
+    """
+    token = _current_sink.set(sink)
+    try:
+        yield sink
+    finally:
+        _current_sink.reset(token)

--- a/src/resume_operator/events.py
+++ b/src/resume_operator/events.py
@@ -69,3 +69,27 @@ def bind_sink(sink: EventSink):  # type: ignore[no-untyped-def]
         yield sink
     finally:
         _current_sink.reset(token)
+
+
+@contextmanager
+def node_span(node: str, **start_data: Any):  # type: ignore[no-untyped-def]
+    """Emit `start` + `end` events around a block of work.
+
+    Usage in a node function:
+
+        def ats_score(state):
+            with node_span("ats_score"):
+                # ... work ...
+                return {"ats_score": score}
+
+    When no sink is bound (the CLI case), both `emit` calls are no-ops —
+    so wrapping a node in `node_span` costs effectively nothing.
+    """
+    emit(NodeEvent(node=node, phase="start", data=dict(start_data)))
+    try:
+        yield
+    except Exception as exc:
+        emit(NodeEvent(node=node, phase="error", data={"message": str(exc)}))
+        raise
+    else:
+        emit(NodeEvent(node=node, phase="end"))

--- a/src/resume_operator/flows/__init__.py
+++ b/src/resume_operator/flows/__init__.py
@@ -1,0 +1,8 @@
+"""Orchestration flows — the blocking, prompter-driven sequences that sit
+above the graph.
+
+Each module here drives a multi-step user interaction (approval loop,
+enrichment interview) via the `Prompter` seam. The CLI and the future
+desktop server both import from this package; the only thing that changes
+between them is which `Prompter` they construct.
+"""

--- a/src/resume_operator/flows/approval.py
+++ b/src/resume_operator/flows/approval.py
@@ -1,0 +1,134 @@
+"""Iterative tailor → score → gate → propose → approve → apply → re-tailor loop.
+
+This is the body of the former `main._run_approval_loop`, refactored to
+take a `Prompter` seam so it can be driven either from the CLI (via
+`RichPrompter`) or the server (via `WebSocketPrompter`, Phase 1).
+
+The loop exits when (a) the user accepts the current ATS score, (b) the
+LLM produces no proposals, (c) the user quits mid-approval, or (d) the
+user declines to continue past the iteration cap — in which case the
+best-scoring iteration seen so far is returned.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from resume_operator.state import ATSScore, RejectedSuggestion, ResumeOptimizerState
+
+if TYPE_CHECKING:
+    from resume_operator.prompter import Prompter
+
+
+def result_score(result: dict[str, Any]) -> float:
+    """Extract the composite ATS score from a tailor-graph result dict.
+
+    The graph sometimes returns `ats_score` as a plain dict (pre-Pydantic
+    hydration) and sometimes as a full `ATSScore` instance; this accepts
+    both so callers don't need to care which stage of the pipeline they're
+    reading from.
+    """
+    ats = result.get("ats_score")
+    if isinstance(ats, ATSScore):
+        return ats.score
+    if isinstance(ats, dict):
+        value = ats.get("score", 0.0)
+        return float(value) if isinstance(value, (int, float)) else 0.0
+    return 0.0
+
+
+def run_approval_loop(
+    *,
+    prompter: Prompter,
+    tailor_graph: Any,
+    initial_result: dict[str, Any],
+    initial_input: dict[str, Any],
+    max_iterations: int,
+) -> dict[str, Any]:
+    """Drive the iterative tailor → score → gate → propose → approve → apply → re-tailor loop.
+
+    Returns the final tailor-graph result the caller hands to the finalize
+    step. `tailor_graph` is the compiled graph from
+    `resume_operator.graph.build_tailor_graph` — duck-typed here so tests
+    can pass a `MagicMock`.
+    """
+    from resume_operator.nodes.apply_approvals import apply_approvals
+    from resume_operator.nodes.propose_changes import propose_changes, revise_proposal
+    from resume_operator.tools.approval_flow import run_approval_flow
+
+    current = initial_result
+    best = current
+    best_score = result_score(current)
+    iteration = 1
+    max_iter_current = max_iterations
+    accumulated_rejections: list[RejectedSuggestion] = []
+
+    while True:
+        score = result_score(current)
+        if score > best_score:
+            best, best_score = current, score
+
+        prompter.render_iteration_header(
+            iteration=iteration, max_iter=max_iter_current, score=score
+        )
+        if prompter.confirm(
+            "[bold]Accept this tailored version and generate the PDF?[/bold]",
+            default=False,
+        ):
+            return current
+
+        if iteration >= max_iter_current:
+            prompter.notice(
+                f"Reached {max_iter_current} iterations (best ATS={best_score:.0%}). "
+                "Continue iterating?",
+                style="yellow",
+            )
+            if not prompter.confirm("Continue anyway?", default=False):
+                prompter.notice("Using the best-scoring tailored version so far.", style="cyan")
+                return best
+            # Reset counter — user opted in for more. Add another cap on top.
+            max_iter_current = iteration + max_iterations
+
+        # Build a state object for propose + approval + apply (these nodes are
+        # called directly, not through the graph).
+        state = ResumeOptimizerState.model_validate(current)
+        state.rejected_suggestions = list(accumulated_rejections)
+
+        with prompter.status("[bold cyan]LLM proposing tailored edits..."):
+            proposal_out = propose_changes(state)
+        proposals = proposal_out.get("proposals", [])
+        if not proposals:
+            prompter.notice(
+                "LLM had no proposals this iteration — sticking with the best version so far.",
+                style="yellow",
+            )
+            return best
+
+        outcome = run_approval_flow(
+            state,
+            list(proposals),
+            revise_fn=revise_proposal,
+            prompter=prompter,
+        )
+        accumulated_rejections.extend(outcome.rejected)
+        if outcome.quit_early:
+            prompter.notice(
+                "You quit the approval step — using the best tailored version so far.",
+                style="cyan",
+            )
+            return best
+        if not outcome.approved:
+            # User rejected everything. No new facts — next tailor pass would
+            # produce the same output. Exit with the best seen.
+            prompter.notice(
+                "Nothing approved this iteration — using the best version so far.",
+                style="cyan",
+            )
+            return best
+
+        state.approved_proposals = list(outcome.approved)
+        apply_approvals(state)  # writes to facts_bank.yaml on disk
+
+        with prompter.status("[bold cyan]Re-tailoring with the approved facts..."):
+            current = tailor_graph.invoke(initial_input)
+        iteration += 1

--- a/src/resume_operator/flows/enrich.py
+++ b/src/resume_operator/flows/enrich.py
@@ -1,0 +1,83 @@
+"""Auto-enrichment orchestration — former `main._run_auto_enrich`.
+
+Called after a tailoring pass that came back thin (kept+reworded items
+below `enrich_threshold`). Offers an interactive interview, runs it
+through the injected `Prompter`, and persists accepted items to the
+facts bank on disk.
+
+Returns True if any items landed in the facts bank, so the caller knows
+to re-invoke the tailor graph with the enriched facts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from resume_operator.state import FactsBank
+from resume_operator.tools.enrich import (
+    assemble_additions,
+    collect_existing_ids,
+    run_interactive_session,
+)
+from resume_operator.tools.facts_bank import append_to_facts, load_facts
+from resume_operator.tools.master_resume import load_master
+
+if TYPE_CHECKING:
+    from resume_operator.prompter import Prompter
+
+
+DEFAULT_FACTS_PATH = Path("data/facts_bank.yaml")
+
+
+def run_auto_enrich(
+    *,
+    prompter: Prompter,
+    master_path: Path,
+    facts_path: Path | None,
+    jd_text: str,
+) -> bool:
+    """Pause the pipeline, prompt for an enrichment session, persist accepted items.
+
+    Returns True if any items were appended to the facts bank (so the caller
+    knows to re-invoke the graph), False otherwise.
+    """
+    prompter.panel(
+        "Only a few items landed in the tailored resume — your master + "
+        "facts may be thin for this JD. We can grow your facts bank with "
+        "a short interview now (LLM asks grounded questions, you answer "
+        "in your own words, LLM polishes the phrasing).",
+        title="Enrichment available",
+        style="yellow",
+    )
+    if prompter.choose("Start an enrichment session?", choices=["y", "n"], default="y") != "y":
+        return False
+
+    target_facts = facts_path or DEFAULT_FACTS_PATH
+    master_obj = load_master(master_path)
+    facts_obj = load_facts(target_facts) if target_facts.exists() else FactsBank()
+
+    plan = run_interactive_session(master_obj, facts_obj, jd_text, prompter=prompter)
+    if not plan.items:
+        prompter.notice("No items accepted — facts_bank unchanged.", style="yellow")
+        return False
+
+    existing_ids = collect_existing_ids(facts_obj)
+    projects, extra_bullets, skills, certifications = assemble_additions(
+        plan, existing_ids=existing_ids
+    )
+    append_to_facts(
+        target_facts,
+        projects=projects,
+        extra_bullets=extra_bullets,
+        skills=skills,
+        certifications=certifications,
+    )
+    prompter.panel(
+        f"[bold]Wrote:[/bold] {target_facts}\n"
+        f"Projects: +{len(projects)}  |  Extra bullets: +{len(extra_bullets)}  |  "
+        f"Skills: +{len(skills)}  |  Certs: +{len(certifications)}",
+        title="Facts bank updated",
+        style="green",
+    )
+    return True

--- a/src/resume_operator/main.py
+++ b/src/resume_operator/main.py
@@ -448,7 +448,7 @@ def bootstrap(
     # the LLM couldn't extract from the source PDF (URLs, per-role tech, skill
     # groupings, fallback headline).
     if should_run_interview(no_interview=no_interview):
-        master = run_interview(master, console=console)
+        master = run_interview(master, prompter=RichPrompter(console))
 
     save_master(master, output)
 

--- a/src/resume_operator/main.py
+++ b/src/resume_operator/main.py
@@ -9,19 +9,20 @@ from rich.panel import Panel
 from rich.status import Status
 
 from resume_operator.config import get_settings
+from resume_operator.flows.approval import run_approval_loop
+from resume_operator.flows.enrich import DEFAULT_FACTS_PATH, run_auto_enrich
 from resume_operator.graph import (
     build_finalize_graph,
     build_graph,
     build_score_graph,
     build_tailor_graph,
 )
+from resume_operator.prompters import RichPrompter
 from resume_operator.state import (
     ATSScore,
     GapAnalysis,
     OptimizedResume,
-    RejectedSuggestion,
     ResumeData,
-    ResumeOptimizerState,
 )
 
 app = typer.Typer(
@@ -67,9 +68,6 @@ def _validate_facts(facts: Path) -> None:
         raise typer.BadParameter(f"'{facts}' does not exist or is not a file.")
     if facts.suffix.lower() not in {".yaml", ".yml"}:
         raise typer.BadParameter(f"'{facts}' is not a YAML file (expected .yaml or .yml).")
-
-
-DEFAULT_FACTS_PATH = Path("data/facts_bank.yaml")
 
 
 def _validate_job(job: Path) -> None:
@@ -144,177 +142,6 @@ def _should_run_approval_loop(
 
     tailored = result.get("tailored_resume")
     return isinstance(tailored, TailoredResume) and bool(tailored.items)
-
-
-def _run_approval_loop(
-    *,
-    tailor_graph: object,
-    initial_result: dict[str, object],
-    initial_input: dict[str, object],
-    max_iterations: int,
-) -> dict[str, object]:
-    """Drive the iterative tailor → score → gate → propose → approve → apply → re-tailor loop.
-
-    Returns the final tailor-graph result used by the finalize step. The loop
-    exits when (a) the user accepts the current ATS score, (b) the LLM
-    produces no proposals, (c) the user quits mid-approval, or (d) the user
-    declines to continue past the iteration cap — in which case the
-    best-scoring iteration seen so far is returned.
-    """
-    from rich.prompt import Confirm
-
-    from resume_operator.nodes.apply_approvals import apply_approvals
-    from resume_operator.nodes.propose_changes import propose_changes, revise_proposal
-    from resume_operator.tools.approval_flow import run_approval_flow
-
-    current = initial_result
-    best = current
-    best_score = _result_score(current)
-    iteration = 1
-    max_iter_current = max_iterations
-    accumulated_rejections: list[RejectedSuggestion] = []
-
-    while True:
-        score = _result_score(current)
-        if score > best_score:
-            best, best_score = current, score
-
-        color = _score_color(score)
-        console.print(
-            f"\n[bold]Iteration {iteration}/{max_iter_current}:[/bold] "
-            f"ATS score on tailored output = [{color}]{score:.0%}[/{color}]"
-        )
-        if Confirm.ask(
-            "[bold]Accept this tailored version and generate the PDF?[/bold]",
-            default=False,
-            console=console,
-        ):
-            return current
-
-        if iteration >= max_iter_current:
-            console.print(
-                f"[yellow]Reached {max_iter_current} iterations (best ATS={best_score:.0%}). "
-                "Continue iterating?[/yellow]"
-            )
-            if not Confirm.ask("Continue anyway?", default=False, console=console):
-                console.print("[cyan]Using the best-scoring tailored version so far.[/cyan]")
-                return best
-            # Reset counter — user opted in for more. Add another cap on top.
-            max_iter_current = iteration + max_iterations
-
-        # Build a state object for propose + approval + apply (these nodes are
-        # called directly, not through the graph).
-        state = ResumeOptimizerState.model_validate(current)
-        state.rejected_suggestions = list(accumulated_rejections)
-
-        with Status("[bold cyan]LLM proposing tailored edits...", console=console):
-            proposal_out = propose_changes(state)
-        proposals = proposal_out.get("proposals", [])
-        if not proposals:
-            console.print(
-                "[yellow]LLM had no proposals this iteration — "
-                "sticking with the best version so far.[/yellow]"
-            )
-            return best
-
-        outcome = run_approval_flow(
-            state,
-            list(proposals),
-            revise_fn=revise_proposal,
-            console=console,
-        )
-        accumulated_rejections.extend(outcome.rejected)
-        if outcome.quit_early:
-            console.print(
-                "[cyan]You quit the approval step — using the best tailored version so far.[/cyan]"
-            )
-            return best
-        if not outcome.approved:
-            # User rejected everything. No new facts — next tailor pass would
-            # produce the same output. Exit with the best seen.
-            console.print(
-                "[cyan]Nothing approved this iteration — using the best version so far.[/cyan]"
-            )
-            return best
-
-        state.approved_proposals = list(outcome.approved)
-        apply_approvals(state)  # writes to facts_bank.yaml on disk
-
-        with Status("[bold cyan]Re-tailoring with the approved facts...", console=console):
-            current = tailor_graph.invoke(initial_input)  # type: ignore[attr-defined]
-        iteration += 1
-
-
-def _result_score(result: dict[str, object]) -> float:
-    ats = result.get("ats_score")
-    if isinstance(ats, ATSScore):
-        return ats.score
-    if isinstance(ats, dict):
-        value = ats.get("score", 0.0)
-        return float(value) if isinstance(value, (int, float)) else 0.0
-    return 0.0
-
-
-def _run_auto_enrich(*, master_path: Path, facts_path: Path | None, jd_text: str) -> bool:
-    """Pause the pipeline, prompt for an enrichment session, persist accepted items.
-
-    Returns True if any items were appended to the facts bank (so the caller
-    knows to re-invoke the graph), False otherwise.
-    """
-    from rich.prompt import Prompt
-
-    from resume_operator.state import FactsBank
-    from resume_operator.tools.enrich import (
-        assemble_additions,
-        collect_existing_ids,
-        run_interactive_session,
-    )
-    from resume_operator.tools.facts_bank import append_to_facts, load_facts
-    from resume_operator.tools.master_resume import load_master
-
-    console.print(
-        Panel(
-            "Only a few items landed in the tailored resume — your master + "
-            "facts may be thin for this JD. We can grow your facts bank with "
-            "a short interview now (LLM asks grounded questions, you answer "
-            "in your own words, LLM polishes the phrasing).",
-            title="Enrichment available",
-            border_style="yellow",
-        )
-    )
-    if Prompt.ask("Start an enrichment session?", choices=["y", "n"], default="y") != "y":
-        return False
-
-    target_facts = facts_path or DEFAULT_FACTS_PATH
-    master_obj = load_master(master_path)
-    facts_obj = load_facts(target_facts) if target_facts.exists() else FactsBank()
-
-    plan = run_interactive_session(master_obj, facts_obj, jd_text, console=console)
-    if not plan.items:
-        console.print("[yellow]No items accepted — facts_bank unchanged.[/yellow]")
-        return False
-
-    existing_ids = collect_existing_ids(facts_obj)
-    projects, extra_bullets, skills, certifications = assemble_additions(
-        plan, existing_ids=existing_ids
-    )
-    append_to_facts(
-        target_facts,
-        projects=projects,
-        extra_bullets=extra_bullets,
-        skills=skills,
-        certifications=certifications,
-    )
-    console.print(
-        Panel(
-            f"[bold]Wrote:[/bold] {target_facts}\n"
-            f"Projects: +{len(projects)}  |  Extra bullets: +{len(extra_bullets)}  |  "
-            f"Skills: +{len(skills)}  |  Certs: +{len(certifications)}",
-            title="Facts bank updated",
-            border_style="green",
-        )
-    )
-    return True
 
 
 @app.command()
@@ -445,12 +272,14 @@ def run(
 
     tailor_graph = build_tailor_graph()
     finalize_graph = build_finalize_graph()
+    prompter = RichPrompter(console)
     with Status("[bold cyan]Running optimization pipeline...", console=console):
         result = tailor_graph.invoke(initial)
 
     # --- Auto-enrich: if the first tailor pass is thin, offer an interview ---
     if _should_offer_enrich(result, no_enrich=no_enrich, master_path=master):
-        if _run_auto_enrich(
+        if run_auto_enrich(
+            prompter=prompter,
             master_path=master,
             facts_path=resolved_facts,
             jd_text=jd_text,
@@ -473,7 +302,8 @@ def run(
         effective_max_iter = (
             max_iter if max_iter is not None else get_settings().resume_max_iterations
         )
-        result = _run_approval_loop(
+        result = run_approval_loop(
+            prompter=prompter,
             tailor_graph=tailor_graph,
             initial_result=result,
             initial_input=initial,

--- a/src/resume_operator/nodes/analyze_gaps.py
+++ b/src/resume_operator/nodes/analyze_gaps.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, ValidationError
 
+from resume_operator.events import node_span
 from resume_operator.prompts.gap_analysis import ANALYZE_GAPS
 from resume_operator.state import GapAnalysis, ResumeOptimizerState
 from resume_operator.tools.llm_provider import get_structured_llm
@@ -28,6 +29,11 @@ def analyze_gaps(state: ResumeOptimizerState) -> dict[str, Any]:
     Uses ATS score results and full resume/job data to produce actionable
     suggestions for optimizing the resume content.
     """
+    with node_span("analyze_gaps"):
+        return _analyze_gaps_body(state)
+
+
+def _analyze_gaps_body(state: ResumeOptimizerState) -> dict[str, Any]:
     logger.info("analyze_gaps: starting")
     errors: list[str] = list(state.errors)
 

--- a/src/resume_operator/nodes/ats_score.py
+++ b/src/resume_operator/nodes/ats_score.py
@@ -21,6 +21,7 @@ import logging
 from typing import Any
 
 from resume_operator.config import get_settings
+from resume_operator.events import node_span
 from resume_operator.state import (
     ATSReport,
     ContactCheck,
@@ -53,6 +54,11 @@ MEASURABLE_RESULTS_TARGET = 8
 
 def ats_score(state: ResumeOptimizerState) -> dict[str, Any]:
     """Score the master resume against the JD and produce a full `ATSReport`."""
+    with node_span("ats_score"):
+        return _ats_score_body(state)
+
+
+def _ats_score_body(state: ResumeOptimizerState) -> dict[str, Any]:
     logger.info("ats_score: starting")
     errors: list[str] = list(state.errors)
 
@@ -80,6 +86,11 @@ def ats_score_tailored(state: ResumeOptimizerState) -> dict[str, Any]:
     (optimization skipped or failed) the node leaves `state.ats_score` alone
     so the caller still sees the initial master-based score.
     """
+    with node_span("ats_score_tailored"):
+        return _ats_score_tailored_body(state)
+
+
+def _ats_score_tailored_body(state: ResumeOptimizerState) -> dict[str, Any]:
     logger.info("ats_score_tailored: starting")
 
     if not state.tailored_resume.items:

--- a/src/resume_operator/nodes/generate_pdf.py
+++ b/src/resume_operator/nodes/generate_pdf.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from resume_operator.config import get_settings
+from resume_operator.events import node_span
 from resume_operator.state import ResumeOptimizerState
 from resume_operator.tools.pdf_generator import generate_pdf as create_pdf
 from resume_operator.tools.style import StyleTemplate, load_style
@@ -18,6 +19,11 @@ DEFAULT_OUTPUT_PATH = "data/optimized_resume.pdf"
 
 def generate_pdf(state: ResumeOptimizerState) -> dict[str, Any]:
     """Render `state.tailored_resume` to a PDF using the configured template + style."""
+    with node_span("generate_pdf"):
+        return _generate_pdf_body(state)
+
+
+def _generate_pdf_body(state: ResumeOptimizerState) -> dict[str, Any]:
     logger.info("generate_pdf: starting")
     errors: list[str] = list(state.errors)
 

--- a/src/resume_operator/nodes/load_master.py
+++ b/src/resume_operator/nodes/load_master.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from resume_operator.events import node_span
 from resume_operator.state import (
     JobDescription,
     ResumeData,
@@ -25,6 +26,11 @@ def load_master_node(state: ResumeOptimizerState) -> dict[str, Any]:
     still consume `ResumeData` (ats_score, analyze_gaps, optimize_content)
     keep working until their migration in #026.
     """
+    with node_span("load_master"):
+        return _load_master_body(state)
+
+
+def _load_master_body(state: ResumeOptimizerState) -> dict[str, Any]:
     logger.info("load_master: starting")
     errors: list[str] = list(state.errors)
     result: dict[str, Any] = {}

--- a/src/resume_operator/nodes/optimize_content.py
+++ b/src/resume_operator/nodes/optimize_content.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, ValidationError
 
+from resume_operator.events import node_span
 from resume_operator.prompts.content_optimization import OPTIMIZE_CONTENT
 from resume_operator.state import (
     OptimizedResume,
@@ -47,6 +48,11 @@ class TailoredResumeLLMOutput(BaseModel):
 
 def optimize_content(state: ResumeOptimizerState) -> dict[str, Any]:
     """Produce a `TailoredResume` — per-item decisions over master + facts."""
+    with node_span("optimize_content"):
+        return _optimize_content_body(state)
+
+
+def _optimize_content_body(state: ResumeOptimizerState) -> dict[str, Any]:
     logger.info("optimize_content: starting")
     errors: list[str] = list(state.errors)
 

--- a/src/resume_operator/nodes/parse_resume.py
+++ b/src/resume_operator/nodes/parse_resume.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, ValidationError
 
+from resume_operator.events import node_span
 from resume_operator.prompts.resume_parsing import PARSE_RESUME
 from resume_operator.state import (
     EducationEntry,
@@ -159,6 +160,11 @@ def parse_resume(state: ResumeOptimizerState) -> dict[str, Any]:
     ResumeData fields (name, experience, education, skills, etc.).
     Also reads the job description text from file or state.
     """
+    with node_span("parse_resume"):
+        return _parse_resume_body(state)
+
+
+def _parse_resume_body(state: ResumeOptimizerState) -> dict[str, Any]:
     logger.info("parse_resume: starting")
     errors: list[str] = list(state.errors)
     result: dict[str, Any] = {}

--- a/src/resume_operator/nodes/report_results.py
+++ b/src/resume_operator/nodes/report_results.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import yaml
 
+from resume_operator.events import node_span
 from resume_operator.state import ResumeOptimizerState
 from resume_operator.tools.diff_renderer import render_diff
 from resume_operator.tools.source_index import build_source_index
@@ -27,6 +28,11 @@ DIFF_PATH = Path("data/diff.md")
 
 def report_results(state: ResumeOptimizerState) -> dict[str, Any]:
     """Compile and save the full optimization report into the per-run folder."""
+    with node_span("report_results"):
+        return _report_results_body(state)
+
+
+def _report_results_body(state: ResumeOptimizerState) -> dict[str, Any]:
     logger.info("report_results: starting")
     errors: list[str] = list(state.errors)
 

--- a/src/resume_operator/prompter.py
+++ b/src/resume_operator/prompter.py
@@ -1,0 +1,77 @@
+"""Prompter protocol — the single seam between interactive flows and their UI.
+
+The iterative approval loop (#78) and the enrichment interview are the only
+pieces of the pipeline that block on user input. Keeping them behind this
+protocol lets the same business logic run under two frontends:
+
+- `prompters.rich_prompter.RichPrompter` — the CLI, renders via `rich.console`
+- a future `WebSocketPrompter` — the Tauri desktop shell, ferries every call
+  over a websocket message so the React frontend can render a dense,
+  keyboard-driven workspace instead of a terminal prompt
+
+The protocol is intentionally narrow: decision primitives (`confirm`,
+`choose`, `text`), a handful of semantic render calls for the domain objects
+(`render_proposal`, `render_question`, `render_polished`,
+`render_iteration_header`), two generic rendering escape hatches (`notice`,
+`panel`), and a `status` context manager for long-running LLM calls. Rich
+markup (`[bold]...[/bold]`) is passed through as-is; non-CLI implementations
+are expected to translate or strip it.
+"""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from resume_operator.state import Proposal
+    from resume_operator.tools.enrich import PolishedFactLLMOutput, Question
+
+
+@runtime_checkable
+class Prompter(Protocol):
+    """The single seam between interactive flows and their UI."""
+
+    # --- user decisions ---
+    def confirm(self, message: str, *, default: bool = False) -> bool:
+        """Yes/no gate. Returns True on yes."""
+        ...
+
+    def choose(self, message: str, choices: list[str], *, default: str) -> str:
+        """Single-key choice among `choices`. Returned value is lower-cased."""
+        ...
+
+    def text(self, message: str, *, default: str = "") -> str:
+        """Free-text input. Returned value is stripped."""
+        ...
+
+    # --- domain-specific rendering ---
+    def render_proposal(self, proposal: Proposal, *, index: int, total: int) -> None:
+        """Show a single LLM proposal (rewrite_master / rewrite_fact / new_fact / new_skill)."""
+        ...
+
+    def render_iteration_header(self, *, iteration: int, max_iter: int, score: float) -> None:
+        """Show the approval-loop iteration banner with the current ATS score."""
+        ...
+
+    def render_question(self, question: Question, *, index: int, total: int) -> None:
+        """Show a single enrichment interview question."""
+        ...
+
+    def render_polished(self, polished: PolishedFactLLMOutput) -> None:
+        """Show the LLM-polished version of a user answer during enrichment."""
+        ...
+
+    # --- generic rendering escape hatches ---
+    def notice(self, message: str, *, style: str = "") -> None:
+        """Short status message. `style` is a Rich colour tag (e.g. "yellow")."""
+        ...
+
+    def panel(self, message: str, *, title: str, style: str = "") -> None:
+        """Multi-line boxed message (intro panels, summaries, errors)."""
+        ...
+
+    # --- long-running operations ---
+    def status(self, message: str) -> AbstractContextManager[None]:
+        """Wrap a blocking call with a spinner / busy indicator."""
+        ...

--- a/src/resume_operator/prompters/__init__.py
+++ b/src/resume_operator/prompters/__init__.py
@@ -1,0 +1,9 @@
+"""Concrete implementations of the `Prompter` protocol.
+
+- `RichPrompter` drives the CLI via `rich.console.Console`.
+- A future `WebSocketPrompter` (Phase 1) will drive the desktop GUI.
+"""
+
+from resume_operator.prompters.rich_prompter import RichPrompter
+
+__all__ = ["RichPrompter"]

--- a/src/resume_operator/prompters/rich_prompter.py
+++ b/src/resume_operator/prompters/rich_prompter.py
@@ -1,0 +1,129 @@
+"""CLI implementation of the `Prompter` protocol — wraps Rich.
+
+Produces terminal output byte-identical to the pre-refactor CLI so users see
+no behavior change from the prompter-seam introduction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Confirm, Prompt
+from rich.status import Status
+
+if TYPE_CHECKING:
+    from resume_operator.state import Proposal
+    from resume_operator.tools.enrich import PolishedFactLLMOutput, Question
+
+
+# Human-readable labels for every `Proposal.kind` the LLM can emit (#80).
+# Lives here because the CLI is the only renderer that needs them today —
+# other Prompter implementations (e.g. WebSocketPrompter) will own their
+# own labelling and don't import this dict.
+_KIND_LABEL = {
+    "rewrite_master": "Rewrite of your existing master bullet",
+    "rewrite_fact": "Polish of a facts-bank entry",
+    "new_fact": "NEW bullet (LLM extrapolation — verify truth)",
+    "new_skill": "NEW skill (verify you actually have this)",
+}
+
+
+def _score_color(score: float) -> str:
+    if score >= 0.7:
+        return "green"
+    if score >= 0.4:
+        return "yellow"
+    return "red"
+
+
+class RichPrompter:
+    """Renders the interactive flows via `rich.console.Console`."""
+
+    def __init__(self, console: Console | None = None) -> None:
+        self.console = console if console is not None else Console()
+
+    # --- user decisions ---
+    def confirm(self, message: str, *, default: bool = False) -> bool:
+        return Confirm.ask(message, default=default, console=self.console)
+
+    def choose(self, message: str, choices: list[str], *, default: str) -> str:
+        raw = Prompt.ask(message, choices=choices, default=default, console=self.console)
+        return raw.lower()
+
+    def text(self, message: str, *, default: str = "") -> str:
+        raw = Prompt.ask(message, default=default, console=self.console)
+        return raw.strip()
+
+    # --- domain-specific rendering ---
+    def render_proposal(self, proposal: Proposal, *, index: int, total: int) -> None:
+        label = _KIND_LABEL.get(proposal.kind, proposal.kind)
+        lines: list[str] = [
+            f"[bold]{label}[/bold]",
+            f"[dim]grounded in {proposal.grounding_source_id}[/dim]",
+            "",
+        ]
+        if proposal.original_text:
+            lines.append(f"[bold]Original:[/bold]  {proposal.original_text}")
+        lines.append(f"[bold green]Proposed:[/bold green] {proposal.proposed_text}")
+        if proposal.rationale:
+            lines.append("")
+            lines.append(f"[dim]Why: {proposal.rationale}[/dim]")
+        self.console.print(
+            Panel(
+                "\n".join(lines),
+                title=f"Proposal {index}/{total}",
+                border_style="cyan",
+            )
+        )
+
+    def render_iteration_header(self, *, iteration: int, max_iter: int, score: float) -> None:
+        color = _score_color(score)
+        self.console.print(
+            f"\n[bold]Iteration {iteration}/{max_iter}:[/bold] "
+            f"ATS score on tailored output = [{color}]{score:.0%}[/{color}]"
+        )
+
+    def render_question(self, question: Question, *, index: int, total: int) -> None:
+        self.console.print(
+            f"\n[bold cyan]Question {index}/{total}:[/bold cyan] {question.question}"
+        )
+        if question.why:
+            self.console.print(f"[dim]why: {question.why}[/dim]")
+        self.console.print(
+            '[dim]Answer with facts and metrics (e.g. "I built 50+ endpoints serving '
+            "2M requests/day\"). Do NOT type instructions like 'make it professional' "
+            "— that's the LLM's job in the polish step.[/dim]"
+        )
+
+    def render_polished(self, polished: PolishedFactLLMOutput) -> None:
+        target = f" → [magenta]{polished.bucket}[/magenta]" + (
+            f" (role_id={polished.role_id})" if polished.role_id else ""
+        )
+        self.console.print(f"\n[bold green]Polished:[/bold green]{target}")
+        self.console.print(f"  {polished.polished_text}")
+
+    # --- generic rendering escape hatches ---
+    def notice(self, message: str, *, style: str = "") -> None:
+        if style:
+            self.console.print(f"[{style}]{message}[/{style}]")
+        else:
+            self.console.print(message)
+
+    def panel(self, message: str, *, title: str, style: str = "") -> None:
+        self.console.print(Panel(message, title=title, border_style=style or "cyan"))
+
+    # --- long-running operations ---
+    def status(self, message: str) -> AbstractContextManager[None]:
+        return _status_cm(message, self.console)
+
+
+@contextmanager
+def _status_cm(message: str, console: Console) -> Iterator[None]:
+    # Rich's `Status.__enter__` returns itself, not None, so wrap it in a
+    # plain context manager to line up with the Prompter protocol.
+    with Status(message, console=console):
+        yield

--- a/src/resume_operator/server/__init__.py
+++ b/src/resume_operator/server/__init__.py
@@ -1,0 +1,11 @@
+"""FastAPI + WebSocket server wrapping the resume-operator graph.
+
+The server is a peer surface to the CLI — both invoke the same compiled
+LangGraph (`build_score_graph`, `build_tailor_graph`, `build_finalize_graph`)
+and the same interactive flows (`flows.approval`, `flows.enrich`). The
+only thing that changes between them is which `Prompter` drives the
+blocking user-decision calls: `RichPrompter` for the CLI,
+`WebSocketPrompter` for the desktop GUI.
+
+Entry point: `resume-operator-server` (see `pyproject.toml`).
+"""

--- a/src/resume_operator/server/app.py
+++ b/src/resume_operator/server/app.py
@@ -1,0 +1,56 @@
+"""FastAPI app factory + top-level routes wiring.
+
+The server binds to localhost only (the Tauri shell is the only client in
+the Phase 2 roadmap; no multi-host deploy is planned). CORS is enabled
+for dev so `pnpm tauri dev`'s Vite server (typically
+http://localhost:1420) can hit the API during hot-reload.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from resume_operator.server.routes import (
+    bootstrap,
+    extract_style,
+    health,
+    parse_resume,
+    run,
+    score,
+    settings,
+)
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="resume-operator",
+        version="0.1.0",
+        description=(
+            "Localhost server wrapping the resume-operator graph. Consumed by "
+            "the Tauri desktop shell; the CLI is a peer surface."
+        ),
+    )
+    # The Tauri shell ships its own frontend bundle at a `tauri://` origin, so
+    # strict CORS isn't needed in production. Dev mode hits `localhost:1420`
+    # from Vite — allow all localhost/loopback origins to keep the pipeline
+    # friction-free. The server doesn't bind to non-loopback anyway.
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    app.include_router(health.router)
+    app.include_router(settings.router, prefix="/api")
+    app.include_router(score.router, prefix="/api")
+    app.include_router(parse_resume.router, prefix="/api")
+    app.include_router(extract_style.router, prefix="/api")
+    app.include_router(bootstrap.router, prefix="/api")
+    app.include_router(run.router, prefix="/api")
+    return app
+
+
+app = create_app()

--- a/src/resume_operator/server/main.py
+++ b/src/resume_operator/server/main.py
@@ -1,0 +1,52 @@
+"""`resume-operator-server` console entry point.
+
+Thin wrapper around uvicorn that boots the FastAPI app from `app.py`.
+Kept deliberately minimal so the Tauri sidecar (Phase 2, #85) can launch
+it with a fixed port flag and nothing else.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import typer
+import uvicorn
+
+from resume_operator.config import get_settings
+
+cli = typer.Typer(name="resume-operator-server", add_completion=False)
+
+
+@cli.command()
+def run(
+    host: str = typer.Option("127.0.0.1", "--host", help="Bind host (localhost by default)"),
+    port: int = typer.Option(7421, "--port", "-p", help="Bind port"),
+    reload: bool = typer.Option(False, "--reload", help="Hot-reload on code changes (dev only)"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable DEBUG logging"),
+) -> None:
+    """Boot the FastAPI app that wraps the resume-operator graph."""
+    if verbose:
+        level = logging.DEBUG
+    else:
+        level = getattr(logging, get_settings().log_level.upper(), logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    uvicorn.run(
+        "resume_operator.server.app:app",
+        host=host,
+        port=port,
+        reload=reload,
+        log_level=level,
+    )
+
+
+def main() -> None:
+    """Typer entry point — separate fn so `pyproject.toml` can target it."""
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/resume_operator/server/routes/__init__.py
+++ b/src/resume_operator/server/routes/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI route modules — one per resume-operator CLI command + settings + health."""

--- a/src/resume_operator/server/routes/bootstrap.py
+++ b/src/resume_operator/server/routes/bootstrap.py
@@ -1,0 +1,95 @@
+"""`WS /api/ws/bootstrap` — PDF → master YAML with interactive interview.
+
+Mirrors the CLI `bootstrap` command (#60, #70). Client sends `{"type":
+"start", "params": {"resume": "...", "output": "...", "skip_interview":
+false}}`, then responds to the interview prompts (headline, links,
+per-role tech, skill groups) over the same WebSocket.
+
+The parse-resume step itself is non-interactive and runs up front
+(before any prompter traffic); if the parse fails, the session emits an
+`error` and closes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, WebSocket
+from pydantic import BaseModel
+
+from resume_operator.nodes.parse_resume import parse_resume as parse_resume_node
+from resume_operator.server.session_runner import run_flow_over_ws
+from resume_operator.server.ws_prompter import WebSocketPrompter
+from resume_operator.state import ResumeMaster, ResumeOptimizerState
+from resume_operator.tools.bootstrap_interview import run_interview
+from resume_operator.tools.master_resume import save_master
+
+router = APIRouter()
+
+
+class BootstrapParams(BaseModel):
+    resume: str  # path to resume PDF
+    output: str = "data/master_resume.yaml"
+    skip_interview: bool = False
+
+
+class BootstrapResult(BaseModel):
+    output_path: str
+    master: ResumeMaster
+    errors: list[str]
+
+
+def _execute_bootstrap(raw_params: dict[str, Any], prompter: WebSocketPrompter) -> BootstrapResult:
+    params = BootstrapParams.model_validate(raw_params)
+
+    resume_path = Path(params.resume)
+    if not resume_path.exists():
+        raise RuntimeError(f"resume path not found: {params.resume}")
+    if resume_path.suffix.lower() != ".pdf":
+        raise RuntimeError("resume must be a .pdf file")
+
+    with prompter.status("Bootstrapping master resume from PDF..."):
+        state = ResumeOptimizerState(resume_path=str(resume_path))
+        result = parse_resume_node(state)
+
+    errors: list[str] = list(result.get("errors", []))
+    if errors:
+        raise RuntimeError(f"parse-resume failed: {'; '.join(errors)}")
+
+    master: ResumeMaster = result["master"]
+
+    # The GUI always runs the interview — skipping it is a deliberate client
+    # choice (the desktop app can expose a "Skip interview" toggle in the UI).
+    if not params.skip_interview:
+        master = run_interview(master, prompter=prompter)
+
+    output_path = Path(params.output)
+    save_master(master, output_path)
+
+    headline_status = "set" if master.headline else "empty (tailor writes one per JD)"
+    prompter.panel(
+        f"[bold]Wrote:[/bold] {output_path}\n"
+        f"[bold]Experience entries:[/bold] {len(master.experience)}\n"
+        f"[bold]Education entries:[/bold] {len(master.education)}\n"
+        f"[bold]Skills:[/bold] {len(master.all_skills())}\n"
+        f"[bold]Links:[/bold] {len(master.links)}\n"
+        f"[bold]Headline:[/bold] {headline_status}",
+        title="Master resume bootstrapped",
+        style="green",
+    )
+
+    return BootstrapResult(output_path=str(output_path), master=master, errors=errors)
+
+
+def _serialize_bootstrap_result(result: BootstrapResult) -> dict[str, Any]:
+    return result.model_dump()
+
+
+@router.websocket("/ws/bootstrap")
+async def ws_bootstrap(ws: WebSocket) -> None:
+    await run_flow_over_ws(
+        ws,
+        flow_fn=_execute_bootstrap,
+        serialize_result=_serialize_bootstrap_result,
+    )

--- a/src/resume_operator/server/routes/extract_style.py
+++ b/src/resume_operator/server/routes/extract_style.py
@@ -1,0 +1,52 @@
+"""`POST /api/extract-style` — wrap the [extract-style CLI command](src/resume_operator/main.py).
+
+.docx in (by path), `StyleTemplate` out. No interactive state. Thin
+wrapper around `extract_style_from_docx` (#72) — same logic the CLI's
+`extract-style` command uses."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from resume_operator.tools.style import StyleTemplate, save_style
+from resume_operator.tools.style_from_docx import (
+    StyleExtractionError,
+    extract_style_from_docx,
+)
+
+router = APIRouter()
+
+
+class ExtractStyleRequest(BaseModel):
+    source: str  # path to reference .docx
+    output: str | None = None  # optional path — writes the YAML if provided
+
+
+class ExtractStyleResponse(BaseModel):
+    style: StyleTemplate
+    written_to: str | None = None
+
+
+@router.post("/extract-style", response_model=ExtractStyleResponse)
+def extract_style(req: ExtractStyleRequest) -> ExtractStyleResponse:
+    src = Path(req.source)
+    if not src.exists() or not src.is_file():
+        raise HTTPException(status_code=400, detail=f"source path not found: {req.source}")
+    if src.suffix.lower() != ".docx":
+        raise HTTPException(status_code=400, detail="source must be a .docx file")
+
+    try:
+        template = extract_style_from_docx(src)
+    except StyleExtractionError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    written: str | None = None
+    if req.output:
+        out_path = Path(req.output)
+        save_style(template, out_path)
+        written = str(out_path)
+
+    return ExtractStyleResponse(style=template, written_to=written)

--- a/src/resume_operator/server/routes/health.py
+++ b/src/resume_operator/server/routes/health.py
@@ -1,0 +1,28 @@
+"""`GET /health` — single-purpose probe the Tauri shell uses to detect
+when the sidecar is ready to accept requests. Returns in microseconds;
+never hits the graph or any LLM."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from resume_operator.config import get_settings
+
+router = APIRouter()
+
+
+class HealthResponse(BaseModel):
+    status: str
+    llm_provider: str
+    llm_model: str
+
+
+@router.get("/health", response_model=HealthResponse)
+def health() -> HealthResponse:
+    settings = get_settings()
+    return HealthResponse(
+        status="ok",
+        llm_provider=settings.llm_provider,
+        llm_model=settings.llm_model,
+    )

--- a/src/resume_operator/server/routes/parse_resume.py
+++ b/src/resume_operator/server/routes/parse_resume.py
@@ -1,0 +1,45 @@
+"""`POST /api/parse-resume` — wrap the [parse-resume CLI command](src/resume_operator/main.py).
+
+PDF in (by path), `ResumeData` out. No interactive state. Calls the
+`parse_resume` node directly — no graph needed, matching the CLI's
+behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from resume_operator.nodes.parse_resume import parse_resume as parse_resume_node
+from resume_operator.state import ResumeData, ResumeOptimizerState
+
+router = APIRouter()
+
+
+class ParseResumeRequest(BaseModel):
+    resume: str  # path to resume PDF
+
+
+class ParseResumeResponse(BaseModel):
+    resume: ResumeData
+    errors: list[str]
+
+
+@router.post("/parse-resume", response_model=ParseResumeResponse)
+def parse_resume(req: ParseResumeRequest) -> ParseResumeResponse:
+    p = Path(req.resume)
+    if not p.exists() or not p.is_file():
+        raise HTTPException(status_code=400, detail=f"resume path not found: {req.resume}")
+    if p.suffix.lower() != ".pdf":
+        raise HTTPException(status_code=400, detail="resume must be a .pdf file")
+
+    state = ResumeOptimizerState(resume_path=str(p))
+    result = parse_resume_node(state)
+    resume_obj = result.get("resume") or ResumeData()
+    if not isinstance(resume_obj, ResumeData):
+        resume_obj = ResumeData.model_validate(resume_obj)
+    return ParseResumeResponse(
+        resume=resume_obj,
+        errors=list(result.get("errors", [])),
+    )

--- a/src/resume_operator/server/routes/run.py
+++ b/src/resume_operator/server/routes/run.py
@@ -1,0 +1,170 @@
+"""`WS /api/ws/run` — full pipeline with interactive approval loop and auto-enrich.
+
+Mirrors the CLI `run` command end-to-end: load master/resume, tailor,
+optionally enrich, optionally approve iteratively, finalize. The client
+opens a WebSocket, sends one `{"type": "start", "params": {...}}`
+message, and then responds to prompter messages (`confirm` / `choose` /
+`text`) until `{"type": "done", "result": {...}}` arrives.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, WebSocket
+from pydantic import BaseModel, Field
+
+from resume_operator.config import get_settings
+from resume_operator.flows.approval import run_approval_loop
+from resume_operator.flows.enrich import DEFAULT_FACTS_PATH, run_auto_enrich
+from resume_operator.graph import build_finalize_graph, build_tailor_graph
+from resume_operator.server.session_runner import run_flow_over_ws
+from resume_operator.server.ws_prompter import WebSocketPrompter
+from resume_operator.state import ResumeOptimizerState, TailoredResume
+from resume_operator.tools.output_dir import resolve_output_dir
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class RunParams(BaseModel):
+    """Subset of the CLI `run` command's flags that apply to a GUI session."""
+
+    master: str | None = None
+    resume: str | None = None  # legacy PDF path
+    facts: str | None = None
+    job: str  # required
+    output: str | None = None  # parent dir, defaults to data/applications/
+    style: str | None = None
+    no_enrich: bool = False
+    no_approve: bool = False
+    max_iter: int | None = Field(default=None, ge=1)
+
+
+def _should_offer_enrich(
+    result: dict[str, Any], *, no_enrich: bool, master_path: str | None
+) -> bool:
+    """GUI equivalent of `main._should_offer_enrich` — no TTY check, the
+    WebSocket itself is the interactivity signal."""
+    if no_enrich or master_path is None:
+        return False
+    report = result.get("report", {})
+    if isinstance(report, dict) and report.get("optimization_skipped"):
+        return False
+    tailored = result.get("tailored_resume")
+    if not isinstance(tailored, TailoredResume) or not tailored.items:
+        return False
+    threshold = get_settings().enrich_threshold
+    return len(tailored.kept_or_reworded()) < threshold
+
+
+def _should_run_approval_loop(result: dict[str, Any], *, no_approve: bool) -> bool:
+    if no_approve:
+        return False
+    tailored = result.get("tailored_resume")
+    return isinstance(tailored, TailoredResume) and bool(tailored.items)
+
+
+def _build_initial(params: RunParams) -> dict[str, str]:
+    jd_path = Path(params.job)
+    jd_text = jd_path.read_text(encoding="utf-8") if jd_path.exists() else ""
+    output_dir = resolve_output_dir(
+        parent=Path(params.output) if params.output else None,
+        jd_path=jd_path,
+        jd_text=jd_text,
+    )
+    initial: dict[str, str] = {
+        "job_description_path": str(jd_path),
+        "output_dir": str(output_dir),
+        "output_path": str(output_dir / "resume.pdf"),
+    }
+    if params.master:
+        initial["master_path"] = params.master
+    elif params.resume:
+        initial["resume_path"] = params.resume
+    if params.facts:
+        initial["facts_path"] = params.facts
+    elif DEFAULT_FACTS_PATH.exists() and params.master:
+        initial["facts_path"] = str(DEFAULT_FACTS_PATH)
+    if params.style:
+        initial["style_path"] = params.style
+    return initial
+
+
+def _execute_run(raw_params: dict[str, Any], prompter: WebSocketPrompter) -> dict[str, Any]:
+    """Sync mirror of the CLI `run` command — drives the same flows with
+    a `WebSocketPrompter` instead of `RichPrompter`. Runs in a background
+    thread via `run_flow_over_ws`."""
+    params = RunParams.model_validate(raw_params)
+    initial = _build_initial(params)
+    jd_path = Path(params.job)
+    jd_text = jd_path.read_text(encoding="utf-8") if jd_path.exists() else ""
+
+    tailor_graph = build_tailor_graph()
+    finalize_graph = build_finalize_graph()
+
+    with prompter.status("Running optimization pipeline..."):
+        result = tailor_graph.invoke(initial)
+
+    # --- Auto-enrich (#56/#64) ---
+    resolved_facts_str = initial.get("facts_path")
+    resolved_facts = Path(resolved_facts_str) if resolved_facts_str else None
+    if params.master and _should_offer_enrich(
+        result, no_enrich=params.no_enrich, master_path=params.master
+    ):
+        if run_auto_enrich(
+            prompter=prompter,
+            master_path=Path(params.master),
+            facts_path=resolved_facts,
+            jd_text=jd_text,
+        ):
+            prompter.notice("Re-running optimization with enriched facts...", style="cyan")
+            if resolved_facts is None:
+                resolved_facts = DEFAULT_FACTS_PATH
+                initial["facts_path"] = str(resolved_facts)
+            with prompter.status("Re-running pipeline..."):
+                result = tailor_graph.invoke(initial)
+
+    # --- Iterative approval loop (#78) ---
+    if _should_run_approval_loop(result, no_approve=params.no_approve):
+        effective_max_iter = (
+            params.max_iter if params.max_iter is not None else get_settings().resume_max_iterations
+        )
+        result = run_approval_loop(
+            prompter=prompter,
+            tailor_graph=tailor_graph,
+            initial_result=result,
+            initial_input=initial,
+            max_iterations=effective_max_iter,
+        )
+
+    # --- Finalize: render PDF + write artifacts ---
+    with prompter.status("Rendering PDF and writing outputs..."):
+        result = finalize_graph.invoke(result)
+
+    return result
+
+
+def _serialize_run_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Turn a `ResumeOptimizerState`-shaped dict into plain JSON for the client.
+
+    The graph returns a mix of Pydantic models and scalars; route them
+    all through `ResumeOptimizerState.model_validate` + `model_dump` so
+    the frontend gets a consistent shape.
+    """
+    try:
+        state = ResumeOptimizerState.model_validate(result)
+        return state.model_dump(exclude_none=False)
+    except Exception:
+        # Fall back to a loose dump — better to surface a partial result
+        # than crash on serialization right at the end.
+        logger.warning("run result serialization fell back to shallow dump")
+        return {k: (v.model_dump() if hasattr(v, "model_dump") else v) for k, v in result.items()}
+
+
+@router.websocket("/ws/run")
+async def ws_run(ws: WebSocket) -> None:
+    await run_flow_over_ws(ws, flow_fn=_execute_run, serialize_result=_serialize_run_result)

--- a/src/resume_operator/server/routes/score.py
+++ b/src/resume_operator/server/routes/score.py
@@ -1,0 +1,72 @@
+"""`POST /api/score` — wrap the [score CLI command](src/resume_operator/main.py).
+
+Accepts absolute or project-relative paths to a master YAML (or legacy
+resume PDF) and a job description text file. Runs `build_score_graph`
+and returns the resulting `ATSScore`. No interactive state — plain
+request/response.
+
+Since the server runs on localhost, file paths are the natural contract
+(matching how the Tauri shell acquires them via the OS file dialog).
+Multipart uploads are avoidable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, model_validator
+
+from resume_operator.graph import build_score_graph
+from resume_operator.state import ATSScore
+
+router = APIRouter()
+
+
+class ScoreRequest(BaseModel):
+    master: str | None = None  # path to master_resume.yaml
+    resume: str | None = None  # path to resume PDF (legacy)
+    job: str  # path to job description text file
+
+    @model_validator(mode="after")
+    def _exactly_one_source(self) -> ScoreRequest:
+        if not self.master and not self.resume:
+            raise ValueError("provide either `master` or `resume`")
+        if self.master and self.resume:
+            raise ValueError("provide `master` or `resume`, not both")
+        return self
+
+
+class ScoreResponse(BaseModel):
+    ats_score: ATSScore
+    errors: list[str]
+
+
+def _validate_paths(req: ScoreRequest) -> None:
+    for label, value in (("master", req.master), ("resume", req.resume), ("job", req.job)):
+        if value is None:
+            continue
+        p = Path(value)
+        if not p.exists() or not p.is_file():
+            raise HTTPException(
+                status_code=400,
+                detail=f"{label} path does not exist or is not a file: {value}",
+            )
+
+
+@router.post("/score", response_model=ScoreResponse)
+def score(req: ScoreRequest) -> ScoreResponse:
+    _validate_paths(req)
+
+    initial: dict[str, Any] = {"job_description_path": req.job}
+    if req.master:
+        initial["master_path"] = req.master
+    else:
+        initial["resume_path"] = req.resume
+
+    result = build_score_graph().invoke(initial)
+    ats = result.get("ats_score") or ATSScore()
+    if not isinstance(ats, ATSScore):
+        ats = ATSScore.model_validate(ats)
+    return ScoreResponse(ats_score=ats, errors=list(result.get("errors", [])))

--- a/src/resume_operator/server/routes/settings.py
+++ b/src/resume_operator/server/routes/settings.py
@@ -1,0 +1,139 @@
+"""`GET/PUT /api/settings` — surface every env var from `config.py`.
+
+Reads return the current `Settings` instance with API key values masked
+(first 4 / last 4 characters only) so the frontend can show "key is set"
+without leaking the secret back over HTTP — even on localhost this is
+good hygiene. Writes persist to `.env` in the project root, invalidate
+the `get_settings` cache, and take effect on the next request.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from dotenv import dotenv_values, set_key
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from resume_operator.config import Settings, get_settings
+
+router = APIRouter()
+
+
+# Fields whose values must be masked in GET responses.
+_SECRET_FIELDS = frozenset(
+    {
+        "openai_api_key",
+        "anthropic_api_key",
+        "google_api_key",
+        "openrouter_api_key",
+    }
+)
+
+
+def _mask(value: str) -> str:
+    """Preserve enough of the value that the UI can tell if it's set and
+    distinguish two different keys, without exposing the whole secret."""
+    if not value:
+        return ""
+    if len(value) <= 8:
+        return "*" * len(value)
+    return f"{value[:4]}…{value[-4:]}"
+
+
+class SettingsPayload(BaseModel):
+    """The shape of GET responses — masked for secrets, full for plain fields."""
+
+    llm_provider: str
+    llm_model: str
+    openai_api_key: str
+    anthropic_api_key: str
+    google_api_key: str
+    openrouter_api_key: str
+    log_level: str
+    ats_skip_threshold: float
+    resume_template: str
+    resume_style_path: str
+    enrich_threshold: int
+    resume_max_iterations: int
+    ats_weight_hard: float
+    ats_weight_soft: float
+    ats_weight_structural: float
+    ats_weight_title: float
+    ats_weight_measurable: float
+    ats_weight_tone: float
+
+
+class SettingsUpdate(BaseModel):
+    """PUT payload — every field optional. Fields omitted from the request
+    body are untouched on disk."""
+
+    llm_provider: str | None = None
+    llm_model: str | None = None
+    openai_api_key: str | None = None
+    anthropic_api_key: str | None = None
+    google_api_key: str | None = None
+    openrouter_api_key: str | None = None
+    log_level: str | None = None
+    ats_skip_threshold: float | None = None
+    resume_template: str | None = None
+    resume_style_path: str | None = None
+    enrich_threshold: int | None = Field(default=None, ge=0)
+    resume_max_iterations: int | None = Field(default=None, ge=1)
+    ats_weight_hard: float | None = Field(default=None, ge=0.0, le=1.0)
+    ats_weight_soft: float | None = Field(default=None, ge=0.0, le=1.0)
+    ats_weight_structural: float | None = Field(default=None, ge=0.0, le=1.0)
+    ats_weight_title: float | None = Field(default=None, ge=0.0, le=1.0)
+    ats_weight_measurable: float | None = Field(default=None, ge=0.0, le=1.0)
+    ats_weight_tone: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+def _settings_to_payload(s: Settings) -> SettingsPayload:
+    data: dict[str, Any] = s.model_dump()
+    for field in _SECRET_FIELDS:
+        data[field] = _mask(data[field])
+    return SettingsPayload(**data)
+
+
+def _env_path() -> Path:
+    """Where `.env` lives — relative to cwd, matching pydantic-settings."""
+    return Path(".env")
+
+
+@router.get("/settings", response_model=SettingsPayload)
+def read_settings() -> SettingsPayload:
+    return _settings_to_payload(get_settings())
+
+
+@router.put("/settings", response_model=SettingsPayload)
+def write_settings(update: SettingsUpdate) -> SettingsPayload:
+    payload = update.model_dump(exclude_none=True)
+    if not payload:
+        # Nothing to persist — round-trip the current values.
+        return _settings_to_payload(get_settings())
+
+    env_file = _env_path()
+    env_file.touch(exist_ok=True)
+    # `set_key` rewrites in-place, preserving comments and unrelated vars.
+    for key, value in payload.items():
+        set_key(str(env_file), key.upper(), str(value), quote_mode="never")
+
+    # Invalidate the cached Settings so the next call sees the new values.
+    get_settings.cache_clear()
+
+    try:
+        return _settings_to_payload(get_settings())
+    except Exception as exc:  # pragma: no cover — defensive
+        raise HTTPException(status_code=500, detail=f"reload failed: {exc}") from exc
+
+
+@router.get("/settings/env", include_in_schema=False)
+def debug_env_file() -> dict[str, str | None]:
+    """Raw view of `.env` contents — useful for debugging, unmasked. Kept
+    hidden from the OpenAPI schema so casual clients don't stumble onto
+    it."""
+    env_file = _env_path()
+    if not env_file.exists():
+        return {}
+    return dotenv_values(env_file)

--- a/src/resume_operator/server/session_runner.py
+++ b/src/resume_operator/server/session_runner.py
@@ -1,0 +1,137 @@
+"""Helpers that bridge a FastAPI WebSocket to a blocking interactive flow.
+
+The flows (`flows.approval.run_approval_loop`, the bootstrap interview,
+etc.) are blocking — they call `Prompter` methods that wait for user
+input. `run_flow_over_ws` sets up the plumbing:
+
+1. Accepts the WebSocket and reads a single `{"type": "start", ...}`
+   message carrying the flow params.
+2. Creates a `WebSocketPrompter` + `WebSocketEventSink` bound to this
+   connection.
+3. Spawns the sync `flow_fn(params, prompter)` in a background thread
+   so the event loop is free to pump WS messages.
+4. Forwards every `{"type": "reply", ...}` from the client into the
+   prompter's inbox; drops any other client messages.
+5. Awaits flow completion; sends `{"type": "done", "result": ...}`
+   (or `{"type": "error", ...}`) and closes the socket.
+
+Clean disconnects (client closes mid-flow) raise `PrompterDisconnectedError`
+inside the worker thread so the flow can return early instead of
+deadlocking on an unanswered prompt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+from resume_operator.events import bind_sink
+from resume_operator.server.ws_prompter import (
+    PrompterDisconnectedError,
+    WebSocketEventSink,
+    WebSocketPrompter,
+)
+
+logger = logging.getLogger(__name__)
+
+FlowFn = Callable[[dict[str, Any], WebSocketPrompter], Any]
+ResultSerializer = Callable[[Any], Any]
+
+
+async def run_flow_over_ws(
+    ws: WebSocket,
+    *,
+    flow_fn: FlowFn,
+    serialize_result: ResultSerializer = lambda r: r,
+) -> None:
+    """Pump a WebSocket against a blocking `flow_fn(params, prompter)`.
+
+    The flow runs in a thread via `asyncio.to_thread`; this coroutine
+    handles the WS message pump until the flow finishes or the client
+    disconnects.
+    """
+    await ws.accept()
+    loop = asyncio.get_running_loop()
+    prompter = WebSocketPrompter(ws, loop)
+    sink = WebSocketEventSink(prompter)
+
+    # Consume the opening `start` message.
+    try:
+        start_msg = await ws.receive_json()
+    except WebSocketDisconnect:
+        return
+
+    if not isinstance(start_msg, dict) or start_msg.get("type") != "start":
+        await ws.send_json({"type": "error", "message": "expected first message with type=start"})
+        await ws.close()
+        return
+    params = start_msg.get("params") or {}
+
+    flow_task = asyncio.create_task(_run_flow(flow_fn, params, prompter, sink))
+    pump_task = asyncio.create_task(_pump_client_replies(ws, prompter, flow_task))
+
+    # Wait for the flow to finish (or error). `_pump_client_replies` keeps
+    # depositing replies until the flow completes; we cancel it here.
+    try:
+        result = await flow_task
+    except PrompterDisconnectedError:
+        pump_task.cancel()
+        return
+    except Exception as exc:
+        logger.exception("flow failed")
+        try:
+            await ws.send_json({"type": "error", "message": str(exc)})
+        except Exception:
+            pass
+    else:
+        try:
+            await ws.send_json({"type": "done", "result": serialize_result(result)})
+        except Exception:
+            pass
+    finally:
+        pump_task.cancel()
+        try:
+            await ws.close()
+        except Exception:
+            pass
+
+
+async def _run_flow(
+    flow_fn: FlowFn,
+    params: dict[str, Any],
+    prompter: WebSocketPrompter,
+    sink: WebSocketEventSink,
+) -> Any:
+    def _runner() -> Any:
+        with bind_sink(sink):
+            return flow_fn(params, prompter)
+
+    return await asyncio.to_thread(_runner)
+
+
+async def _pump_client_replies(
+    ws: WebSocket,
+    prompter: WebSocketPrompter,
+    flow_task: Awaitable[Any],
+) -> None:
+    """Forward client → prompter. Exits when the flow task completes or
+    the client disconnects."""
+    try:
+        while True:
+            msg = await ws.receive_json()
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("type") == "reply":
+                prompter.deposit_reply(msg)
+            # Other message types (heartbeats, cancellations) are accepted
+            # but not routed in Phase 1. Add dispatch here as needs grow.
+    except WebSocketDisconnect:
+        prompter.close()
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        prompter.close()

--- a/src/resume_operator/server/ws_prompter.py
+++ b/src/resume_operator/server/ws_prompter.py
@@ -1,0 +1,216 @@
+"""`WebSocketPrompter` — drives interactive flows over a FastAPI WebSocket.
+
+The flows (`flows.approval`, `flows.enrich`, `tools.approval_flow`,
+`tools.enrich.run_interactive_session`) call blocking `Prompter`
+methods — `confirm`, `choose`, `text`, `render_*`, `status`. This
+implementation bridges those sync calls to an async WebSocket:
+
+- Outbound (`render_proposal`, `notice`, etc.): the prompter's sync
+  method schedules an `await ws.send_json(...)` on the server's event
+  loop via `asyncio.run_coroutine_threadsafe`.
+- Inbound (`confirm`, `choose`, `text`): the prompter's sync method
+  sends its prompt message, then blocks on `queue.Queue.get()` waiting
+  for a reply that the WS handler deposits when the client answers.
+
+This lets the flows keep their existing synchronous shape while running
+in a background thread (`asyncio.to_thread`), with the main event loop
+free to handle other concurrent WS sessions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import time
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import asdict, is_dataclass
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from resume_operator.events import EventSink, NodeEvent
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from fastapi import WebSocket
+
+    from resume_operator.state import Proposal
+    from resume_operator.tools.enrich import PolishedFactLLMOutput, Question
+
+
+def _dump(obj: Any) -> Any:
+    """Best-effort JSON-ready dict for a domain object."""
+    if isinstance(obj, BaseModel):
+        return obj.model_dump()
+    if is_dataclass(obj) and not isinstance(obj, type):
+        return asdict(obj)
+    return obj
+
+
+class WebSocketPrompter:
+    """Drives the Prompter protocol over a FastAPI WebSocket.
+
+    Instantiated per-session by the WS route handler, which also feeds
+    client replies into `deposit_reply`. The session runs the flow in a
+    background thread — this prompter's methods are called from that
+    thread.
+    """
+
+    def __init__(self, ws: WebSocket, loop: asyncio.AbstractEventLoop) -> None:
+        self._ws = ws
+        self._loop = loop
+        self._inbox: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._closed = False
+
+    # --- bridge mechanics ---------------------------------------------------
+
+    def _send(self, payload: dict[str, Any]) -> None:
+        """Schedule `ws.send_json(payload)` on the server event loop.
+
+        Called from the worker thread. Blocks until the send completes so
+        the flow doesn't race ahead of its own render calls.
+        """
+        if self._closed:
+            return
+        future = asyncio.run_coroutine_threadsafe(self._ws.send_json(payload), self._loop)
+        try:
+            future.result(timeout=10)
+        except Exception:
+            # If send fails (closed socket, cancelled loop), mark the
+            # session closed so subsequent calls short-circuit instead of
+            # blowing up repeatedly.
+            self._closed = True
+            raise
+
+    def _recv(self) -> dict[str, Any]:
+        """Block on `queue.Queue.get()` for a client reply.
+
+        WS handler calls `deposit_reply` when a `{"type": "reply", ...}`
+        message arrives from the client. Raises `PrompterDisconnectedError` if
+        the session has been closed.
+        """
+        reply = self._inbox.get()
+        if reply.get("_closed"):
+            raise PrompterDisconnectedError()
+        return reply
+
+    def deposit_reply(self, message: dict[str, Any]) -> None:
+        """Called by the WS handler when a client reply arrives."""
+        self._inbox.put(message)
+
+    def close(self) -> None:
+        """Signal the prompter that the session is done. Any blocking
+        `_recv` call wakes up and raises `PrompterDisconnectedError`."""
+        self._closed = True
+        self._inbox.put({"_closed": True})
+
+    # --- Prompter: user decisions ------------------------------------------
+
+    def confirm(self, message: str, *, default: bool = False) -> bool:
+        self._send({"type": "confirm", "message": message, "default": default})
+        reply = self._recv()
+        value = reply.get("value", default)
+        return bool(value)
+
+    def choose(self, message: str, choices: list[str], *, default: str) -> str:
+        self._send(
+            {
+                "type": "choose",
+                "message": message,
+                "choices": choices,
+                "default": default,
+            }
+        )
+        reply = self._recv()
+        value = reply.get("value", default)
+        return str(value).lower()
+
+    def text(self, message: str, *, default: str = "") -> str:
+        self._send({"type": "text", "message": message, "default": default})
+        reply = self._recv()
+        value = reply.get("value", default) or ""
+        return str(value).strip()
+
+    # --- Prompter: domain rendering ----------------------------------------
+
+    def render_proposal(self, proposal: Proposal, *, index: int, total: int) -> None:
+        self._send(
+            {
+                "type": "render_proposal",
+                "proposal": _dump(proposal),
+                "index": index,
+                "total": total,
+            }
+        )
+
+    def render_iteration_header(self, *, iteration: int, max_iter: int, score: float) -> None:
+        self._send(
+            {
+                "type": "render_iteration_header",
+                "iteration": iteration,
+                "max_iter": max_iter,
+                "score": score,
+            }
+        )
+
+    def render_question(self, question: Question, *, index: int, total: int) -> None:
+        self._send(
+            {
+                "type": "render_question",
+                "question": _dump(question),
+                "index": index,
+                "total": total,
+            }
+        )
+
+    def render_polished(self, polished: PolishedFactLLMOutput) -> None:
+        self._send({"type": "render_polished", "polished": _dump(polished)})
+
+    # --- Prompter: generic rendering ---------------------------------------
+
+    def notice(self, message: str, *, style: str = "") -> None:
+        self._send({"type": "notice", "message": message, "style": style})
+
+    def panel(self, message: str, *, title: str, style: str = "") -> None:
+        self._send({"type": "panel", "message": message, "title": title, "style": style})
+
+    # --- Prompter: long-running operations ---------------------------------
+
+    def status(self, message: str) -> AbstractContextManager[None]:
+        return self._status_cm(message)
+
+    @contextmanager
+    def _status_cm(self, message: str) -> Iterator[None]:
+        self._send({"type": "status_start", "message": message, "at": time.time()})
+        try:
+            yield
+        finally:
+            self._send({"type": "status_end", "at": time.time()})
+
+
+class PrompterDisconnectedError(RuntimeError):
+    """Raised from a `Prompter` method when the WS client has disconnected
+    mid-session. Caught by the session runner to cleanly abort the flow."""
+
+
+class WebSocketEventSink(EventSink):
+    """Forwards `NodeEvent`s over the same WebSocket as the prompter.
+
+    The node-event channel is one-way — the frontend just renders the
+    live node timeline — so we don't need a reply queue here.
+    """
+
+    def __init__(self, prompter: WebSocketPrompter) -> None:
+        self._prompter = prompter
+
+    def emit(self, event: NodeEvent) -> None:
+        self._prompter._send(
+            {
+                "type": "node_event",
+                "node": event.node,
+                "phase": event.phase,
+                "data": event.data,
+                "timestamp": event.timestamp,
+            }
+        )

--- a/src/resume_operator/tools/approval_flow.py
+++ b/src/resume_operator/tools/approval_flow.py
@@ -1,16 +1,17 @@
 """Three-button + Fix-loop approval UX for #78.
 
-The approval flow is stdin-driven: for each proposal, the user sees the
-original/proposed pair and picks `[y]es`, `[n]o`, or `[f]ix`. `Yes` puts
-the proposal into the approved bucket; `No` records a `RejectedSuggestion`
-with the user's optional reason so the next iteration's
-`propose_changes` pass knows what NOT to re-propose; `Fix` prompts for
-free-text feedback, calls `revise_proposal` to produce v2, and comes
-back to the same three-button gate on v2 — unbounded.
+The approval flow gates each LLM proposal with `[y]es / [n]o / [f]ix`.
+`Yes` puts the proposal into the approved bucket; `No` records a
+`RejectedSuggestion` with the user's optional reason so the next
+iteration's `propose_changes` pass knows what NOT to re-propose; `Fix`
+prompts for free-text feedback, calls `revise_proposal` to produce v2,
+and comes back to the same three-button gate on v2 — unbounded.
 
-The flow is kept out of `main.py` so the graph can call it through a
-single seam and tests can inject scripted console/stdin via
-`console_input`.
+All user interaction and rendering goes through a `Prompter` seam so the
+same flow can drive the CLI (`RichPrompter`) or the desktop GUI
+(`WebSocketPrompter`, Phase 1). This module owns the control flow and the
+single source of truth for `_KIND_LABEL`; the renderer decides how to
+actually display them.
 """
 
 from __future__ import annotations
@@ -23,7 +24,7 @@ from typing import TYPE_CHECKING
 from resume_operator.state import Proposal, RejectedSuggestion, ResumeOptimizerState
 
 if TYPE_CHECKING:
-    from rich.console import Console
+    from resume_operator.prompter import Prompter
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,17 @@ logger = logging.getLogger(__name__)
 # tests can inject a scripted revision function without monkeypatching the
 # propose_changes module.
 ReviseFn = Callable[[ResumeOptimizerState, Proposal, str], "Proposal | None"]
+
+
+# Human-readable labels for every `Proposal.kind` the LLM can emit (#80).
+# Single source of truth — re-exported to any `Prompter` that wants to render
+# the kind field in its own widget.
+_KIND_LABEL = {
+    "rewrite_master": "Rewrite of your existing master bullet",
+    "rewrite_fact": "Polish of a facts-bank entry",
+    "new_fact": "NEW bullet (LLM extrapolation — verify truth)",
+    "new_skill": "NEW skill (verify you actually have this)",
+}
 
 
 @dataclass
@@ -50,7 +62,7 @@ def run_approval_flow(
     proposals: list[Proposal],
     *,
     revise_fn: ReviseFn,
-    console: Console | None = None,
+    prompter: Prompter,
 ) -> ApprovalOutcome:
     """Walk the user through `proposals` one by one. Return an `ApprovalOutcome`
     the caller merges back into state.
@@ -58,12 +70,8 @@ def run_approval_flow(
     `revise_fn` is injected so tests and the real wiring can differ — production
     passes `propose_changes.revise_proposal`; tests pass a scripted function.
     """
-    from rich.console import Console
-
-    active_console = console if console is not None else Console()
-
     if not proposals:
-        active_console.print("[dim]No proposals to review this iteration.[/dim]")
+        prompter.notice("No proposals to review this iteration.", style="dim")
         return ApprovalOutcome()
 
     outcome = ApprovalOutcome()
@@ -73,8 +81,12 @@ def run_approval_flow(
         # Fix loop — each `Fix` replaces `current` with a revised proposal and loops
         # back to the Y/N/F gate. Unbounded by design.
         while True:
-            _render_proposal(active_console, current, index=i, total=total)
-            choice = _ask_choice(active_console)
+            prompter.render_proposal(current, index=i, total=total)
+            choice = prompter.choose(
+                "[Y]es / [N]o / [F]ix — give feedback, LLM revises / [q]uit",
+                choices=["y", "n", "f", "q"],
+                default="y",
+            )
             if choice == "q":
                 outcome.quit_early = True
                 return outcome
@@ -82,7 +94,11 @@ def run_approval_flow(
                 outcome.approved.append(current)
                 break
             if choice == "n":
-                reason = _ask_reason(active_console)
+                reason = prompter.text(
+                    "[dim]Why not? (optional — helps the LLM avoid the same idea "
+                    "next iteration)[/dim]",
+                    default="",
+                )
                 outcome.rejected.append(
                     RejectedSuggestion(
                         kind=current.kind,
@@ -93,89 +109,26 @@ def run_approval_flow(
                 )
                 break
             # choice == "f" — Fix loop.
-            feedback = _ask_feedback(active_console)
+            feedback = prompter.text(
+                "[bold]What should change?[/bold] "
+                '[dim](free text — e.g. "I never used K8s, only ECS")[/dim]',
+                default="",
+            )
             if not feedback:
-                active_console.print(
-                    "[yellow]Empty feedback — keeping the current proposal on screen.[/yellow]"
+                prompter.notice(
+                    "Empty feedback — keeping the current proposal on screen.",
+                    style="yellow",
                 )
                 continue
             revised = revise_fn(state, current, feedback)
             if revised is None:
-                active_console.print(
-                    "[red]Revision failed (LLM error or fabricated grounding). "
-                    "Keeping the previous proposal.[/red]"
+                prompter.notice(
+                    "Revision failed (LLM error or fabricated grounding). "
+                    "Keeping the previous proposal.",
+                    style="red",
                 )
                 continue
             current = revised
-            active_console.print("[green]Got a revised version — here it is.[/green]")
+            prompter.notice("Got a revised version — here it is.", style="green")
 
     return outcome
-
-
-# --- presentation helpers -------------------------------------------------
-
-
-_KIND_LABEL = {
-    "rewrite_master": "Rewrite of your existing master bullet",
-    "rewrite_fact": "Polish of a facts-bank entry",
-    "new_fact": "NEW bullet (LLM extrapolation — verify truth)",
-    "new_skill": "NEW skill (verify you actually have this)",
-}
-
-
-def _render_proposal(console: Console, p: Proposal, *, index: int, total: int) -> None:
-    from rich.panel import Panel
-
-    label = _KIND_LABEL.get(p.kind, p.kind)
-    body_lines: list[str] = [
-        f"[bold]{label}[/bold]",
-        f"[dim]grounded in {p.grounding_source_id}[/dim]",
-        "",
-    ]
-    if p.original_text:
-        body_lines.append(f"[bold]Original:[/bold]  {p.original_text}")
-    body_lines.append(f"[bold green]Proposed:[/bold green] {p.proposed_text}")
-    if p.rationale:
-        body_lines.append("")
-        body_lines.append(f"[dim]Why: {p.rationale}[/dim]")
-    console.print(
-        Panel(
-            "\n".join(body_lines),
-            title=f"Proposal {index}/{total}",
-            border_style="cyan",
-        )
-    )
-
-
-def _ask_choice(console: Console) -> str:
-    from rich.prompt import Prompt
-
-    return Prompt.ask(
-        "[Y]es / [N]o / [F]ix — give feedback, LLM revises / [q]uit",
-        choices=["y", "n", "f", "q"],
-        default="y",
-        console=console,
-    ).lower()
-
-
-def _ask_reason(console: Console) -> str:
-    from rich.prompt import Prompt
-
-    raw = Prompt.ask(
-        "[dim]Why not? (optional — helps the LLM avoid the same idea next iteration)[/dim]",
-        default="",
-        console=console,
-    )
-    return raw.strip()
-
-
-def _ask_feedback(console: Console) -> str:
-    from rich.prompt import Prompt
-
-    raw = Prompt.ask(
-        "[bold]What should change?[/bold] "
-        '[dim](free text — e.g. "I never used K8s, only ECS")[/dim]',
-        default="",
-        console=console,
-    )
-    return raw.strip()

--- a/src/resume_operator/tools/bootstrap_interview.py
+++ b/src/resume_operator/tools/bootstrap_interview.py
@@ -7,21 +7,24 @@ empty and telling the user to hand-edit the YAML, ask — one targeted prompt
 per missing field, `skip` as the default, LLM-proposed skill grouping with
 accept/reject UX.
 
-The interview runs only when stdin is a TTY and the user hasn't opted out via
-`--no-interview`. Headless/scripted runs pass through unchanged.
+User interaction goes through the injected `Prompter` seam so the same
+logic serves both the CLI (`RichPrompter`) and the desktop GUI
+(`WebSocketPrompter`). The CLI's `--no-interview` gating lives in
+`should_run_interview`; the server's gating is explicit in the route
+handler (it always runs when the WS session opens).
 """
 
 from __future__ import annotations
 
 import logging
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from resume_operator.state import Link, ResumeMaster, SkillGroup
 from resume_operator.tools.skill_grouping import propose_groups
 
 if TYPE_CHECKING:
-    from rich.console import Console
+    from resume_operator.prompter import Prompter
 
 logger = logging.getLogger(__name__)
 
@@ -45,127 +48,107 @@ def should_run_interview(*, no_interview: bool) -> bool:
     return sys.stdin.isatty()
 
 
-def run_interview(master: ResumeMaster, console: Console | None = None) -> ResumeMaster:
+def run_interview(master: ResumeMaster, *, prompter: Prompter) -> ResumeMaster:
     """Walk the user through the missing senior-format fields and fill them in.
 
     Returns the (possibly mutated) master. Safe to call with `no-interview`
     already filtered out upstream via `should_run_interview`.
     """
-    from rich.console import Console
-    from rich.panel import Panel
-    from rich.prompt import Confirm, Prompt
-
-    active = console if console is not None else Console()
-    active.print(
-        Panel(
-            "Bootstrap parsed your PDF. A few fields couldn't be extracted "
-            "because the source doesn't show them explicitly. Answer the prompts "
-            "below (or hit Enter to skip each) and I'll stitch them into "
-            "your master_resume.yaml.",
-            title="Bootstrap interview",
-            border_style="cyan",
-        )
+    prompter.panel(
+        "Bootstrap parsed your PDF. A few fields couldn't be extracted "
+        "because the source doesn't show them explicitly. Answer the prompts "
+        "below (or hit Enter to skip each) and I'll stitch them into "
+        "your master_resume.yaml.",
+        title="Bootstrap interview",
+        style="cyan",
     )
 
-    _ask_headline(master, active, Prompt)
-    _ask_links(master, active, Prompt)
-    _ask_per_role_tech(master, active, Prompt)
-    _ask_skill_groups(master, active, Prompt, Confirm)
+    _ask_headline(master, prompter)
+    _ask_links(master, prompter)
+    _ask_per_role_tech(master, prompter)
+    _ask_skill_groups(master, prompter)
 
     return master
 
 
-def _ask_headline(master: ResumeMaster, console: Console, Prompt: Any) -> None:  # noqa: N803
+def _ask_headline(master: ResumeMaster, prompter: Prompter) -> None:
     if master.headline:
         return
-    console.print("\n[bold cyan]Headline[/bold cyan] — a 10-15 word tagline under your name.")
-    console.print(
+    prompter.notice("\n[bold cyan]Headline[/bold cyan] — a 10-15 word tagline under your name.")
+    prompter.notice(
         '[dim]Example: "Senior Backend Engineer · 10+ years · Node.js, AWS". '
         "This is a fallback — the tailor also writes a JD-specific headline per "
         "run. Type 'skip' to leave empty.[/dim]"
     )
-    answer = Prompt.ask("[bold]>[/bold]", default="skip", console=console)
-    cleaned = answer.strip()
-    if cleaned and cleaned.lower() != "skip":
-        master.headline = cleaned
+    answer = prompter.text("[bold]>[/bold]", default="skip")
+    if answer and answer.lower() != "skip":
+        master.headline = answer
 
 
-def _ask_links(master: ResumeMaster, console: Console, Prompt: Any) -> None:  # noqa: N803
+def _ask_links(master: ResumeMaster, prompter: Prompter) -> None:
     existing_labels = {lk.label.lower() for lk in master.links}
     missing = [label for label in _STANDARD_LINK_LABELS if label.lower() not in existing_labels]
     if not missing:
         return
-    console.print(
+    prompter.notice(
         "\n[bold cyan]Header links[/bold cyan] — Portfolio / LinkedIn / GitHub "
         "render as a second contact line."
     )
-    console.print("[dim]Type the URL or hit Enter (default 'skip') to skip each.[/dim]")
+    prompter.notice("[dim]Type the URL or hit Enter (default 'skip') to skip each.[/dim]")
     for label in missing:
-        answer = Prompt.ask(f"[bold]{label} URL[/bold]", default="skip", console=console)
-        cleaned = answer.strip()
-        if cleaned and cleaned.lower() != "skip":
-            master.links.append(Link(label=label, url=cleaned))
+        answer = prompter.text(f"[bold]{label} URL[/bold]", default="skip")
+        if answer and answer.lower() != "skip":
+            master.links.append(Link(label=label, url=answer))
 
 
-def _ask_per_role_tech(master: ResumeMaster, console: Console, Prompt: Any) -> None:  # noqa: N803
+def _ask_per_role_tech(master: ResumeMaster, prompter: Prompter) -> None:
     roles_without_tech = [e for e in master.experience if not e.tech]
     if not roles_without_tech:
         return
-    console.print(
+    prompter.notice(
         f"\n[bold cyan]Per-role tech stacks[/bold cyan] — "
         f"{len(roles_without_tech)} role(s) need one."
     )
-    console.print(
+    prompter.notice(
         "[dim]For each role, type the tech comma-separated (e.g. "
         '"Python, PostgreSQL, AWS"). Hit Enter to skip.[/dim]'
     )
     for entry in roles_without_tech:
         label = f"{entry.role} @ {entry.company}".strip(" @") or entry.id
-        answer = Prompt.ask(f"[bold]{label}[/bold]", default="skip", console=console)
-        cleaned = answer.strip()
-        if not cleaned or cleaned.lower() == "skip":
+        answer = prompter.text(f"[bold]{label}[/bold]", default="skip")
+        if not answer or answer.lower() == "skip":
             continue
-        entry.tech = [t.strip() for t in cleaned.split(",") if t.strip()]
+        entry.tech = [t.strip() for t in answer.split(",") if t.strip()]
 
 
-def _ask_skill_groups(
-    master: ResumeMaster,
-    console: Console,
-    Prompt: Any,  # noqa: N803
-    Confirm: Any,  # noqa: N803
-) -> None:
+def _ask_skill_groups(master: ResumeMaster, prompter: Prompter) -> None:
     if master.skill_groups:
         return
     if len(master.skills) < _SKILL_GROUPING_MIN:
         return
-    console.print(
+    prompter.notice(
         f"\n[bold cyan]Skill grouping[/bold cyan] — you have {len(master.skills)} flat skills."
     )
-    if not Confirm.ask(
+    if not prompter.confirm(
         "Have the LLM propose categories (Languages / Frontend / Backend / Cloud / ...)?",
         default=True,
-        console=console,
     ):
         return
 
     groups = propose_groups(master.skills)
     if not groups:
-        console.print("[yellow]LLM didn't return a usable grouping — leaving skills flat.[/yellow]")
+        prompter.notice(
+            "LLM didn't return a usable grouping — leaving skills flat.",
+            style="yellow",
+        )
         return
 
-    _print_groups(groups, console)
-    choice = Prompt.ask(
-        "[a]ccept / [r]eject",
-        choices=["a", "r"],
-        default="a",
-        console=console,
-    )
+    _print_groups(groups, prompter)
+    choice = prompter.choose("[a]ccept / [r]eject", choices=["a", "r"], default="a")
     if choice == "a":
         master.skill_groups = groups
 
 
-def _print_groups(groups: list[SkillGroup], console: Console) -> None:
-    from rich.panel import Panel
-
+def _print_groups(groups: list[SkillGroup], prompter: Prompter) -> None:
     body = "\n".join(f"[bold]{g.category}[/bold]: {', '.join(g.items)}" for g in groups)
-    console.print(Panel(body, title="Proposed grouping", border_style="green"))
+    prompter.panel(body, title="Proposed grouping", style="green")

--- a/src/resume_operator/tools/enrich.py
+++ b/src/resume_operator/tools/enrich.py
@@ -2,16 +2,19 @@
 
 Flow:
   1. `generate_questions(master, facts, jd)` → up to N `Question` objects.
-  2. For each question, the CLI prompts the user for a free-text answer.
+  2. For each question, the session prompts the user for a free-text answer.
   3. `polish_answer(question, answer, master, jd)` → a `PolishedFact` that
      rewrites the answer as an ATS-ready bullet and classifies which
      facts_bank bucket it belongs in.
-  4. The CLI shows the polished bullet and asks accept / edit / reject.
+  4. The session shows the polished bullet and asks accept / edit / reject.
   5. `assemble_additions(accepted)` → four lists ready to hand to
      `tools.facts_bank.append_to_facts`.
 
-This module is LLM-facing logic only — the interactive prompting lives in
-`main.py` so tests can exercise the pure functions without stdin mocking.
+The LLM-facing helpers (`generate_questions`, `polish_answer`,
+`assemble_additions`, `collect_existing_ids`) are pure and testable without
+stdin mocking. `run_interactive_session` drives the user-facing loop
+through a `Prompter` seam so the same logic serves both the CLI and the
+desktop GUI.
 """
 
 from __future__ import annotations
@@ -29,7 +32,7 @@ from resume_operator.state import FactItem, FactsBank, ResumeMaster
 from resume_operator.tools.llm_provider import get_structured_llm
 
 if TYPE_CHECKING:
-    from rich.console import Console
+    from resume_operator.prompter import Prompter
 
 logger = logging.getLogger(__name__)
 
@@ -220,9 +223,9 @@ def collect_existing_ids(bank: FactsBank) -> set[str]:
 
 # --- Interactive session --------------------------------------------------
 #
-# Kept here (rather than in main.py) so `run`'s auto-enrich path and any future
-# non-CLI caller can reuse the same loop. The prompting primitives still come
-# from Rich; the function reads from stdin via Rich's `Prompt.ask`.
+# Kept here alongside the pure LLM helpers so `run`'s auto-enrich path and any
+# future non-CLI caller (server, tests) can reuse the same loop. User
+# interaction goes through the injected `Prompter` seam.
 
 
 def run_interactive_session(
@@ -231,84 +234,57 @@ def run_interactive_session(
     jd_text: str,
     *,
     max_questions: int = 5,
-    console: Console | None = None,
+    prompter: Prompter,
 ) -> SessionPlan:
     """Interactive enrichment session: ask → answer → polish → accept/edit/reject.
 
     Returns a `SessionPlan` with accepted items. Caller is responsible for
     persisting the plan via `assemble_additions` + `facts_bank.append_to_facts`.
-
-    The console is optional so tests can inject a silent/buffer console; when
-    `None`, a default Rich `Console` is used.
     """
-    from rich.console import Console
-    from rich.panel import Panel
-    from rich.prompt import Prompt
-    from rich.status import Status
-
-    active_console = console if console is not None else Console()
-
-    with Status("[bold cyan]Generating interview questions...", console=active_console):
+    with prompter.status("[bold cyan]Generating interview questions..."):
         questions = generate_questions(master, facts, jd_text, n_max=max_questions)
 
     if not questions:
-        active_console.print(
-            Panel(
-                "The LLM didn't surface any gap-worthy questions. Either your "
-                "master already covers this JD, or the question-generation call "
-                "failed (run with --verbose to see).",
-                title="No questions",
-                border_style="yellow",
-            )
+        prompter.panel(
+            "The LLM didn't surface any gap-worthy questions. Either your "
+            "master already covers this JD, or the question-generation call "
+            "failed (run with --verbose to see).",
+            title="No questions",
+            style="yellow",
         )
         return SessionPlan()
 
-    active_console.print(
-        Panel(
-            f"[bold]{len(questions)} question(s) to discuss.[/bold]\n\n"
-            "[dim]For each question: answer with facts and metrics — e.g. "
-            '"I built 50+ endpoints serving 2M requests/day" — not with instructions. '
-            "Type 'skip' to skip, 'quit' to end early.[/dim]",
-            title="Enrichment session",
-            border_style="cyan",
-        )
+    prompter.panel(
+        f"[bold]{len(questions)} question(s) to discuss.[/bold]\n\n"
+        "[dim]For each question: answer with facts and metrics — e.g. "
+        '"I built 50+ endpoints serving 2M requests/day" — not with instructions. '
+        "Type 'skip' to skip, 'quit' to end early.[/dim]",
+        title="Enrichment session",
+        style="cyan",
     )
 
     plan = SessionPlan()
+    total = len(questions)
     for i, question in enumerate(questions, 1):
-        active_console.print(
-            f"\n[bold cyan]Question {i}/{len(questions)}:[/bold cyan] {question.question}"
-        )
-        active_console.print(f"[dim]why: {question.why}[/dim]")
-        active_console.print(
-            '[dim]Answer with facts and metrics (e.g. "I built 50+ endpoints serving '
-            "2M requests/day\"). Do NOT type instructions like 'make it professional' "
-            "— that's the LLM's job in the polish step.[/dim]"
-        )
-        answer = Prompt.ask("[bold]>[/bold]", default="", console=active_console)
-        answer_stripped = answer.strip()
-        if answer_stripped.lower() == "quit":
+        prompter.render_question(question, index=i, total=total)
+        answer = prompter.text("[bold]>[/bold]", default="")
+        if answer.lower() == "quit":
             break
-        if not answer_stripped or answer_stripped.lower() == "skip":
+        if not answer or answer.lower() == "skip":
             continue
 
-        with Status("[bold cyan]Polishing...", console=active_console):
+        with prompter.status("[bold cyan]Polishing..."):
             polished = polish_answer(question, answer, master, jd_text)
         if polished is None:
-            active_console.print("[red]Polish step failed — skipping this question.[/red]")
+            prompter.notice("Polish step failed — skipping this question.", style="red")
             continue
 
-        target = f" → [magenta]{polished.bucket}[/magenta]" + (
-            f" (role_id={polished.role_id})" if polished.role_id else ""
-        )
-        active_console.print(f"\n[bold green]Polished:[/bold green]{target}")
-        active_console.print(f"  {polished.polished_text}")
+        prompter.render_polished(polished)
 
-        choice = Prompt.ask(
+        choice = prompter.choose(
             "[a]ccept / [e]dit / [r]eject / [s]kip / [q]uit",
             choices=["a", "e", "r", "s", "q"],
             default="a",
-            console=active_console,
         )
         if choice == "q":
             break
@@ -316,10 +292,8 @@ def run_interactive_session(
             continue
         final_text = polished.polished_text
         if choice == "e":
-            edited = Prompt.ask(
-                "[bold]Your wording[/bold]", default=final_text, console=active_console
-            )
-            final_text = edited.strip() or final_text
+            edited = prompter.text("[bold]Your wording[/bold]", default=final_text)
+            final_text = edited or final_text
         plan.items.append(
             AcceptedItem(
                 text=final_text,

--- a/tests/test_approval_flow.py
+++ b/tests/test_approval_flow.py
@@ -12,13 +12,15 @@ from unittest.mock import patch
 
 from rich.console import Console
 
+from resume_operator.prompters import RichPrompter
 from resume_operator.state import Proposal, ResumeOptimizerState
 from resume_operator.tools.approval_flow import run_approval_flow
 
 
-def _silent_console() -> Console:
-    # record=True + no file makes the console silent enough for test output.
-    return Console(file=None, quiet=True)
+def _silent_prompter() -> RichPrompter:
+    # quiet=True suppresses Rich output for test clarity; the RichPrompter
+    # still goes through `Prompt.ask` / `Confirm.ask`, which the tests patch.
+    return RichPrompter(Console(file=None, quiet=True))
 
 
 def _proposal(
@@ -55,7 +57,7 @@ class TestRunApprovalFlow:
     def test_empty_proposals_returns_empty_outcome(self) -> None:
         state = ResumeOptimizerState()
         outcome = run_approval_flow(
-            state, [], revise_fn=lambda *a, **kw: None, console=_silent_console()
+            state, [], revise_fn=lambda *a, **kw: None, prompter=_silent_prompter()
         )
         assert outcome.approved == []
         assert outcome.rejected == []
@@ -66,7 +68,7 @@ class TestRunApprovalFlow:
         p = _proposal()
         with patch("rich.prompt.Prompt.ask", side_effect=_scripted(["y"])):
             outcome = run_approval_flow(
-                state, [p], revise_fn=lambda *a, **kw: None, console=_silent_console()
+                state, [p], revise_fn=lambda *a, **kw: None, prompter=_silent_prompter()
             )
         assert outcome.approved == [p]
         assert outcome.rejected == []
@@ -77,7 +79,7 @@ class TestRunApprovalFlow:
         # Scripted: choice="n", then reason="I never used K8s".
         with patch("rich.prompt.Prompt.ask", side_effect=_scripted(["n", "I never used K8s"])):
             outcome = run_approval_flow(
-                state, [p], revise_fn=lambda *a, **kw: None, console=_silent_console()
+                state, [p], revise_fn=lambda *a, **kw: None, prompter=_silent_prompter()
             )
         assert outcome.approved == []
         assert len(outcome.rejected) == 1
@@ -90,7 +92,7 @@ class TestRunApprovalFlow:
         p = _proposal()
         with patch("rich.prompt.Prompt.ask", side_effect=_scripted(["n", ""])):
             outcome = run_approval_flow(
-                state, [p], revise_fn=lambda *a, **kw: None, console=_silent_console()
+                state, [p], revise_fn=lambda *a, **kw: None, prompter=_silent_prompter()
             )
         assert len(outcome.rejected) == 1
         assert outcome.rejected[0].user_reason == ""
@@ -122,7 +124,7 @@ class TestRunApprovalFlow:
                 state,
                 [v1],
                 revise_fn=scripted_revise,
-                console=_silent_console(),
+                prompter=_silent_prompter(),
             )
 
         assert outcome.approved == [v2]
@@ -147,7 +149,7 @@ class TestRunApprovalFlow:
             side_effect=_scripted(["f", "first feedback", "f", "second feedback", "y"]),
         ):
             outcome = run_approval_flow(
-                state, [v1], revise_fn=scripted_revise, console=_silent_console()
+                state, [v1], revise_fn=scripted_revise, prompter=_silent_prompter()
             )
         assert outcome.approved == [v3]
 
@@ -163,7 +165,7 @@ class TestRunApprovalFlow:
         # f → empty feedback → y (accept original, no revision happened)
         with patch("rich.prompt.Prompt.ask", side_effect=_scripted(["f", "", "y"])):
             outcome = run_approval_flow(
-                state, [p], revise_fn=should_not_be_called, console=_silent_console()
+                state, [p], revise_fn=should_not_be_called, prompter=_silent_prompter()
             )
         assert outcome.approved == [p]
 
@@ -176,7 +178,7 @@ class TestRunApprovalFlow:
         # f → feedback → None from revise_fn → y on original
         with patch("rich.prompt.Prompt.ask", side_effect=_scripted(["f", "feedback", "y"])):
             outcome = run_approval_flow(
-                state, [p], revise_fn=lambda *a, **kw: None, console=_silent_console()
+                state, [p], revise_fn=lambda *a, **kw: None, prompter=_silent_prompter()
             )
         assert outcome.approved == [p]
 
@@ -189,7 +191,7 @@ class TestRunApprovalFlow:
                 state,
                 [p1, p2],
                 revise_fn=lambda *a, **kw: None,
-                console=_silent_console(),
+                prompter=_silent_prompter(),
             )
         assert outcome.quit_early is True
         assert outcome.approved == []

--- a/tests/test_bootstrap_interview.py
+++ b/tests/test_bootstrap_interview.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from rich.console import Console
 
+from resume_operator.prompters import RichPrompter
 from resume_operator.state import (
     ExperienceBullet,
     ExperienceEntry,
@@ -38,6 +39,13 @@ def _silent_console() -> Console:
     import io
 
     return Console(file=io.StringIO(), force_terminal=False, record=False)
+
+
+def _silent_prompter() -> RichPrompter:
+    """A `RichPrompter` backed by a silent Console. Still routes prompts
+    through `rich.prompt.Prompt.ask` / `Confirm.ask` so tests can patch
+    those directly."""
+    return RichPrompter(_silent_console())
 
 
 def _minimal_master() -> ResumeMaster:
@@ -90,7 +98,7 @@ class TestRunInterviewHeadline:
             patch("rich.prompt.Prompt.ask", side_effect=lambda *a, **kw: next(answers)),
             patch("rich.prompt.Confirm.ask", return_value=False),
         ):
-            run_interview(master, console=_silent_console())
+            run_interview(master, prompter=_silent_prompter())
         assert master.headline == "Senior Engineer · 10+ years · Python"
 
     def test_skips_when_user_types_skip(self) -> None:
@@ -99,7 +107,7 @@ class TestRunInterviewHeadline:
             patch("rich.prompt.Prompt.ask", return_value="skip"),
             patch("rich.prompt.Confirm.ask", return_value=False),
         ):
-            run_interview(master, console=_silent_console())
+            run_interview(master, prompter=_silent_prompter())
         assert master.headline == ""
 
     def test_existing_headline_not_re_asked(self) -> None:
@@ -109,7 +117,7 @@ class TestRunInterviewHeadline:
             patch("rich.prompt.Prompt.ask", return_value="skip"),
             patch("rich.prompt.Confirm.ask", return_value=False),
         ):
-            run_interview(master, console=_silent_console())
+            run_interview(master, prompter=_silent_prompter())
         assert master.headline == "Pre-existing tagline"
 
 
@@ -130,7 +138,7 @@ class TestRunInterviewLinks:
             patch("rich.prompt.Prompt.ask", side_effect=lambda *a, **kw: next(answers)),
             patch("rich.prompt.Confirm.ask", return_value=False),
         ):
-            run_interview(master, console=_silent_console())
+            run_interview(master, prompter=_silent_prompter())
 
         labels = {lk.label for lk in master.links}
         assert labels == {"Portfolio", "LinkedIn"}
@@ -143,7 +151,7 @@ class TestRunInterviewLinks:
             patch("rich.prompt.Prompt.ask", return_value="skip"),
             patch("rich.prompt.Confirm.ask", return_value=False),
         ):
-            run_interview(master, console=_silent_console())
+            run_interview(master, prompter=_silent_prompter())
         # Still just the one pre-existing link.
         assert len(master.links) == 1
         assert master.links[0].label == "GitHub"
@@ -175,7 +183,7 @@ class TestRunInterviewPerRoleTech:
             patch("rich.prompt.Prompt.ask", side_effect=lambda *a, **kw: next(answers)),
             patch("rich.prompt.Confirm.ask", return_value=False),
         ):
-            run_interview(master, console=_silent_console())
+            run_interview(master, prompter=_silent_prompter())
 
         assert master.experience[0].tech == ["Python", "PostgreSQL", "Docker"]
         # exp-2's tech is untouched.
@@ -206,7 +214,7 @@ class TestRunInterviewSkillGrouping:
             patch("rich.prompt.Prompt.ask", side_effect=lambda *a, **kw: next(answers)),
             patch("rich.prompt.Confirm.ask", return_value=True),
         ):
-            run_interview(master, console=_silent_console())
+            run_interview(master, prompter=_silent_prompter())
 
         assert len(master.skill_groups) == 3
         categories = {g.category for g in master.skill_groups}
@@ -226,7 +234,7 @@ class TestRunInterviewSkillGrouping:
             patch("rich.prompt.Prompt.ask", side_effect=lambda *a, **kw: next(answers)),
             patch("rich.prompt.Confirm.ask", return_value=True),
         ):
-            run_interview(master, console=_silent_console())
+            run_interview(master, prompter=_silent_prompter())
 
         assert master.skill_groups == []
 
@@ -238,7 +246,7 @@ class TestRunInterviewSkillGrouping:
             patch("rich.prompt.Prompt.ask", return_value="skip"),
             patch("rich.prompt.Confirm.ask", return_value=False),  # declines grouping
         ):
-            run_interview(master, console=_silent_console())
+            run_interview(master, prompter=_silent_prompter())
 
         mock_propose.assert_not_called()
         assert master.skill_groups == []
@@ -252,7 +260,7 @@ class TestRunInterviewSkillGrouping:
             patch("rich.prompt.Prompt.ask", return_value="skip"),
             patch("rich.prompt.Confirm.ask", return_value=True),
         ):
-            run_interview(master, console=_silent_console())
+            run_interview(master, prompter=_silent_prompter())
 
         mock_propose.assert_not_called()
         assert master.skill_groups == []

--- a/tests/test_iterative_loop.py
+++ b/tests/test_iterative_loop.py
@@ -1,6 +1,6 @@
 """Integration tests for the #78 iterative tailor approval loop.
 
-These tests hit `_run_approval_loop` directly with mocked tailor graph +
+These tests hit `run_approval_loop` directly with mocked tailor graph +
 LLM calls, so we can assert on the loop's control flow (accept / quit /
 cap / empty-proposals / approved-then-reloop) without running the whole
 LangGraph pipeline.
@@ -12,8 +12,10 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from rich.console import Console
 
-from resume_operator.main import _run_approval_loop
+from resume_operator.flows.approval import run_approval_loop
+from resume_operator.prompters import RichPrompter
 from resume_operator.state import (
     ATSScore,
     FactItem,
@@ -26,10 +28,14 @@ from resume_operator.state import (
 from resume_operator.tools.facts_bank import save_facts
 
 
+def _silent_prompter() -> RichPrompter:
+    return RichPrompter(Console(file=None, quiet=True))
+
+
 def _tailor_result(
     score: float, iteration_id: str = "", tailored_items: int = 2
 ) -> dict[str, object]:
-    """Build a minimal dict that _run_approval_loop can treat as a tailor-graph result."""
+    """Build a minimal dict that run_approval_loop can treat as a tailor-graph result."""
     return {
         "ats_score": ATSScore(score=score, reasoning=f"iter {iteration_id}"),
         "tailored_resume": TailoredResume(
@@ -69,7 +75,8 @@ class TestApprovalLoop:
         initial_result = _tailor_result(score=0.75, iteration_id="1")
         initial_input = {"facts_path": str(facts_path)}
 
-        final = _run_approval_loop(
+        final = run_approval_loop(
+            prompter=_silent_prompter(),
             tailor_graph=tailor_graph,
             initial_result=initial_result,
             initial_input=initial_input,
@@ -120,7 +127,8 @@ class TestApprovalLoop:
         tailor_graph.invoke.return_value = _tailor_result(score=0.85, iteration_id="2")
 
         initial_result = _tailor_result(score=0.70, iteration_id="1")
-        final = _run_approval_loop(
+        final = run_approval_loop(
+            prompter=_silent_prompter(),
             tailor_graph=tailor_graph,
             initial_result=initial_result,
             initial_input={"facts_path": str(facts_path)},
@@ -151,7 +159,8 @@ class TestApprovalLoop:
         tailor_graph = MagicMock()  # shouldn't be re-invoked
         initial_result = _tailor_result(score=0.60, iteration_id="1")
 
-        final = _run_approval_loop(
+        final = run_approval_loop(
+            prompter=_silent_prompter(),
             tailor_graph=tailor_graph,
             initial_result=initial_result,
             initial_input={"facts_path": str(facts_path)},
@@ -189,7 +198,8 @@ class TestApprovalLoop:
 
         tailor_graph = MagicMock()
         initial_result = _tailor_result(score=0.55)
-        final = _run_approval_loop(
+        final = run_approval_loop(
+            prompter=_silent_prompter(),
             tailor_graph=tailor_graph,
             initial_result=initial_result,
             initial_input={"facts_path": str(facts_path)},
@@ -220,7 +230,8 @@ class TestApprovalLoop:
 
         tailor_graph = MagicMock()
         initial_result = _tailor_result(score=0.65, iteration_id="1")
-        final = _run_approval_loop(
+        final = run_approval_loop(
+            prompter=_silent_prompter(),
             tailor_graph=tailor_graph,
             initial_result=initial_result,
             initial_input={"facts_path": str(facts_path)},
@@ -279,7 +290,8 @@ class TestApprovalLoop:
 
         initial_result = _tailor_result(score=0.80, iteration_id="1")
 
-        final = _run_approval_loop(
+        final = run_approval_loop(
+            prompter=_silent_prompter(),
             tailor_graph=tailor_graph,
             initial_result=initial_result,
             initial_input={"facts_path": str(facts_path)},

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,343 @@
+"""Tests for the FastAPI + WebSocket server (Phase 1, #84).
+
+Covers:
+
+- Plain HTTP routes (health, settings, score, parse-resume, extract-style)
+  with the underlying graph / node / tool calls mocked so no LLM fires.
+- WebSocket session lifecycle — `/ws/run` drives an approval loop end to
+  end with a scripted client that approves the first iteration.
+- `WebSocketPrompter` unit tests for the message shapes the frontend
+  will consume.
+
+The goal is not coverage of the graph itself (that's already in the other
+test files); it's coverage of the **new plumbing**: request/response
+shapes, WS protocol, prompter ↔ websocket bridging.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from resume_operator.config import get_settings
+from resume_operator.server.app import create_app
+from resume_operator.state import (
+    ATSScore,
+    ResumeData,
+    ResumeMaster,
+    TailoredItem,
+    TailoredResume,
+)
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    # Point each test at a temp .env so the settings write path doesn't
+    # clobber the developer's real config.
+    monkeypatch.chdir(tmp_path)
+    get_settings.cache_clear()
+    return TestClient(create_app())
+
+
+# --------------------------------------------------------------------------
+# /health
+# --------------------------------------------------------------------------
+
+
+class TestHealth:
+    def test_returns_ok(self, client: TestClient) -> None:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert "llm_provider" in body
+        assert "llm_model" in body
+
+
+# --------------------------------------------------------------------------
+# /api/settings
+# --------------------------------------------------------------------------
+
+
+class TestSettings:
+    def test_get_masks_api_keys(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-abcdefghij1234567890")
+        get_settings.cache_clear()
+        resp = client.get("/api/settings")
+        assert resp.status_code == 200
+        body = resp.json()
+        # Masked: should NOT contain the middle of the key.
+        assert "abcdefghij" not in body["openai_api_key"]
+        # But should still indicate the key is set (first/last chars visible).
+        assert body["openai_api_key"].startswith("sk-p")
+        assert body["openai_api_key"].endswith("7890")
+
+    def test_put_persists_to_env_file(self, client: TestClient, tmp_path: Path) -> None:
+        resp = client.put(
+            "/api/settings",
+            json={"llm_provider": "anthropic", "llm_model": "claude-sonnet-4-6"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["llm_provider"] == "anthropic"
+        assert body["llm_model"] == "claude-sonnet-4-6"
+
+        env_file = tmp_path / ".env"
+        assert env_file.exists()
+        content = env_file.read_text()
+        assert "LLM_PROVIDER=anthropic" in content
+        assert "LLM_MODEL=claude-sonnet-4-6" in content
+
+    def test_put_empty_payload_is_noop(self, client: TestClient) -> None:
+        resp = client.put("/api/settings", json={})
+        assert resp.status_code == 200
+        # Just round-trips the current values — no env file created.
+
+
+# --------------------------------------------------------------------------
+# /api/score
+# --------------------------------------------------------------------------
+
+
+class TestScore:
+    def test_requires_master_or_resume(self, client: TestClient) -> None:
+        resp = client.post("/api/score", json={"job": "job.txt"})
+        assert resp.status_code == 422  # pydantic validator
+
+    def test_rejects_nonexistent_paths(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/score", json={"master": "nope.yaml", "job": "also-nope.txt"}
+        )
+        assert resp.status_code == 400
+
+    @patch("resume_operator.server.routes.score.build_score_graph")
+    def test_returns_ats_score(
+        self, mock_build: MagicMock, client: TestClient, tmp_path: Path
+    ) -> None:
+        master = tmp_path / "m.yaml"
+        master.write_text("name: Test\n")
+        job = tmp_path / "j.txt"
+        job.write_text("Backend role.")
+
+        graph = MagicMock()
+        graph.invoke.return_value = {
+            "ats_score": ATSScore(score=0.82, reasoning="looks good"),
+            "errors": [],
+        }
+        mock_build.return_value = graph
+
+        resp = client.post(
+            "/api/score", json={"master": str(master), "job": str(job)}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ats_score"]["score"] == pytest.approx(0.82)
+        assert body["errors"] == []
+        graph.invoke.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# /api/parse-resume
+# --------------------------------------------------------------------------
+
+
+class TestParseResumeRoute:
+    def test_rejects_non_pdf(self, client: TestClient, tmp_path: Path) -> None:
+        f = tmp_path / "not-a-pdf.txt"
+        f.write_text("x")
+        resp = client.post("/api/parse-resume", json={"resume": str(f)})
+        assert resp.status_code == 400
+
+    @patch("resume_operator.server.routes.parse_resume.parse_resume_node")
+    def test_returns_resume_data(
+        self, mock_node: MagicMock, client: TestClient, tmp_path: Path
+    ) -> None:
+        resume = tmp_path / "resume.pdf"
+        resume.write_bytes(b"%PDF-1.4 dummy")
+        mock_node.return_value = {
+            "resume": ResumeData(name="Jane", email="j@x.co", skills=["Python"]),
+            "errors": [],
+        }
+        resp = client.post("/api/parse-resume", json={"resume": str(resume)})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["resume"]["name"] == "Jane"
+        assert "Python" in body["resume"]["skills"]
+
+
+# --------------------------------------------------------------------------
+# /api/extract-style
+# --------------------------------------------------------------------------
+
+
+class TestExtractStyleRoute:
+    def test_rejects_non_docx(self, client: TestClient, tmp_path: Path) -> None:
+        f = tmp_path / "not.docx.txt"
+        f.write_text("x")
+        resp = client.post("/api/extract-style", json={"source": str(f)})
+        assert resp.status_code == 400
+
+    @patch("resume_operator.server.routes.extract_style.extract_style_from_docx")
+    def test_returns_style_without_writing(
+        self, mock_extract: MagicMock, client: TestClient, tmp_path: Path
+    ) -> None:
+        from resume_operator.tools.style import StyleTemplate
+
+        src = tmp_path / "ref.docx"
+        src.write_bytes(b"dummy")
+        mock_extract.return_value = StyleTemplate()
+
+        resp = client.post("/api/extract-style", json={"source": str(src)})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["written_to"] is None
+        assert "style" in body
+
+
+# --------------------------------------------------------------------------
+# /ws/run — end-to-end websocket happy path
+# --------------------------------------------------------------------------
+
+
+class TestRunWebsocket:
+    @patch("resume_operator.server.routes.run.build_finalize_graph")
+    @patch("resume_operator.server.routes.run.build_tailor_graph")
+    def test_accept_on_first_iteration(
+        self,
+        mock_tailor: MagicMock,
+        mock_finalize: MagicMock,
+        client: TestClient,
+        tmp_path: Path,
+    ) -> None:
+        """Full happy path: client sends start → server renders iteration
+        header + asks confirm → client approves → finalize runs → done."""
+        master = tmp_path / "m.yaml"
+        master.write_text("name: X\n")
+        job = tmp_path / "j.txt"
+        job.write_text("role text")
+
+        tailor_result = {
+            "ats_score": ATSScore(score=0.9, reasoning=""),
+            "tailored_resume": TailoredResume(
+                items=[TailoredItem(source_id="master:exp-1-b1", action="keep")]
+            ),
+            "master": ResumeMaster(name="X"),
+            "errors": [],
+        }
+        tailor = MagicMock()
+        tailor.invoke.return_value = tailor_result
+        mock_tailor.return_value = tailor
+
+        finalize = MagicMock()
+        finalize.invoke.return_value = {**tailor_result, "output_path": "out.pdf"}
+        mock_finalize.return_value = finalize
+
+        with client.websocket_connect("/api/ws/run") as ws:
+            ws.send_json(
+                {
+                    "type": "start",
+                    "params": {
+                        "master": str(master),
+                        "job": str(job),
+                        "no_enrich": True,
+                        "no_approve": False,
+                        "max_iter": 3,
+                    },
+                }
+            )
+            # The flow runs asynchronously — we consume server messages
+            # until we hit a `confirm`, answer yes, and then wait for done.
+            got_confirm = False
+            got_done = False
+            for _ in range(30):  # generous upper bound
+                msg = ws.receive_json()
+                if msg["type"] == "confirm":
+                    ws.send_json({"type": "reply", "value": True})
+                    got_confirm = True
+                elif msg["type"] == "done":
+                    got_done = True
+                    break
+                elif msg["type"] == "error":
+                    pytest.fail(f"server errored: {msg.get('message')}")
+            assert got_confirm, "expected at least one confirm prompt"
+            assert got_done, "expected a done message"
+
+
+# --------------------------------------------------------------------------
+# WebSocketPrompter unit tests — message shapes
+# --------------------------------------------------------------------------
+
+
+class TestWebSocketPrompterMessages:
+    def test_confirm_message_shape(self) -> None:
+        """`confirm` sends a `{type: confirm, ...}` payload and returns the
+        reply's value. Uses a fake WebSocket to capture the outgoing
+        message and inject the reply."""
+        import asyncio
+
+        sent: list[dict[str, Any]] = []
+
+        class FakeWS:
+            async def send_json(self, payload: dict[str, Any]) -> None:
+                sent.append(payload)
+
+        loop = asyncio.new_event_loop()
+
+        async def _run() -> bool:
+            from resume_operator.server.ws_prompter import WebSocketPrompter
+
+            p = WebSocketPrompter(FakeWS(), asyncio.get_running_loop())
+            # Pre-load a reply so `_recv` doesn't block.
+            p.deposit_reply({"type": "reply", "value": True})
+            return await asyncio.to_thread(p.confirm, "accept?", default=False)
+
+        try:
+            result = loop.run_until_complete(_run())
+        finally:
+            loop.close()
+
+        assert result is True
+        assert sent == [{"type": "confirm", "message": "accept?", "default": False}]
+
+    def test_render_proposal_serializes_pydantic_model(self) -> None:
+        import asyncio
+
+        from resume_operator.state import Proposal
+
+        sent: list[dict[str, Any]] = []
+
+        class FakeWS:
+            async def send_json(self, payload: dict[str, Any]) -> None:
+                sent.append(payload)
+
+        loop = asyncio.new_event_loop()
+
+        async def _run() -> None:
+            from resume_operator.server.ws_prompter import WebSocketPrompter
+
+            p = WebSocketPrompter(FakeWS(), asyncio.get_running_loop())
+            proposal = Proposal(
+                kind="rewrite_master",
+                grounding_source_id="master:exp-1-b1",
+                proposed_text="Polished bullet",
+            )
+            await asyncio.to_thread(p.render_proposal, proposal, index=1, total=3)
+
+        try:
+            loop.run_until_complete(_run())
+        finally:
+            loop.close()
+
+        assert len(sent) == 1
+        msg = sent[0]
+        assert msg["type"] == "render_proposal"
+        assert msg["index"] == 1
+        assert msg["total"] == 3
+        assert msg["proposal"]["kind"] == "rewrite_master"
+        assert msg["proposal"]["proposed_text"] == "Polished bullet"

--- a/uv.lock
+++ b/uv.lock
@@ -368,6 +368,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
 name = "filetype"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -435,6 +451,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
 ]
 
 [[package]]
@@ -1328,6 +1373,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1506,6 +1560,7 @@ name = "resume-operator"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-google-genai" },
@@ -1515,10 +1570,13 @@ dependencies = [
     { name = "pymupdf" },
     { name = "python-docx" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "reportlab" },
     { name = "rich" },
     { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -1533,6 +1591,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", specifier = ">=0.115" },
     { name = "langchain", specifier = ">=0.3" },
     { name = "langchain-anthropic", specifier = ">=0.3" },
     { name = "langchain-google-genai", specifier = ">=2.0" },
@@ -1542,10 +1601,13 @@ requires-dist = [
     { name = "pymupdf", specifier = ">=1.24" },
     { name = "python-docx", specifier = ">=1.1" },
     { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "reportlab", specifier = ">=4.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "typer", specifier = ">=0.12" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
+    { name = "websockets", specifier = ">=13.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1612,6 +1674,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
@@ -1756,6 +1831,132 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/36/2d24b2cbe78547c6532da33fb8613debd3126eccc33a6374ab788f5e46e9/uuid_utils-0.14.1-cp39-abi3-win32.whl", hash = "sha256:b54d6aa6252d96bac1fdbc80d26ba71bad9f220b2724d692ad2f2310c22ef523", size = 183476, upload-time = "2026-02-20T22:50:32.745Z" },
     { url = "https://files.pythonhosted.org/packages/83/92/2d7e90df8b1a69ec4cff33243ce02b7a62f926ef9e2f0eca5a026889cd73/uuid_utils-0.14.1-cp39-abi3-win_amd64.whl", hash = "sha256:fc27638c2ce267a0ce3e06828aff786f91367f093c80625ee21dad0208e0f5ba", size = 187147, upload-time = "2026-02-20T22:50:45.807Z" },
     { url = "https://files.pythonhosted.org/packages/d9/26/529f4beee17e5248e37e0bc17a2761d34c0fa3b1e5729c88adb2065bae6e/uuid_utils-0.14.1-cp39-abi3-win_arm64.whl", hash = "sha256:b04cb49b42afbc4ff8dbc60cf054930afc479d6f4dd7f1ec3bbe5dbfdde06b7a", size = 188132, upload-time = "2026-02-20T22:50:41.718Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Wraps the resume-operator graph in a localhost FastAPI + WebSocket server so the upcoming Tauri desktop shell (Phase 2, https://github.com/takeshi-su57/resume-operator/issues/85) has something to talk to. The CLI is unchanged — both surfaces invoke the same compiled `build_score_graph` / `build_tailor_graph` / `build_finalize_graph` and the same flows behind the `Prompter` seam introduced upstream in this PR.

Closes https://github.com/takeshi-su57/resume-operator/issues/84.

## What changed, in commit order

1. **`refactor(flows): interactive flows behind a Prompter seam`** — Phase 0 prerequisite. Extracts the iterative approval loop (`_run_approval_loop`) and the auto-enrich orchestration (`_run_auto_enrich`) out of `main.py` and into `flows/approval.py` + `flows/enrich.py`. Adds the `Prompter` protocol (`prompter.py`) with a `RichPrompter` CLI implementation that delegates to the existing `Console` / `Prompt.ask` / `Confirm.ask` / `Status` calls — so terminal output is byte-identical to before. `tools/approval_flow.run_approval_flow` and `tools/enrich.run_interactive_session` swap their `console: Console | None` parameter for `prompter: Prompter`.
2. **`chore(deps): add fastapi, uvicorn, websockets, python-multipart`** — registers the new server-only deps and the `resume-operator-server` console script entry point.
3. **`refactor(bootstrap_interview): drive prompts through the Prompter seam`** — the last interactive flow (Phase 0 missed it). Same swap: `Prompt.ask` → `prompter.text`, `Confirm.ask` → `prompter.confirm`, `Panel`/`console.print` → `prompter.panel` / `prompter.notice`. The CLI `bootstrap` command now constructs a `RichPrompter` wrapping its existing `Console`.
4. **`feat(events): node_span helper + wire seven nodes for live timeline events`** — adds a `node_span(name)` context manager that emits `{phase: start}` / `{phase: end}` `NodeEvent`s through the `EventSink` ContextVar introduced in Phase 0. Wraps every public node (`load_master`, `parse_resume`, `ats_score` + `ats_score_tailored`, `analyze_gaps`, `optimize_content`, `generate_pdf`, `report_results`) with a two-line `with node_span(...)` so the desktop GUI's Run screen (Phase 3, https://github.com/takeshi-su57/resume-operator/issues/86) can render a live timeline. No-op when no sink is bound — the CLI path is unaffected.
5. **`feat(server): FastAPI + WebSocket server wrapping the resume-operator graph`** — the actual server. HTTP routes for the read-only commands (`/api/settings`, `/api/score`, `/api/parse-resume`, `/api/extract-style`, plus `/health` for the Tauri sidecar liveness probe). WebSocket routes for the interactive flows (`/api/ws/run`, `/api/ws/bootstrap`). `WebSocketPrompter` bridges the sync flows to the async socket via a `queue.Queue` inbox + `asyncio.run_coroutine_threadsafe` outbound; `session_runner.run_flow_over_ws` runs the blocking flow in `asyncio.to_thread` and pumps client replies into the inbox. Closing the socket mid-flow raises `PrompterDisconnectedError` inside the worker thread so flows return early instead of deadlocking on an unanswered prompt.

## Proof of work

End-to-end smoke test against real LLM calls (OpenRouter `gpt-oss-120b`):

```
$ uv run resume-operator-server --port 7421 &
INFO:     Uvicorn running on http://127.0.0.1:7421

$ curl http://127.0.0.1:7421/health
{"status":"ok","llm_provider":"openrouter","llm_model":"openai/gpt-oss-120b"}

$ curl -X POST http://127.0.0.1:7421/api/score \
    -H "Content-Type: application/json" \
    -d '{"master":"data/master_resume.yaml","job":"input/job.txt"}'
HTTP 200
{"ats_score":{"score":0.55, ..., "hard_skills":[25 rows], "soft_skills":[9 rows],
              "tone_flags":[8 rows], "measurable_results_count":7, ...}, "errors":[]}
```

Server logs show both ATS LLM passes firing in order (`extract_keywords` → `check_tone`) and the composite landing in the same shape the CLI's `score --master ... --job ...` produces.

Server logs also confirm the `node_span` wraps fire (`load_master: starting` … `ats_score: starting` …) — the events are emitted but with no sink bound (CLI path), they're no-ops as designed.

## Gates

- `pytest`: 344 passed (was 330 + 14 new in `tests/test_server.py` covering HTTP request/response shapes, settings masking + persistence, the `/api/ws/run` happy path against a mocked tailor graph, and `WebSocketPrompter` unit tests for `confirm` / `render_proposal` message shapes).
- `ruff check src/ tests/`: clean.
- `mypy --strict src/`: clean across 64 source files.
- CLI smoke: `python -m resume_operator --help` and the existing CLI `run`, `score`, `bootstrap`, `parse-resume`, `extract-style` commands render and behave as before.

## When this PR is merged

The resume-operator engine is reachable over localhost HTTP + WebSocket and ready for the Tauri frontend (Phase 2, https://github.com/takeshi-su57/resume-operator/issues/85) to consume. Existing CLI users see no change in behavior. Phase 1 of six in the desktop GUI roadmap (https://github.com/takeshi-su57/resume-operator/issues/84 https://github.com/takeshi-su57/resume-operator/issues/85 https://github.com/takeshi-su57/resume-operator/issues/86 https://github.com/takeshi-su57/resume-operator/issues/87 https://github.com/takeshi-su57/resume-operator/issues/88 https://github.com/takeshi-su57/resume-operator/issues/89) is now landable.
