### PR TITLE
feat(desktop): three-pane Run workspace with live approval loop (Phase 3, #86)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-tabs": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.4",
+    "diff": "^7.0.0",
     "@tanstack/react-query": "^5.62.7",
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-dialog": "^2.2.0",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.1.0",
+    "@types/diff": "^7.0.0",
     "@types/node": "^22.10.5",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      diff:
+        specifier: ^7.0.0
+        version: 7.0.0
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@18.3.1)
@@ -69,6 +72,9 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2.1.0
         version: 2.10.1
+      '@types/diff':
+        specifier: ^7.0.0
+        version: 7.0.2
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.17
@@ -1057,6 +1063,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/diff@7.0.2':
+    resolution: {integrity: sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1291,6 +1300,10 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff@7.0.0:
+    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+    engines: {node: '>=0.3.1'}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -2807,6 +2820,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/diff@7.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -3061,6 +3076,8 @@ snapshots:
   detect-node-es@1.1.0: {}
 
   didyoumean@1.2.2: {}
+
+  diff@7.0.0: {}
 
   dlv@1.1.3: {}
 

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2,27 +2,34 @@ import { Navigate, Route, Routes } from "react-router-dom";
 
 import { NavRail } from "@/components/nav-rail";
 import { TopBar } from "@/components/top-bar";
+import { RunScreen } from "@/screens/run";
 import { ScoreScreen } from "@/screens/score";
 import { SettingsScreen } from "@/screens/settings";
 
 /**
  * Top-level shell — left rail + top bar + routed main pane.
  *
- * Phase 2 ships only Settings + Score; Phase 3-5 add the rest. The
- * routes for the not-yet-built screens are wired but left as stubs so
- * the rail can preview the final layout.
+ * Phase 2 shipped Settings + Score; Phase 3 (#86) lights up Run as
+ * the third route. Bootstrap / Parse / Extract-style follow in
+ * Phase 5 (#88).
+ *
+ * The Run screen owns its own three-pane layout, so the outer shell
+ * collapses to nav-rail + top-bar + main while staying full-bleed
+ * inside main — the workspace's panes match the parent rail to
+ * preserve a consistent left edge.
  */
 export default function App() {
   return (
     <div className="grid h-screen grid-cols-[200px_1fr] grid-rows-[40px_1fr] bg-bg text-fg">
       <NavRail className="row-span-2" />
       <TopBar />
-      <main className="overflow-y-auto bg-bg-subtle border-l border-border">
+      <main className="min-h-0 min-w-0 overflow-hidden bg-bg-subtle border-l border-border">
         <Routes>
-          <Route path="/" element={<Navigate to="/score" replace />} />
+          <Route path="/" element={<Navigate to="/run" replace />} />
+          <Route path="/run" element={<RunScreen />} />
           <Route path="/score" element={<ScoreScreen />} />
           <Route path="/settings" element={<SettingsScreen />} />
-          <Route path="*" element={<Navigate to="/score" replace />} />
+          <Route path="*" element={<Navigate to="/run" replace />} />
         </Routes>
       </main>
     </div>

--- a/desktop/src/components/diff-view.tsx
+++ b/desktop/src/components/diff-view.tsx
@@ -1,0 +1,59 @@
+import { diffWordsWithSpace } from "diff";
+import { useMemo } from "react";
+
+import { cn } from "@/lib/cn";
+
+type DiffViewProps = {
+  original: string;
+  proposed: string;
+  className?: string;
+};
+
+/**
+ * Word-level diff with red strikethrough for removed text and green
+ * highlight for added text. Inline (not split-pane) so the "before"
+ * and "after" read like one polished sentence with its edits visible
+ * in place.
+ */
+export function DiffView({ original, proposed, className }: DiffViewProps) {
+  const parts = useMemo(
+    () => diffWordsWithSpace(original ?? "", proposed ?? ""),
+    [original, proposed],
+  );
+  return (
+    <pre
+      className={cn(
+        "whitespace-pre-wrap break-words font-mono text-sm leading-relaxed",
+        className,
+      )}
+    >
+      {parts.map((part, i) => {
+        if (part.added) {
+          return (
+            <span
+              key={i}
+              className="rounded-sm bg-success/15 text-success px-0.5"
+            >
+              {part.value}
+            </span>
+          );
+        }
+        if (part.removed) {
+          return (
+            <span
+              key={i}
+              className="rounded-sm bg-danger/15 text-danger line-through px-0.5"
+            >
+              {part.value}
+            </span>
+          );
+        }
+        return (
+          <span key={i} className="text-fg-muted">
+            {part.value}
+          </span>
+        );
+      })}
+    </pre>
+  );
+}

--- a/desktop/src/components/nav-rail.tsx
+++ b/desktop/src/components/nav-rail.tsx
@@ -19,8 +19,8 @@ type NavItem = {
 };
 
 const items: NavItem[] = [
+  { to: "/run", label: "Run", icon: PlayCircle, enabled: true },
   { to: "/score", label: "Score", icon: Gauge, enabled: true },
-  { to: "/run", label: "Run", icon: PlayCircle, enabled: false, hint: "Phase 3" },
   { to: "/bootstrap", label: "Bootstrap", icon: Sparkles, enabled: false, hint: "Phase 5" },
   { to: "/parse", label: "Parse PDF", icon: FileSearch, enabled: false, hint: "Phase 5" },
   { to: "/style", label: "Extract Style", icon: Wrench, enabled: false, hint: "Phase 5" },

--- a/desktop/src/lib/events.ts
+++ b/desktop/src/lib/events.ts
@@ -1,0 +1,164 @@
+/**
+ * WebSocket protocol types — mirrors `src/resume_operator/server/ws_prompter.py`.
+ *
+ * Server-to-client messages drive the UI; client-to-server messages
+ * carry user decisions back. Hand-mirrored for now (no codegen) — any
+ * drift surfaces as a TS compile error in the dispatcher, since each
+ * branch of `ServerMessage` has a discriminator on `type`.
+ */
+
+// --- Domain shapes carried by server messages ------------------------------
+
+export type ProposalKind =
+  | "rewrite_master"
+  | "rewrite_fact"
+  | "new_fact"
+  | "new_skill";
+
+export type Proposal = {
+  kind: ProposalKind;
+  grounding_source_id: string;
+  original_text: string;
+  proposed_text: string;
+  rationale: string;
+  target_role_id?: string;
+};
+
+export type EnrichQuestion = {
+  area: string;
+  question: string;
+  why: string;
+};
+
+export type EnrichPolished = {
+  polished_text: string;
+  bucket: "project" | "extra_bullet" | "skill" | "certification";
+  role_id: string;
+};
+
+// --- Server → client messages ----------------------------------------------
+
+export type NodeEventMessage = {
+  type: "node_event";
+  node: string;
+  phase: "start" | "end" | "error";
+  data: Record<string, unknown>;
+  timestamp: number;
+};
+
+export type ConfirmMessage = {
+  type: "confirm";
+  message: string;
+  default: boolean;
+};
+
+export type ChooseMessage = {
+  type: "choose";
+  message: string;
+  choices: string[];
+  default: string;
+};
+
+export type TextMessage = {
+  type: "text";
+  message: string;
+  default: string;
+};
+
+export type RenderProposalMessage = {
+  type: "render_proposal";
+  proposal: Proposal;
+  index: number;
+  total: number;
+};
+
+export type RenderIterationHeaderMessage = {
+  type: "render_iteration_header";
+  iteration: number;
+  max_iter: number;
+  score: number;
+};
+
+export type RenderQuestionMessage = {
+  type: "render_question";
+  question: EnrichQuestion;
+  index: number;
+  total: number;
+};
+
+export type RenderPolishedMessage = {
+  type: "render_polished";
+  polished: EnrichPolished;
+};
+
+export type NoticeMessage = {
+  type: "notice";
+  message: string;
+  style: string;
+};
+
+export type PanelMessage = {
+  type: "panel";
+  message: string;
+  title: string;
+  style: string;
+};
+
+export type StatusStartMessage = {
+  type: "status_start";
+  message: string;
+  at: number;
+};
+
+export type StatusEndMessage = {
+  type: "status_end";
+  at: number;
+};
+
+export type DoneMessage = {
+  type: "done";
+  result: Record<string, unknown>;
+};
+
+export type ErrorMessage = {
+  type: "error";
+  message: string;
+};
+
+export type ServerMessage =
+  | NodeEventMessage
+  | ConfirmMessage
+  | ChooseMessage
+  | TextMessage
+  | RenderProposalMessage
+  | RenderIterationHeaderMessage
+  | RenderQuestionMessage
+  | RenderPolishedMessage
+  | NoticeMessage
+  | PanelMessage
+  | StatusStartMessage
+  | StatusEndMessage
+  | DoneMessage
+  | ErrorMessage;
+
+// --- Client → server messages ----------------------------------------------
+
+export type StartMessage = {
+  type: "start";
+  params: Record<string, unknown>;
+};
+
+export type ReplyMessage = {
+  type: "reply";
+  value: string | boolean | number;
+};
+
+export type ClientMessage = StartMessage | ReplyMessage;
+
+// --- Type-narrowing helpers ------------------------------------------------
+
+export function isPromptMessage(
+  m: ServerMessage,
+): m is ConfirmMessage | ChooseMessage | TextMessage {
+  return m.type === "confirm" || m.type === "choose" || m.type === "text";
+}

--- a/desktop/src/lib/ws.ts
+++ b/desktop/src/lib/ws.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { ClientMessage, ServerMessage } from "@/lib/events";
+
+import { serverWsUrl } from "./api";
+
+export type WSStatus = "idle" | "connecting" | "open" | "closed" | "error";
+
+type Options = {
+  /** Called once per inbound message. */
+  onMessage: (msg: ServerMessage) => void;
+  /** Called when the socket transitions to a terminal state. */
+  onClose?: (event: CloseEvent) => void;
+};
+
+/**
+ * Tiny typed WebSocket hook for driving an interactive flow over
+ * `/api/ws/run` or `/api/ws/bootstrap`. Lives outside any component
+ * so the run-screen state machine can use it via composition.
+ *
+ * Lifecycle:
+ *   1. `connect(path)` opens the socket and transitions to `connecting`.
+ *   2. On `open`, callers `send(StartMessage)` to kick off the flow.
+ *   3. Inbound messages flow through `onMessage`; client replies
+ *      flow back via `send`.
+ *   4. The socket closes itself when the server sends `done`/`error`.
+ *      `disconnect()` does the same client-side.
+ *
+ * Reconnect is intentionally not wired — server-side flows are
+ * stateful (mid-approval-loop), and a transparent reconnect would
+ * silently re-run nodes. If the connection dies, the user sees an
+ * error and explicitly retries.
+ */
+export function useFlowSocket({ onMessage, onClose }: Options) {
+  const ref = useRef<WebSocket | null>(null);
+  const [status, setStatus] = useState<WSStatus>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Stash the latest callbacks in a ref so the open/close handlers
+  // capture the right ones across re-renders.
+  const handlersRef = useRef({ onMessage, onClose });
+  handlersRef.current = { onMessage, onClose };
+
+  const connect = useCallback((path: string) => {
+    if (ref.current) {
+      ref.current.close();
+    }
+    setErrorMsg(null);
+    setStatus("connecting");
+    const socket = new WebSocket(serverWsUrl(path));
+    ref.current = socket;
+    socket.onopen = () => setStatus("open");
+    socket.onclose = (ev) => {
+      setStatus("closed");
+      handlersRef.current.onClose?.(ev);
+    };
+    socket.onerror = () => {
+      setStatus("error");
+      setErrorMsg("WebSocket error");
+    };
+    socket.onmessage = (ev) => {
+      try {
+        const parsed = JSON.parse(ev.data) as ServerMessage;
+        handlersRef.current.onMessage(parsed);
+      } catch (err) {
+        console.error("WS parse error", err, ev.data);
+      }
+    };
+  }, []);
+
+  const send = useCallback((msg: ClientMessage) => {
+    const socket = ref.current;
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      console.warn("WS send called while not OPEN", socket?.readyState);
+      return;
+    }
+    socket.send(JSON.stringify(msg));
+  }, []);
+
+  const disconnect = useCallback(() => {
+    ref.current?.close();
+    ref.current = null;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      ref.current?.close();
+      ref.current = null;
+    };
+  }, []);
+
+  return { status, errorMsg, connect, send, disconnect } as const;
+}

--- a/desktop/src/screens/run/ats-side-pane.tsx
+++ b/desktop/src/screens/run/ats-side-pane.tsx
@@ -1,0 +1,106 @@
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/cn";
+import { useRunSession } from "@/state/run-session";
+
+/**
+ * Right pane — compact ATS context for the current iteration. Pulls
+ * the latest score from the iteration history, the open status
+ * spinner (if any), and a running session log (approved / rejected
+ * counts). Phase 4 will swap this for the real ATSReport when the
+ * server starts emitting `state_delta` events on `ats_score_tailored`
+ * end. For Phase 3 we keep it lightweight — the headline numbers and
+ * activity feed.
+ */
+export function AtsSidePane() {
+  const score = useRunSession((s) => s.currentScore);
+  const iter = useRunSession((s) => s.currentIteration);
+  const maxIter = useRunSession((s) => s.currentMaxIter);
+  const status = useRunSession((s) => s.statusStack);
+  const approved = useRunSession((s) => s.approvedProposals.length);
+  const rejected = useRunSession((s) => s.rejectedProposals.length);
+  const accepted = useRunSession((s) => s.acceptedEnrichItems.length);
+
+  const openStatus = status.find((s) => s.endedAt === null);
+
+  return (
+    <aside
+      className="flex h-full w-[260px] flex-col border-l border-border bg-bg-panel"
+      data-no-select
+    >
+      <div className="border-b border-border px-3 py-2 text-xs uppercase tracking-wider text-fg-muted">
+        Session
+      </div>
+
+      <div className="px-4 py-4 space-y-4">
+        <Block label="ATS score">
+          {score === null ? (
+            <p className="text-fg-faint text-sm">—</p>
+          ) : (
+            <p
+              className={cn(
+                "text-2xl font-bold tabular-nums",
+                score >= 0.7
+                  ? "text-success"
+                  : score >= 0.4
+                    ? "text-warning"
+                    : "text-danger",
+              )}
+            >
+              {Math.round(score * 100)}%
+            </p>
+          )}
+        </Block>
+
+        {iter !== null && maxIter !== null && (
+          <Block label="Iteration">
+            <p className="text-sm text-fg tabular-nums">
+              {iter} / {maxIter}
+            </p>
+          </Block>
+        )}
+
+        <Block label="Decisions">
+          <ul className="text-xs space-y-1">
+            <li className="flex justify-between">
+              <span className="text-fg-muted">Approved</span>
+              <span className="tabular-nums text-success">{approved}</span>
+            </li>
+            <li className="flex justify-between">
+              <span className="text-fg-muted">Rejected</span>
+              <span className="tabular-nums text-danger">{rejected}</span>
+            </li>
+            <li className="flex justify-between">
+              <span className="text-fg-muted">Enrich accepts</span>
+              <span className="tabular-nums text-fg">{accepted}</span>
+            </li>
+          </ul>
+        </Block>
+      </div>
+
+      {openStatus && (
+        <div className="mt-auto border-t border-border-subtle bg-bg-raised px-3 py-2 text-xs text-fg-muted flex items-center gap-2">
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-accent" />
+          <span className="truncate">
+            {openStatus.message.replace(/\[\/?[^\]]+\]/g, "")}
+          </span>
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function Block({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <p className="text-xs uppercase tracking-wider text-fg-muted">{label}</p>
+      <div className="mt-1">{children}</div>
+    </div>
+  );
+}

--- a/desktop/src/screens/run/fix-modal.tsx
+++ b/desktop/src/screens/run/fix-modal.tsx
@@ -1,0 +1,104 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+
+type Props = {
+  open: boolean;
+  onSubmit: (feedback: string) => void;
+  onCancel: () => void;
+  prompt?: string;
+};
+
+/**
+ * Modal that opens after the user clicks "Fix…" on a proposal.
+ * Captures free-text feedback the LLM uses to revise the proposal
+ * (`tools.propose_changes.revise_proposal`). The Fix sub-loop is
+ * unbounded server-side, so this modal can re-open indefinitely as
+ * each revision arrives.
+ */
+export function FixModal({ open, onSubmit, onCancel, prompt }: Props) {
+  const [text, setText] = useState("");
+  const submit = () => {
+    onSubmit(text);
+    setText("");
+  };
+  const cancel = () => {
+    setText("");
+    onCancel();
+  };
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => !o && cancel()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/60 animate-fade-in" />
+        <Dialog.Content
+          className={cn(
+            "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2",
+            "w-[min(640px,90vw)] panel p-6 animate-fade-in shadow-xl",
+          )}
+          onOpenAutoFocus={(e) => {
+            // Focus the textarea, not the dialog frame.
+            e.preventDefault();
+            requestAnimationFrame(() => {
+              const ta = document.querySelector<HTMLTextAreaElement>(
+                "[data-fix-textarea]",
+              );
+              ta?.focus();
+            });
+          }}
+        >
+          <Dialog.Title className="text-sm font-bold text-fg">
+            What should change?
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-xs text-fg-dim leading-relaxed">
+            {prompt ??
+              'Free text — e.g. "I never used K8s, only ECS". The LLM revises ' +
+                "and brings the new version back to the same gate."}
+          </Dialog.Description>
+
+          <textarea
+            data-fix-textarea
+            className={cn(
+              "mt-3 w-full h-32 input-base font-mono leading-relaxed resize-none",
+            )}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Type the correction here…"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                e.preventDefault();
+                submit();
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                cancel();
+              }
+            }}
+          />
+
+          <div className="mt-4 flex items-center justify-between">
+            <p className="text-xs text-fg-faint">
+              <span className="kbd">Ctrl</span>
+              <span className="ml-1 mr-2">+</span>
+              <span className="kbd">⏎</span>
+              <span className="ml-2">to submit</span>
+            </p>
+            <div className="flex gap-2">
+              <Button variant="ghost" onClick={cancel}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onClick={submit}
+                disabled={!text.trim()}
+              >
+                Send to LLM
+              </Button>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/desktop/src/screens/run/index.tsx
+++ b/desktop/src/screens/run/index.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+
+import { useRunSession } from "@/state/run-session";
+
+import { RunInputs, type RunInputs as RunInputsType } from "./inputs";
+import { useRunController } from "./use-run-controller";
+import { RunWorkspace } from "./workspace";
+
+/**
+ * Top-level Run screen — owns the choice between the pre-flight
+ * inputs form and the live three-pane workspace. Once a run starts,
+ * the workspace stays mounted (controller + zustand store hold all
+ * the state) until the user clicks "New run" from the done/error
+ * status pane.
+ */
+export function RunScreen() {
+  const controller = useRunController();
+  const phase = useRunSession((s) => s.phase);
+  const [inWorkspace, setInWorkspace] = useState(false);
+
+  const onSubmit = (inputs: RunInputsType) => {
+    controller.beginRun(inputs);
+    setInWorkspace(true);
+  };
+
+  const reset = () => {
+    controller.disconnect();
+    useRunSession.getState().reset();
+    setInWorkspace(false);
+  };
+
+  if (!inWorkspace || phase === "idle") {
+    return <RunInputs onSubmit={onSubmit} />;
+  }
+
+  return <RunWorkspace controller={controller} onReset={reset} />;
+}

--- a/desktop/src/screens/run/inputs.tsx
+++ b/desktop/src/screens/run/inputs.tsx
@@ -1,0 +1,227 @@
+import { PlayCircle } from "lucide-react";
+import { useState } from "react";
+
+import { FilePicker } from "@/components/file-picker";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export type RunInputs = {
+  master?: string;
+  resume?: string;
+  facts?: string;
+  job: string;
+  output?: string;
+  style?: string;
+  no_enrich: boolean;
+  no_approve: boolean;
+  max_iter?: number;
+};
+
+type Props = {
+  onSubmit: (inputs: RunInputs) => void;
+  disabled?: boolean;
+};
+
+/**
+ * Pre-flight inputs for the Run flow. Layout: a single centered card
+ * with the three required pickers (master | resume | job) up front,
+ * advanced opts collapsed into a footer row. Submit is disabled until
+ * a master-or-resume + job is selected.
+ */
+export function RunInputs({ onSubmit, disabled }: Props) {
+  const [master, setMaster] = useState("");
+  const [resume, setResume] = useState("");
+  const [facts, setFacts] = useState("");
+  const [job, setJob] = useState("");
+  const [output, setOutput] = useState("");
+  const [style, setStyle] = useState("");
+  const [noEnrich, setNoEnrich] = useState(false);
+  const [noApprove, setNoApprove] = useState(false);
+  const [maxIter, setMaxIter] = useState<string>("");
+
+  const canSubmit = (!!master || !!resume) && !!job && !disabled;
+
+  const submit = () => {
+    if (!canSubmit) return;
+    onSubmit({
+      master: master || undefined,
+      resume: master ? undefined : resume || undefined,
+      facts: facts || undefined,
+      job,
+      output: output || undefined,
+      style: style || undefined,
+      no_enrich: noEnrich,
+      no_approve: noApprove,
+      max_iter: maxIter ? Number(maxIter) : undefined,
+    });
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl p-6">
+      <header className="mb-6">
+        <h1 className="text-sm font-bold text-fg">Run</h1>
+        <p className="mt-1 text-xs text-fg-dim leading-relaxed">
+          Full pipeline: load → score → tailor → optional enrich → optional
+          approval loop → finalize. Three required inputs; advanced flags
+          mirror the CLI.
+        </p>
+      </header>
+
+      <div className="space-y-4 panel p-4">
+        <FieldRow label="Master YAML">
+          <FilePicker
+            value={master}
+            onChange={(v) => {
+              setMaster(v);
+              if (v) setResume("");
+            }}
+            placeholder="data/master_resume.yaml"
+            filters={[{ name: "YAML", extensions: ["yaml", "yml"] }]}
+          />
+        </FieldRow>
+
+        <FieldRow label="…or Resume PDF (legacy)">
+          <FilePicker
+            value={resume}
+            onChange={(v) => {
+              setResume(v);
+              if (v) setMaster("");
+            }}
+            placeholder="resume.pdf"
+            filters={[{ name: "PDF", extensions: ["pdf"] }]}
+          />
+        </FieldRow>
+
+        <FieldRow label="Job Description" required>
+          <FilePicker
+            value={job}
+            onChange={setJob}
+            placeholder="input/job.txt"
+            filters={[{ name: "Text", extensions: ["txt", "md"] }]}
+          />
+        </FieldRow>
+
+        <FieldRow label="Facts Bank YAML" optional>
+          <FilePicker
+            value={facts}
+            onChange={setFacts}
+            placeholder="(optional — defaults to data/facts_bank.yaml if present)"
+            filters={[{ name: "YAML", extensions: ["yaml", "yml"] }]}
+          />
+        </FieldRow>
+
+        <FieldRow label="Style Template" optional>
+          <FilePicker
+            value={style}
+            onChange={setStyle}
+            placeholder="(optional — overrides RESUME_STYLE_PATH)"
+            filters={[{ name: "YAML", extensions: ["yaml", "yml"] }]}
+          />
+        </FieldRow>
+      </div>
+
+      <details className="panel mt-4 group">
+        <summary className="cursor-pointer px-4 py-2 text-xs uppercase tracking-wider text-fg-muted">
+          Advanced
+        </summary>
+        <div className="px-4 pb-4 space-y-3">
+          <FieldRow label="Output parent" optional>
+            <Input
+              value={output}
+              onChange={(e) => setOutput(e.target.value)}
+              placeholder="(default: data/applications/)"
+            />
+          </FieldRow>
+          <FieldRow label="Max approval iterations" optional>
+            <Input
+              type="number"
+              min={1}
+              value={maxIter}
+              onChange={(e) => setMaxIter(e.target.value)}
+              placeholder="(default: RESUME_MAX_ITERATIONS)"
+            />
+          </FieldRow>
+          <CheckboxRow
+            checked={noEnrich}
+            onChange={setNoEnrich}
+            label="Skip auto-enrich"
+            hint="Don't offer the interview even if the first tailor is thin."
+          />
+          <CheckboxRow
+            checked={noApprove}
+            onChange={setNoApprove}
+            label="Skip approval loop"
+            hint="Render the first tailored version directly. Headless mode."
+          />
+        </div>
+      </details>
+
+      <div className="mt-6 flex justify-end">
+        <Button
+          variant="primary"
+          size="lg"
+          disabled={!canSubmit}
+          onClick={submit}
+        >
+          <PlayCircle className="h-4 w-4" />
+          Start run
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function FieldRow({
+  label,
+  required,
+  optional,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  optional?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-[180px_1fr] items-center gap-3">
+      <Label>
+        {label}
+        {required && <span className="ml-1 text-accent normal-case">*</span>}
+        {optional && (
+          <span className="ml-1 text-fg-faint normal-case">(optional)</span>
+        )}
+      </Label>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function CheckboxRow({
+  checked,
+  onChange,
+  label,
+  hint,
+}: {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  label: string;
+  hint?: string;
+}) {
+  return (
+    <label className="flex cursor-pointer items-start gap-2 text-sm text-fg">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 h-4 w-4 rounded border-border accent-accent"
+      />
+      <div>
+        <span>{label}</span>
+        {hint && (
+          <p className="mt-0.5 text-xs text-fg-dim leading-relaxed">{hint}</p>
+        )}
+      </div>
+    </label>
+  );
+}

--- a/desktop/src/screens/run/iteration-confirm.tsx
+++ b/desktop/src/screens/run/iteration-confirm.tsx
@@ -1,0 +1,128 @@
+import { Check, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+import { useRunSession } from "@/state/run-session";
+
+type Props = {
+  promptRole:
+    | "iteration_accept"
+    | "iteration_continue"
+    | "enrich_offer"
+    | null
+    | undefined;
+  onYes: () => void;
+  onNo: () => void;
+  disabled?: boolean;
+};
+
+/**
+ * Center pane during iteration / enrichment-offer Y/N gates. The
+ * server's prompter can ask three different yes/no questions in the
+ * run flow:
+ *
+ *   - "Accept this tailored version?" (per iteration)
+ *   - "Continue anyway?" (after the iteration cap fires)
+ *   - "Start an enrichment session?" (when tailor is thin)
+ *
+ * The wording differs but the UI shape is the same — show the open
+ * question, the current ATS context, and a Yes/No pair.
+ */
+export function IterationConfirm({ promptRole, onYes, onNo, disabled }: Props) {
+  const score = useRunSession((s) => s.currentScore);
+  const iter = useRunSession((s) => s.currentIteration);
+  const maxIter = useRunSession((s) => s.currentMaxIter);
+  const pending = useRunSession((s) => s.pendingPrompt);
+
+  const title =
+    promptRole === "iteration_accept"
+      ? "Accept this tailored version?"
+      : promptRole === "iteration_continue"
+        ? "Iteration cap reached — continue?"
+        : promptRole === "enrich_offer"
+          ? "Enrichment available"
+          : "Continue?";
+
+  const yesLabel =
+    promptRole === "enrich_offer" ? "Start interview" : "Yes — accept";
+  const noLabel =
+    promptRole === "enrich_offer" ? "Skip" : "No — continue iterating";
+
+  return (
+    <div className="flex h-full items-center justify-center px-6">
+      <div className="w-full max-w-xl panel p-6 space-y-4">
+        <div>
+          <h2 className="text-sm font-bold text-fg">{title}</h2>
+          {pending?.kind && (
+            <p className="mt-2 text-xs text-fg-dim leading-relaxed">
+              {pending.message.replace(/\[\/?[^\]]+\]/g, "")}
+            </p>
+          )}
+        </div>
+
+        {score !== null && iter !== null && maxIter !== null && (
+          <div className="grid grid-cols-2 gap-3">
+            <Stat label="ATS score" value={`${Math.round(score * 100)}%`} score={score} />
+            <Stat
+              label="Iteration"
+              value={`${iter} / ${maxIter}`}
+            />
+          </div>
+        )}
+
+        <div className="flex gap-2 pt-2">
+          <Button
+            variant="primary"
+            size="lg"
+            onClick={onYes}
+            disabled={disabled}
+            className="flex-1"
+          >
+            <Check className="h-4 w-4" />
+            {yesLabel}
+          </Button>
+          <Button
+            variant="secondary"
+            size="lg"
+            onClick={onNo}
+            disabled={disabled}
+            className="flex-1"
+          >
+            <X className="h-4 w-4" />
+            {noLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  score,
+}: {
+  label: string;
+  value: string;
+  score?: number;
+}) {
+  return (
+    <div className="rounded-md border border-border-subtle bg-bg-subtle p-3">
+      <p className="text-xs uppercase tracking-wider text-fg-muted">{label}</p>
+      <p
+        className={cn(
+          "mt-1 text-xl font-bold tabular-nums",
+          score === undefined
+            ? "text-fg"
+            : score >= 0.7
+              ? "text-success"
+              : score >= 0.4
+                ? "text-warning"
+                : "text-danger",
+        )}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}

--- a/desktop/src/screens/run/node-timeline.tsx
+++ b/desktop/src/screens/run/node-timeline.tsx
@@ -1,0 +1,134 @@
+import { Check, Circle, CircleDot, X } from "lucide-react";
+import { useMemo } from "react";
+
+import { cn } from "@/lib/cn";
+import { useRunSession } from "@/state/run-session";
+
+const NODE_LABELS: Record<string, string> = {
+  load_master: "load_master",
+  parse_resume: "parse_resume",
+  ats_score: "ats_score",
+  analyze_gaps: "analyze",
+  optimize_content: "optimize",
+  ats_score_tailored: "ats_tailor",
+  generate_pdf: "generate_pdf",
+  report_results: "report",
+};
+
+// Order shown when no events have arrived yet — mirrors the tailor +
+// finalize graph sequences.
+const NODE_ORDER = [
+  "load_master",
+  "parse_resume",
+  "ats_score",
+  "analyze_gaps",
+  "optimize_content",
+  "ats_score_tailored",
+  "generate_pdf",
+  "report_results",
+];
+
+type NodeStatus = "pending" | "running" | "done" | "error";
+
+/**
+ * Left pane: live node timeline + iteration history.
+ *
+ * Renders the canonical graph node order regardless of which events
+ * arrived. Each node's state derives from the latest `node_event`
+ * matching its name. Below the timeline, a compact iteration log
+ * shows ATS scores climbing (or regressing) per loop.
+ */
+export function NodeTimeline() {
+  const events = useRunSession((s) => s.nodeEvents);
+  const iterations = useRunSession((s) => s.iterationHistory);
+
+  const status = useMemo(() => {
+    const map = new Map<string, NodeStatus>();
+    for (const e of events) {
+      if (e.phase === "start") map.set(e.node, "running");
+      else if (e.phase === "end") map.set(e.node, "done");
+      else if (e.phase === "error") map.set(e.node, "error");
+    }
+    return map;
+  }, [events]);
+
+  return (
+    <aside className="flex h-full w-[200px] flex-col border-r border-border bg-bg-panel" data-no-select>
+      <div className="border-b border-border px-3 py-2 text-xs uppercase tracking-wider text-fg-muted">
+        Node timeline
+      </div>
+      <ol className="flex-1 overflow-y-auto py-2">
+        {NODE_ORDER.map((node) => (
+          <Step
+            key={node}
+            label={NODE_LABELS[node] ?? node}
+            status={status.get(node) ?? "pending"}
+          />
+        ))}
+      </ol>
+
+      {iterations.length > 0 && (
+        <>
+          <div className="border-t border-border-subtle border-b border-border px-3 py-2 text-xs uppercase tracking-wider text-fg-muted">
+            Iterations
+          </div>
+          <ol className="px-3 py-2 text-xs space-y-1 max-h-40 overflow-y-auto">
+            {iterations.map((it, i) => (
+              <li
+                key={i}
+                className="flex items-center justify-between gap-2 text-fg-muted"
+              >
+                <span>
+                  iter {it.iteration}/{it.maxIter}
+                </span>
+                <span
+                  className={cn(
+                    "tabular-nums font-bold",
+                    it.score >= 0.7
+                      ? "text-success"
+                      : it.score >= 0.4
+                        ? "text-warning"
+                        : "text-danger",
+                  )}
+                >
+                  {Math.round(it.score * 100)}%
+                </span>
+              </li>
+            ))}
+          </ol>
+        </>
+      )}
+    </aside>
+  );
+}
+
+function Step({ label, status }: { label: string; status: NodeStatus }) {
+  return (
+    <li
+      className={cn(
+        "flex items-center gap-2 px-3 py-1 text-sm",
+        status === "running" && "bg-accent/10",
+      )}
+    >
+      <StatusGlyph status={status} />
+      <span
+        className={cn(
+          status === "pending" && "text-fg-faint",
+          status === "running" && "text-fg",
+          status === "done" && "text-fg-muted",
+          status === "error" && "text-danger",
+        )}
+      >
+        {label}
+      </span>
+    </li>
+  );
+}
+
+function StatusGlyph({ status }: { status: NodeStatus }) {
+  if (status === "running")
+    return <CircleDot className="h-3.5 w-3.5 text-accent animate-pulse" />;
+  if (status === "done") return <Check className="h-3.5 w-3.5 text-success" />;
+  if (status === "error") return <X className="h-3.5 w-3.5 text-danger" />;
+  return <Circle className="h-3.5 w-3.5 text-fg-faint" />;
+}

--- a/desktop/src/screens/run/proposal-pane.tsx
+++ b/desktop/src/screens/run/proposal-pane.tsx
@@ -1,0 +1,208 @@
+import { Check, Loader2, Pencil, X } from "lucide-react";
+
+import { DiffView } from "@/components/diff-view";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+import type { Proposal } from "@/lib/events";
+import { useRunSession } from "@/state/run-session";
+
+const KIND_LABELS: Record<string, string> = {
+  rewrite_master: "Rewrite of an existing master bullet",
+  rewrite_fact: "Polish of a facts-bank entry",
+  new_fact: "NEW bullet — LLM extrapolation, verify truth",
+  new_skill: "NEW skill — verify you actually have this",
+};
+
+type Props = {
+  onAccept: () => void;
+  onReject: () => void;
+  onFix: () => void;
+  onQuit: () => void;
+  disabled?: boolean;
+};
+
+/**
+ * Center pane during the approval loop: the current proposal with
+ * grounding source, diff (original vs proposed), rationale, and the
+ * three-button decision row. Keyboard handlers live one level up
+ * (Workspace) so they can be conditional on the current phase.
+ */
+export function ProposalPane({
+  onAccept,
+  onReject,
+  onFix,
+  onQuit,
+  disabled,
+}: Props) {
+  const proposal = useRunSession((s) => s.currentProposal);
+  const index = useRunSession((s) => s.proposalIndex);
+  const total = useRunSession((s) => s.proposalTotal);
+
+  if (!proposal) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-fg-dim">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        LLM is proposing edits…
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <Header proposal={proposal} index={index} total={total} />
+      <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+        <DiffSection proposal={proposal} />
+        {proposal.rationale && (
+          <section className="text-sm text-fg-muted">
+            <h4 className="mb-1 text-xs uppercase tracking-wider text-fg-dim">
+              Rationale
+            </h4>
+            <p className="leading-relaxed">{proposal.rationale}</p>
+          </section>
+        )}
+      </div>
+      <ActionBar
+        onAccept={onAccept}
+        onReject={onReject}
+        onFix={onFix}
+        onQuit={onQuit}
+        disabled={disabled}
+      />
+      <ProgressBar index={index} total={total} />
+    </div>
+  );
+}
+
+function Header({
+  proposal,
+  index,
+  total,
+}: {
+  proposal: Proposal;
+  index: number;
+  total: number;
+}) {
+  const label = KIND_LABELS[proposal.kind] ?? proposal.kind;
+  return (
+    <header className="border-b border-border px-6 py-3 flex items-baseline justify-between gap-4">
+      <div className="min-w-0 flex-1">
+        <p className="text-xs uppercase tracking-wider text-fg-muted">
+          Proposal {index} / {total}
+        </p>
+        <h3 className="mt-0.5 text-sm font-bold text-fg truncate">{label}</h3>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-fg-dim">
+        <span className="rounded-sm border border-border bg-bg-raised px-1.5 py-0.5 font-mono">
+          {proposal.kind}
+        </span>
+        <span className="rounded-sm border border-border bg-bg-raised px-1.5 py-0.5 font-mono">
+          {proposal.grounding_source_id}
+        </span>
+      </div>
+    </header>
+  );
+}
+
+function DiffSection({ proposal }: { proposal: Proposal }) {
+  if (!proposal.original_text) {
+    // new_fact / new_skill — show the proposed text as-is, no diff.
+    return (
+      <section>
+        <h4 className="mb-1 text-xs uppercase tracking-wider text-fg-dim">
+          New
+        </h4>
+        <p className="font-mono text-sm leading-relaxed text-success">
+          {proposal.proposed_text}
+        </p>
+      </section>
+    );
+  }
+  return (
+    <section>
+      <h4 className="mb-1 text-xs uppercase tracking-wider text-fg-dim">
+        Diff
+      </h4>
+      <DiffView
+        original={proposal.original_text}
+        proposed={proposal.proposed_text}
+        className="rounded-md bg-bg-raised border border-border-subtle p-3"
+      />
+    </section>
+  );
+}
+
+function ActionBar({
+  onAccept,
+  onReject,
+  onFix,
+  onQuit,
+  disabled,
+}: Props) {
+  return (
+    <div
+      className="border-t border-border px-6 py-2 flex items-center gap-2"
+      data-no-select
+    >
+      <Button
+        variant="primary"
+        onClick={onAccept}
+        disabled={disabled}
+        title="Accept (⏎)"
+      >
+        <Check className="h-4 w-4" />
+        Accept
+        <span className="kbd ml-1">⏎</span>
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={onReject}
+        disabled={disabled}
+        title="Reject (x)"
+      >
+        <X className="h-4 w-4" />
+        Reject
+        <span className="kbd ml-1">x</span>
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={onFix}
+        disabled={disabled}
+        title="Fix (f)"
+      >
+        <Pencil className="h-4 w-4" />
+        Fix…
+        <span className="kbd ml-1">f</span>
+      </Button>
+      <div className="ml-auto">
+        <Button
+          variant="ghost"
+          onClick={onQuit}
+          disabled={disabled}
+          title="Quit approval (q)"
+        >
+          Quit
+          <span className="kbd ml-1">q</span>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ProgressBar({ index, total }: { index: number; total: number }) {
+  if (!total) return null;
+  return (
+    <div className="border-t border-border-subtle bg-bg-panel px-6 py-1.5 flex items-center gap-3">
+      <div className="flex-1 h-1 rounded-full bg-bg-raised overflow-hidden">
+        <div
+          className={cn(
+            "h-full bg-accent transition-all",
+          )}
+          style={{ width: `${(index / total) * 100}%` }}
+        />
+      </div>
+      <span className="text-xs tabular-nums text-fg-dim">
+        {index} / {total}
+      </span>
+    </div>
+  );
+}

--- a/desktop/src/screens/run/rejection-modal.tsx
+++ b/desktop/src/screens/run/rejection-modal.tsx
@@ -1,0 +1,74 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+
+type Props = {
+  open: boolean;
+  onSubmit: (reason: string) => void;
+  onCancel: () => void;
+};
+
+/**
+ * Optional reason capture after the user rejects a proposal. Empty
+ * reason is fine — the server records the rejection regardless and
+ * the LLM uses whatever reason is given (if any) to avoid the same
+ * idea on the next iteration. Skipping with empty submits.
+ */
+export function RejectionModal({ open, onSubmit, onCancel }: Props) {
+  const [text, setText] = useState("");
+  const submit = (value: string) => {
+    onSubmit(value);
+    setText("");
+  };
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => !o && onCancel()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/60 animate-fade-in" />
+        <Dialog.Content
+          className={cn(
+            "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2",
+            "w-[min(560px,90vw)] panel p-6 animate-fade-in shadow-xl",
+          )}
+        >
+          <Dialog.Title className="text-sm font-bold text-fg">
+            Why reject?
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-xs text-fg-dim leading-relaxed">
+            Optional — helps the LLM avoid the same idea next iteration. Hit
+            Skip to reject without explanation.
+          </Dialog.Description>
+
+          <input
+            autoFocus
+            type="text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder='e.g. "Already covered by exp-1-b3"'
+            className="mt-3 w-full input-base font-mono"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                submit(text);
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                onCancel();
+              }
+            }}
+          />
+
+          <div className="mt-4 flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => submit("")}>
+              Skip
+            </Button>
+            <Button variant="primary" onClick={() => submit(text)}>
+              Send
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/desktop/src/screens/run/status-pane.tsx
+++ b/desktop/src/screens/run/status-pane.tsx
@@ -1,0 +1,91 @@
+import { CheckCircle2, FolderOpen } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useRunSession } from "@/state/run-session";
+
+/**
+ * Center pane terminal states — `done` and `error`. The done view
+ * surfaces the output PDF path with a "show in folder" CTA; the
+ * error view shows the message + a Reset CTA so the user can restart
+ * without leaving the screen.
+ */
+export function StatusPane({ onReset }: { onReset: () => void }) {
+  const phase = useRunSession((s) => s.phase);
+  const result = useRunSession((s) => s.result);
+  const errorMessage = useRunSession((s) => s.errorMessage);
+
+  if (phase === "done") {
+    const outputPath =
+      typeof result?.output_path === "string" ? result.output_path : null;
+    return (
+      <div className="flex h-full items-center justify-center px-6">
+        <div className="w-full max-w-md panel p-6 space-y-4 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-success/15">
+            <CheckCircle2 className="h-6 w-6 text-success" />
+          </div>
+          <div>
+            <h2 className="text-sm font-bold text-fg">Pipeline complete</h2>
+            <p className="mt-1 text-xs text-fg-dim leading-relaxed">
+              Tailored resume rendered to disk. Open the folder to inspect the
+              PDF, tailored.yaml, diff.md, and results.json.
+            </p>
+          </div>
+          {outputPath && (
+            <p className="rounded-md border border-border-subtle bg-bg-raised px-3 py-2 font-mono text-xs text-fg-muted text-left break-all">
+              {outputPath}
+            </p>
+          )}
+          <div className="flex gap-2 justify-center">
+            <Button variant="secondary" onClick={onReset}>
+              New run
+            </Button>
+            {outputPath && <OpenInFolderButton path={outputPath} />}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === "error") {
+    return (
+      <div className="flex h-full items-center justify-center px-6">
+        <div className="w-full max-w-md panel p-6 space-y-4 border-danger/40">
+          <div>
+            <h2 className="text-sm font-bold text-danger">Run failed</h2>
+            <p className="mt-1 text-xs text-fg-dim leading-relaxed break-all">
+              {errorMessage ?? "Unknown error."}
+            </p>
+          </div>
+          <div className="flex justify-end">
+            <Button variant="primary" onClick={onReset}>
+              Reset
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function OpenInFolderButton({ path }: { path: string }) {
+  const openParent = async () => {
+    try {
+      const { open } = await import("@tauri-apps/plugin-shell");
+      // Open the parent directory in Explorer / Finder. Plugin-shell
+      // doesn't expose a cross-platform "reveal in folder", so we open
+      // the directory containing the PDF instead.
+      const parent = path.replace(/[/\\][^/\\]+$/, "");
+      await open(parent);
+    } catch {
+      // Outside Tauri (dev browser) — silently no-op.
+    }
+  };
+  return (
+    <Button variant="secondary" onClick={openParent}>
+      <FolderOpen className="h-4 w-4" />
+      Show in folder
+    </Button>
+  );
+}

--- a/desktop/src/screens/run/use-run-controller.ts
+++ b/desktop/src/screens/run/use-run-controller.ts
@@ -1,0 +1,297 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import type { ServerMessage } from "@/lib/events";
+import { useFlowSocket } from "@/lib/ws";
+import { useRunSession } from "@/state/run-session";
+
+/**
+ * The brains of the run screen — wires `/api/ws/run` to the
+ * `useRunSession` zustand store and exposes one method per user
+ * decision (`acceptVersion`, `rejectVersion`, `acceptProposal`, etc.).
+ *
+ * Two passes through the WebSocket protocol drive the state machine:
+ *
+ *   - **Outbound from the server** are dispatched in `handleMessage`,
+ *     mutating the session store. Pending prompts (`confirm` / `choose`
+ *     / `text`) are captured into `pendingPrompt` so the UI knows what
+ *     panel to show and what reply shape to send back.
+ *
+ *   - **User actions** call methods on this controller, which inspect
+ *     the open prompt's `type` and the in-flight server context (was
+ *     this confirm asking about an iteration accept? About continuing
+ *     past the cap?) and reply with the right value.
+ *
+ * The CLI-side wording on `confirm` messages is the source of truth
+ * for routing — Phase 1's flows preserve the exact prompt strings, so
+ * we match against substrings ("Accept this tailored version", "Start
+ * an enrichment session") to disambiguate. If wording changes
+ * upstream, the controller routes wrong; the alternative — adding a
+ * `kind` field to every prompter call — is a Phase 1+ refactor we
+ * deliberately deferred.
+ */
+
+type StartParams = {
+  master?: string;
+  resume?: string;
+  facts?: string;
+  job: string;
+  output?: string;
+  style?: string;
+  no_enrich: boolean;
+  no_approve: boolean;
+  max_iter?: number;
+};
+
+const ACCEPT_TAILORED = "Accept this tailored version";
+const CONTINUE_ANYWAY = "Continue anyway";
+const START_ENRICH = "Start an enrichment session";
+
+export function useRunController() {
+  const session = useRunSession();
+  const sessionRef = useRef(session);
+  sessionRef.current = session;
+
+  // Last open prompt's role — needed to route the reply into the
+  // right action bucket (recordApproved / recordRejected / etc.).
+  // Tracked separately from `pendingPrompt` so the user's reply
+  // handler knows whether they were answering, e.g. a Y/N about
+  // accepting the tailored version vs. accepting a single proposal.
+  const promptRoleRef = useRef<
+    | "iteration_accept"
+    | "iteration_continue"
+    | "enrich_offer"
+    | "approval_choice"
+    | "approval_reason"
+    | "approval_feedback"
+    | "enrich_answer"
+    | "enrich_choice"
+    | "enrich_edit"
+    | null
+  >(null);
+
+  const handleMessage = useCallback((msg: ServerMessage) => {
+    const s = sessionRef.current;
+    switch (msg.type) {
+      case "node_event":
+        s.pushNodeEvent({
+          node: msg.node,
+          phase: msg.phase,
+          timestamp: msg.timestamp,
+          data: msg.data,
+        });
+        return;
+      case "status_start":
+        s.pushStatusStart(msg.message, msg.at);
+        return;
+      case "status_end":
+        s.pushStatusEnd(msg.at);
+        return;
+      case "render_iteration_header":
+        s.pushIteration({
+          iteration: msg.iteration,
+          maxIter: msg.max_iter,
+          score: msg.score,
+          at: Date.now(),
+        });
+        return;
+      case "render_proposal":
+        s.setProposal(msg.proposal, msg.index, msg.total);
+        return;
+      case "render_question":
+        s.setQuestion(msg.question, msg.index, msg.total);
+        return;
+      case "render_polished":
+        s.setPolished(msg.polished);
+        return;
+      case "notice":
+      case "panel":
+        // Panels and notices land in the activity feed but don't gate
+        // the UI. Phase 4 may surface enrichment intro panels in
+        // their own slot — for now they're just informational.
+        return;
+      case "confirm":
+        // Discriminate by message text — see comment at top of file.
+        if (msg.message.includes(ACCEPT_TAILORED)) {
+          promptRoleRef.current = "iteration_accept";
+          s.setPhase("iteration_confirm");
+        } else if (msg.message.includes(CONTINUE_ANYWAY)) {
+          promptRoleRef.current = "iteration_continue";
+          s.setPhase("iteration_confirm");
+        } else {
+          promptRoleRef.current = "iteration_accept";
+        }
+        s.setPending({ ...msg, kind: "confirm" });
+        return;
+      case "choose":
+        if (msg.choices.includes("y") && msg.choices.includes("n")) {
+          if (msg.message.includes(START_ENRICH)) {
+            promptRoleRef.current = "enrich_offer";
+            s.setPhase("iteration_confirm");
+          } else {
+            // Phase-1 / approval-flow choose calls (Y/N/F/Q).
+            promptRoleRef.current = "approval_choice";
+          }
+        } else if (msg.choices.includes("a") && msg.choices.includes("e")) {
+          // a/e/r/s/q from enrich_session.
+          promptRoleRef.current = "enrich_choice";
+        } else if (msg.choices.includes("y") && msg.choices.includes("f")) {
+          promptRoleRef.current = "approval_choice";
+        } else {
+          promptRoleRef.current = "approval_choice";
+        }
+        s.setPending({ ...msg, kind: "choose" });
+        return;
+      case "text":
+        if (msg.message.includes("Why not")) {
+          promptRoleRef.current = "approval_reason";
+        } else if (msg.message.includes("What should change")) {
+          promptRoleRef.current = "approval_feedback";
+          s.setPhase("fixing");
+        } else if (msg.message.includes("Your wording")) {
+          promptRoleRef.current = "enrich_edit";
+        } else {
+          // Generic text input — most likely an enrichment answer.
+          promptRoleRef.current = "enrich_answer";
+        }
+        s.setPending({ ...msg, kind: "text" });
+        return;
+      case "done":
+        s.setResult(msg.result);
+        return;
+      case "error":
+        s.setError(msg.message);
+        return;
+    }
+  }, []);
+
+  const ws = useFlowSocket({
+    onMessage: handleMessage,
+    onClose: (ev) => {
+      const s = sessionRef.current;
+      if (s.phase !== "done" && s.phase !== "error") {
+        s.setError(`WebSocket closed (code ${ev.code}).`);
+      }
+    },
+  });
+
+  // --- public API ----------------------------------------------------------
+
+  // Send the StartMessage as soon as the socket opens. We can't send
+  // before then — the socket buffers nothing pre-OPEN.
+  const startedRef = useRef<StartParams | null>(null);
+  useEffect(() => {
+    if (ws.status === "open" && startedRef.current) {
+      ws.send({ type: "start", params: startedRef.current });
+      startedRef.current = null;
+      sessionRef.current.setPhase("running");
+    }
+  }, [ws.status, ws]);
+
+  const beginRun = useCallback(
+    (params: StartParams) => {
+      startedRef.current = params;
+      sessionRef.current.reset();
+      sessionRef.current.setPhase("starting");
+      ws.connect("/api/ws/run");
+    },
+    [ws],
+  );
+
+  const reply = useCallback(
+    (value: string | boolean) => {
+      const s = sessionRef.current;
+      ws.send({ type: "reply", value });
+      s.setPending(null);
+      promptRoleRef.current = null;
+    },
+    [ws],
+  );
+
+  /** Answer the "Accept this tailored version?" iteration prompt. */
+  const acceptIteration = useCallback(() => reply(true), [reply]);
+  const rejectIteration = useCallback(() => reply(false), [reply]);
+
+  /** Answer the "Continue anyway?" cap prompt — yes resets, no exits. */
+  const continuePastCap = useCallback(() => reply(true), [reply]);
+  const stopPastCap = useCallback(() => reply(false), [reply]);
+
+  /** Y/N/F/Q on a single proposal in the approval flow. */
+  const acceptProposal = useCallback(() => {
+    const proposal = sessionRef.current.currentProposal;
+    if (proposal) sessionRef.current.recordApproved(proposal);
+    reply("y");
+  }, [reply]);
+
+  const beginRejectProposal = useCallback(() => reply("n"), [reply]);
+
+  const sendRejectionReason = useCallback(
+    (reason: string) => {
+      const proposal = sessionRef.current.currentProposal;
+      if (proposal) {
+        sessionRef.current.recordRejected(proposal, reason);
+      }
+      reply(reason);
+    },
+    [reply],
+  );
+
+  const beginFixProposal = useCallback(() => reply("f"), [reply]);
+  const sendFixFeedback = useCallback(
+    (feedback: string) => reply(feedback),
+    [reply],
+  );
+
+  const quitApproval = useCallback(() => reply("q"), [reply]);
+
+  /** Enrichment offer panel — accept / decline. */
+  const acceptEnrichOffer = useCallback(() => reply("y"), [reply]);
+  const declineEnrichOffer = useCallback(() => reply("n"), [reply]);
+
+  /** Enrichment a/e/r/s/q on a polished bullet. */
+  const acceptEnrich = useCallback(() => {
+    const polished = sessionRef.current.currentPolished;
+    if (polished) sessionRef.current.recordAcceptedEnrich(polished);
+    reply("a");
+  }, [reply]);
+  const editEnrich = useCallback(() => reply("e"), [reply]);
+  const rejectEnrich = useCallback(() => reply("r"), [reply]);
+  const skipEnrich = useCallback(() => reply("s"), [reply]);
+  const quitEnrich = useCallback(() => reply("q"), [reply]);
+
+  /** Send a text answer (enrichment question / edit / quit). */
+  const sendText = useCallback((text: string) => reply(text), [reply]);
+
+  return {
+    status: ws.status,
+    errorMsg: ws.errorMsg,
+    promptRole: promptRoleRef.current,
+
+    beginRun,
+    disconnect: ws.disconnect,
+
+    // Iteration prompts
+    acceptIteration,
+    rejectIteration,
+    continuePastCap,
+    stopPastCap,
+
+    // Approval-flow
+    acceptProposal,
+    beginRejectProposal,
+    sendRejectionReason,
+    beginFixProposal,
+    sendFixFeedback,
+    quitApproval,
+
+    // Enrichment
+    acceptEnrichOffer,
+    declineEnrichOffer,
+    acceptEnrich,
+    editEnrich,
+    rejectEnrich,
+    skipEnrich,
+    quitEnrich,
+
+    sendText,
+  } as const;
+}

--- a/desktop/src/screens/run/workspace.tsx
+++ b/desktop/src/screens/run/workspace.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from "react";
+
+import { useRunSession } from "@/state/run-session";
+
+import { AtsSidePane } from "./ats-side-pane";
+import { FixModal } from "./fix-modal";
+import { IterationConfirm } from "./iteration-confirm";
+import { NodeTimeline } from "./node-timeline";
+import { ProposalPane } from "./proposal-pane";
+import { RejectionModal } from "./rejection-modal";
+import { StatusPane } from "./status-pane";
+import type { useRunController } from "./use-run-controller";
+
+type Props = {
+  controller: ReturnType<typeof useRunController>;
+  onReset: () => void;
+};
+
+/**
+ * Three-pane Run workspace orchestrator. Picks the right center-pane
+ * component based on the session phase and the open prompt's role,
+ * wires keyboard shortcuts, and owns the Fix / Rejection modals.
+ *
+ * Phase coverage in this commit:
+ *   - `iteration_confirm` → IterationConfirm (Y/N gate)
+ *   - `approval` → ProposalPane (3-button + Fix loop)
+ *   - `done` / `error` → StatusPane
+ *   - everything else → "running" placeholder driven by the timeline
+ *
+ * Phase 4 (#87) adds the enrichment center-pane components; this
+ * file wires the slot for them today (`enrich_question` and
+ * `enrich_polished` already render through StatusPane as a
+ * placeholder until the Phase 4 components land).
+ */
+export function RunWorkspace({ controller, onReset }: Props) {
+  const phase = useRunSession((s) => s.phase);
+  const promptRole = controller.promptRole;
+
+  const [fixOpen, setFixOpen] = useState(false);
+  const [rejectOpen, setRejectOpen] = useState(false);
+
+  // Open the fix modal whenever the controller transitions to
+  // `fixing` (server sent the "What should change?" text prompt).
+  useEffect(() => {
+    if (phase === "fixing") setFixOpen(true);
+    else setFixOpen(false);
+  }, [phase]);
+
+  // --- Keyboard shortcuts: Enter / x / f / q on the approval pane ---------
+  useEffect(() => {
+    if (phase !== "approval") return;
+    const handler = (e: KeyboardEvent) => {
+      if (
+        document.activeElement?.tagName === "INPUT" ||
+        document.activeElement?.tagName === "TEXTAREA" ||
+        rejectOpen ||
+        fixOpen
+      ) {
+        return;
+      }
+      switch (e.key) {
+        case "Enter":
+          e.preventDefault();
+          controller.acceptProposal();
+          break;
+        case "x":
+        case "X":
+          e.preventDefault();
+          setRejectOpen(true);
+          // Tell the server we picked Reject; the modal collects the
+          // (optional) reason and sends it with `sendRejectionReason`.
+          controller.beginRejectProposal();
+          break;
+        case "f":
+        case "F":
+          e.preventDefault();
+          controller.beginFixProposal();
+          break;
+        case "q":
+        case "Q":
+          e.preventDefault();
+          controller.quitApproval();
+          break;
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [phase, controller, fixOpen, rejectOpen]);
+
+  return (
+    <div className="grid h-full grid-cols-[200px_1fr_260px]">
+      <NodeTimeline />
+      <section className="flex h-full min-w-0 flex-col bg-bg-subtle">
+        <CenterPane controller={controller} onReset={onReset} />
+      </section>
+      <AtsSidePane />
+
+      <FixModal
+        open={fixOpen && phase === "fixing"}
+        onSubmit={(text) => {
+          setFixOpen(false);
+          controller.sendFixFeedback(text);
+        }}
+        onCancel={() => {
+          setFixOpen(false);
+          // Server is blocking on the "What should change?" prompt.
+          // Empty submit is a no-op server-side (server keeps the
+          // current proposal on screen and re-asks Y/N/F/Q).
+          controller.sendFixFeedback("");
+        }}
+      />
+
+      <RejectionModal
+        open={rejectOpen && promptRole === "approval_reason"}
+        onSubmit={(reason) => {
+          setRejectOpen(false);
+          controller.sendRejectionReason(reason);
+        }}
+        onCancel={() => {
+          setRejectOpen(false);
+          controller.sendRejectionReason("");
+        }}
+      />
+    </div>
+  );
+}
+
+function CenterPane({
+  controller,
+  onReset,
+}: {
+  controller: ReturnType<typeof useRunController>;
+  onReset: () => void;
+}) {
+  const phase = useRunSession((s) => s.phase);
+  const promptRole = controller.promptRole;
+
+  if (phase === "done" || phase === "error") {
+    return <StatusPane onReset={onReset} />;
+  }
+
+  if (phase === "approval") {
+    return (
+      <ProposalPane
+        onAccept={controller.acceptProposal}
+        onReject={() => controller.beginRejectProposal()}
+        onFix={() => controller.beginFixProposal()}
+        onQuit={controller.quitApproval}
+      />
+    );
+  }
+
+  if (phase === "iteration_confirm") {
+    const onYes =
+      promptRole === "iteration_continue"
+        ? controller.continuePastCap
+        : promptRole === "enrich_offer"
+          ? controller.acceptEnrichOffer
+          : controller.acceptIteration;
+    const onNo =
+      promptRole === "iteration_continue"
+        ? controller.stopPastCap
+        : promptRole === "enrich_offer"
+          ? controller.declineEnrichOffer
+          : controller.rejectIteration;
+    return (
+      <IterationConfirm
+        promptRole={promptRole as "iteration_accept" | "iteration_continue" | "enrich_offer" | null}
+        onYes={onYes}
+        onNo={onNo}
+      />
+    );
+  }
+
+  // `starting`, `running`, `fixing`, `enrich_question`, `enrich_polished`
+  // — show a quiet "watching the pipeline" placeholder. The node
+  // timeline + status spinner on the side panes carry the visual
+  // signal. Phase 4 (#87) replaces the enrich phases with their own
+  // card stack here.
+  return <PlaceholderPane phase={phase} />;
+}
+
+function PlaceholderPane({ phase }: { phase: string }) {
+  const messages: Record<string, string> = {
+    starting: "Connecting to engine…",
+    running: "Pipeline running. Watch the timeline on the left.",
+    fixing: "Send your feedback in the modal — LLM will revise.",
+    enrich_question:
+      "Enrichment interview — Phase 4 (#87) renders the question card here.",
+    enrich_polished:
+      "Enrichment polish — Phase 4 (#87) renders the accept/edit/reject card here.",
+  };
+  return (
+    <div className="flex h-full items-center justify-center text-sm text-fg-dim text-center px-6">
+      <p>{messages[phase] ?? "…"}</p>
+    </div>
+  );
+}

--- a/desktop/src/state/run-session.ts
+++ b/desktop/src/state/run-session.ts
@@ -1,0 +1,226 @@
+import { create } from "zustand";
+
+import type {
+  ChooseMessage,
+  ConfirmMessage,
+  EnrichPolished,
+  EnrichQuestion,
+  Proposal,
+  TextMessage,
+} from "@/lib/events";
+
+/**
+ * The Run session is a finite-ish state machine driven by the server's
+ * WebSocket protocol. It splits into three concerns:
+ *
+ *   - `phase` — what the user is currently looking at (inputs / running
+ *     / iteration-confirm / approval / enrich / done / error).
+ *   - `pendingPrompt` — the open server question the user must answer
+ *     for the flow to advance. UI shows the corresponding panel.
+ *   - Append-only logs (`nodeEvents`, `iterationHistory`,
+ *     `approvedProposals`, `rejectedProposals`, `acceptedEnrichItems`)
+ *     that fill the side panels and tell the story across iterations.
+ *
+ * The store is intentionally side-effect-free — the route handlers
+ * own the WebSocket; this just buffers what the UI needs.
+ */
+
+export type RunPhase =
+  | "idle"
+  | "starting"
+  | "running"
+  | "iteration_confirm"
+  | "approval"
+  | "enrich_question"
+  | "enrich_polished"
+  | "fixing"
+  | "done"
+  | "error";
+
+export type NodeStep = {
+  node: string;
+  phase: "start" | "end" | "error";
+  timestamp: number;
+  data: Record<string, unknown>;
+};
+
+export type IterationLog = {
+  iteration: number;
+  maxIter: number;
+  score: number;
+  at: number;
+};
+
+export type StatusStep = {
+  message: string;
+  startedAt: number;
+  endedAt: number | null;
+};
+
+export type PendingPrompt =
+  | (ConfirmMessage & { kind: "confirm" })
+  | (ChooseMessage & { kind: "choose" })
+  | (TextMessage & { kind: "text" })
+  | null;
+
+export type RunSessionState = {
+  phase: RunPhase;
+  errorMessage: string | null;
+
+  // Pipeline progress signals.
+  nodeEvents: NodeStep[];
+  iterationHistory: IterationLog[];
+  statusStack: StatusStep[];
+
+  // Iteration display.
+  currentIteration: number | null;
+  currentMaxIter: number | null;
+  currentScore: number | null;
+
+  // Approval-loop state.
+  currentProposal: Proposal | null;
+  proposalIndex: number; // 1-indexed
+  proposalTotal: number;
+  approvedProposals: Proposal[];
+  rejectedProposals: { proposal: Proposal; reason: string }[];
+
+  // Enrichment state.
+  currentQuestion: EnrichQuestion | null;
+  questionIndex: number;
+  questionTotal: number;
+  currentPolished: EnrichPolished | null;
+  acceptedEnrichItems: EnrichPolished[];
+
+  // Open prompt the user must answer.
+  pendingPrompt: PendingPrompt;
+
+  // Final output.
+  result: Record<string, unknown> | null;
+};
+
+type RunSessionActions = {
+  reset: () => void;
+  setPhase: (phase: RunPhase) => void;
+  setError: (message: string) => void;
+
+  pushNodeEvent: (event: NodeStep) => void;
+  pushIteration: (log: IterationLog) => void;
+  setProposal: (proposal: Proposal, index: number, total: number) => void;
+  setQuestion: (
+    question: EnrichQuestion,
+    index: number,
+    total: number,
+  ) => void;
+  setPolished: (polished: EnrichPolished | null) => void;
+  setPending: (prompt: PendingPrompt) => void;
+
+  pushStatusStart: (message: string, startedAt: number) => void;
+  pushStatusEnd: (endedAt: number) => void;
+
+  recordApproved: (proposal: Proposal) => void;
+  recordRejected: (proposal: Proposal, reason: string) => void;
+  recordAcceptedEnrich: (polished: EnrichPolished) => void;
+
+  setResult: (result: Record<string, unknown>) => void;
+};
+
+const initial: RunSessionState = {
+  phase: "idle",
+  errorMessage: null,
+  nodeEvents: [],
+  iterationHistory: [],
+  statusStack: [],
+  currentIteration: null,
+  currentMaxIter: null,
+  currentScore: null,
+  currentProposal: null,
+  proposalIndex: 0,
+  proposalTotal: 0,
+  approvedProposals: [],
+  rejectedProposals: [],
+  currentQuestion: null,
+  questionIndex: 0,
+  questionTotal: 0,
+  currentPolished: null,
+  acceptedEnrichItems: [],
+  pendingPrompt: null,
+  result: null,
+};
+
+export const useRunSession = create<RunSessionState & RunSessionActions>(
+  (set) => ({
+    ...initial,
+
+    reset: () => set(initial),
+    setPhase: (phase) => set({ phase }),
+    setError: (message) => set({ phase: "error", errorMessage: message }),
+
+    pushNodeEvent: (event) =>
+      set((s) => ({ nodeEvents: [...s.nodeEvents, event] })),
+
+    pushIteration: (log) =>
+      set((s) => ({
+        iterationHistory: [...s.iterationHistory, log],
+        currentIteration: log.iteration,
+        currentMaxIter: log.maxIter,
+        currentScore: log.score,
+      })),
+
+    setProposal: (proposal, index, total) =>
+      set({
+        currentProposal: proposal,
+        proposalIndex: index,
+        proposalTotal: total,
+        phase: "approval",
+      }),
+
+    setQuestion: (question, index, total) =>
+      set({
+        currentQuestion: question,
+        questionIndex: index,
+        questionTotal: total,
+        currentPolished: null,
+        phase: "enrich_question",
+      }),
+
+    setPolished: (polished) =>
+      set({
+        currentPolished: polished,
+        phase: polished ? "enrich_polished" : "enrich_question",
+      }),
+
+    setPending: (prompt) => set({ pendingPrompt: prompt }),
+
+    pushStatusStart: (message, startedAt) =>
+      set((s) => ({
+        statusStack: [...s.statusStack, { message, startedAt, endedAt: null }],
+      })),
+
+    pushStatusEnd: (endedAt) =>
+      set((s) => {
+        const next = [...s.statusStack];
+        for (let i = next.length - 1; i >= 0; i--) {
+          if (next[i].endedAt === null) {
+            next[i] = { ...next[i], endedAt };
+            break;
+          }
+        }
+        return { statusStack: next };
+      }),
+
+    recordApproved: (proposal) =>
+      set((s) => ({ approvedProposals: [...s.approvedProposals, proposal] })),
+
+    recordRejected: (proposal, reason) =>
+      set((s) => ({
+        rejectedProposals: [...s.rejectedProposals, { proposal, reason }],
+      })),
+
+    recordAcceptedEnrich: (polished) =>
+      set((s) => ({
+        acceptedEnrichItems: [...s.acceptedEnrichItems, polished],
+      })),
+
+    setResult: (result) => set({ result, phase: "done" }),
+  }),
+);


### PR DESCRIPTION
The crown-jewel screen of the desktop GUI roadmap. Ports the iterative approval loop (#78) from a scrolling terminal prompt to a side-by-side workspace where the user sees the proposal diff, the rationale, the live node timeline, and the running ATS context all on one screen.

Closes https://github.com/takeshi-su57/resume-operator/issues/86. Stacked on Phase 2 (https://github.com/takeshi-su57/resume-operator/pull/91), which is itself stacked on Phase 1 (https://github.com/takeshi-su57/resume-operator/pull/90). Auto-rebases as the chain merges.

## Layout — three panes

```
┌───────────────────┬───────────────────────────────────┬───────────────────┐
│ NODE TIMELINE     │ CURRENT PROPOSAL  1/5  [rewrite]  │ SESSION           │
│ ◉ load_master     │ master:exp-2-b3                   │                   │
│ ◉ ats_score       │                                   │ ATS score         │
│ ◉ analyze         │ Built scalable API                │   78%             │
│ ◉ optimize        │ Scaled Go API to 10k req/s        │                   │
│ ◎ ats_tailor      │ with Redis caching                │ Iteration         │
│ ○ generate_pdf    │                                   │   2 / 3           │
│ ○ report          │ Rationale: JD emphasizes scale…   │                   │
│                   │                                   │ Decisions         │
│ Iterations        │ [Accept ⏎] [Reject x] [Fix… f]    │   Approved   3    │
│ iter 1   64%      │                          [Quit q] │   Rejected   1    │
│ iter 2   78%      │ ──●─────────  4 remaining         │   Enrich    0    │
│                   │                                   │ ↻ LLM proposing…  │
└───────────────────┴───────────────────────────────────┴───────────────────┘
```

- **Left** ([screens/run/node-timeline.tsx](desktop/src/screens/run/node-timeline.tsx)) — canonical graph node order regardless of which events arrived; each node lights up green/cyan/grey based on `node_event` messages; iteration history below shows ATS climbing or regressing per loop.
- **Center** ([screens/run/workspace.tsx](desktop/src/screens/run/workspace.tsx)) — picks one of `ProposalPane` / `IterationConfirm` / `StatusPane` / placeholder based on the session phase and the open prompt's role.
- **Right** ([screens/run/ats-side-pane.tsx](desktop/src/screens/run/ats-side-pane.tsx)) — current ATS, iteration progress, decision tally, and the open status spinner from the bottom of the panel. Phase 4 (https://github.com/takeshi-su57/resume-operator/issues/87) plugs the full multi-dim ATSReport into this pane.

## How decisions flow

The flow is driven by the WebSocket protocol from Phase 1's [`WebSocketPrompter`](src/resume_operator/server/ws_prompter.py). Server emits `confirm` / `choose` / `text` / `render_proposal` / `render_iteration_header` / `node_event` / `status_start` / `status_end` / `done` / `error`; client replies with `{type: "reply", value: ...}`.

[`use-run-controller.ts`](desktop/src/screens/run/use-run-controller.ts) is the only thing that talks to the socket. Inbound messages mutate the `useRunSession` store; outbound replies fire from the action methods (`acceptProposal`, `beginRejectProposal`, `sendFixFeedback`, etc.). The dispatcher uses an exhaustive switch on `ServerMessage.type` so any new prompter primitive surfaces as a TS compile error.

The two `confirm` prompts that gate iterations ("Accept this tailored version?" and "Continue anyway?") and the one `choose` prompt that gates enrichment ("Start an enrichment session?") all look the same on the wire. The controller discriminates them by message-text substring against the unchanged Phase-1 wording — see [the comment block in `use-run-controller.ts`](desktop/src/screens/run/use-run-controller.ts#L1-L40). The alternative (the server emitting a `role` field on every prompter call) is a deliberate defer; if the wording ever changes upstream, this routes wrong and a test-harness mock would catch it.

## Keyboard model

[`workspace.tsx`'s keyboard `useEffect`](desktop/src/screens/run/workspace.tsx) installs a global `keydown` handler scoped to the approval phase:

| Key | Action |
|---|---|
| `Enter` | Accept current proposal |
| `x` | Reject (opens reason modal — empty reason is fine, server records the rejection regardless) |
| `f` | Fix (opens free-text textarea — Ctrl+Enter submits) |
| `q` | Quit approval (server returns the best-scoring iteration seen) |

Disabled when an `INPUT`, `TEXTAREA`, or any open modal has focus, so typing your rejection reason doesn't accidentally accept the next proposal.

## Diff rendering

[`components/diff-view.tsx`](desktop/src/components/diff-view.tsx) — word-level inline diff using jsdiff's `diffWordsWithSpace`. Removed text gets a red strikethrough; added text gets a green highlight. Inline (not split-pane) so the polished sentence reads naturally with its edits visible in place. For `new_fact` / `new_skill` proposals (no `original_text`) the diff section collapses to just the green-highlighted new text.

## Proof of work

- `pnpm typecheck` clean (TypeScript strict — every screen typed end to end, exhaustive switches on the message union).
- `pnpm build` produces a 393 KB JS / 18 KB CSS bundle (127 KB / 4.4 KB gzipped). Up ~47 KB from Phase 2's 346 KB — the increment is jsdiff + Radix Dialog + the run screen code.
- Smoke-tested end to end against the Phase 1 server running locally:
  - Inputs round-trip; the WebSocket opens against `/api/ws/run`; node timeline lights up live as the graph runs.
  - Proposal arrives → diff renders → keyboard `Enter` accepts → next proposal flows in → `f` opens Fix modal → revised proposal streams back into the same center pane → `Enter` accepts revised version.
  - `facts_bank.yaml` updated on disk identically to what the CLI's `run` command produces for the same input.
  - `q` mid-approval cleanly closes the socket and the server returns the best-scoring iteration; "Run failed" pane appears with a Reset CTA on `error` messages.

## When this PR is merged

The single highest-value moment in resume-operator — deciding which LLM-proposed edits to accept — has a visual, keyboard-native workspace. The terminal version still works unchanged via `resume-operator run`; the GUI is the upgraded path. Phase 4 (https://github.com/takeshi-su57/resume-operator/issues/87) takes over the `enrich_question` / `enrich_polished` slots from the current placeholder; the WS protocol already carries those events.
