### PR TITLE
feat(desktop): enrichment interview card stack on the Run screen (Phase 4, #87)

### DIFF
--- a/desktop/src/screens/run/enrich-polished-pane.tsx
+++ b/desktop/src/screens/run/enrich-polished-pane.tsx
@@ -1,0 +1,195 @@
+import { Check, Pencil, SkipForward, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+import type { EnrichPolished } from "@/lib/events";
+import { useRunSession } from "@/state/run-session";
+
+type Props = {
+  onAccept: () => void;
+  onEdit: (text: string) => void;
+  onReject: () => void;
+  onSkip: () => void;
+  onQuit: () => void;
+};
+
+const BUCKET_LABELS: Record<EnrichPolished["bucket"], string> = {
+  project: "project",
+  extra_bullet: "extra bullet",
+  skill: "skill",
+  certification: "certification",
+};
+
+const BUCKET_TONES: Record<EnrichPolished["bucket"], string> = {
+  project: "border-accent/40 bg-accent/10 text-accent",
+  extra_bullet: "border-success/40 bg-success/10 text-success",
+  skill: "border-warning/40 bg-warning/10 text-warning",
+  certification: "border-fg-muted/30 bg-bg-raised text-fg-muted",
+};
+
+/**
+ * Polished bullet card — server has emitted `render_polished` with
+ * the LLM's classification + role linkage and is waiting on a
+ * choose-prompt with options a/e/r/s/q.
+ *
+ * "Accept" sends `a` and persists; "Edit" expands an inline textarea
+ * pre-filled with the polished text — submit sends `e` followed by a
+ * text reply containing the edited wording (the server's choose
+ * prompt branches on `e`, then issues a new text prompt for "Your
+ * wording", which our controller routes to `enrich_edit`).
+ */
+export function EnrichPolishedPane({
+  onAccept,
+  onEdit,
+  onReject,
+  onSkip,
+  onQuit,
+}: Props) {
+  const polished = useRunSession((s) => s.currentPolished);
+  const question = useRunSession((s) => s.currentQuestion);
+  const index = useRunSession((s) => s.questionIndex);
+  const total = useRunSession((s) => s.questionTotal);
+
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  // When a new polished bullet arrives, snap to non-editing mode.
+  useEffect(() => {
+    setEditing(false);
+    setDraft(polished?.polished_text ?? "");
+  }, [polished]);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  if (!polished) return null;
+
+  const submitEdit = () => {
+    if (!draft.trim()) return;
+    setEditing(false);
+    onEdit(draft);
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="border-b border-border px-6 py-3">
+        <p className="text-xs uppercase tracking-wider text-fg-muted">
+          Enrichment · polished {index} / {total}
+        </p>
+        {question?.question && (
+          <p className="mt-1 text-xs text-fg-dim leading-relaxed">
+            <span className="text-fg-faint">q:</span> {question.question}
+          </p>
+        )}
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span
+            className={cn(
+              "rounded-md border px-2 py-0.5 text-xs font-mono",
+              BUCKET_TONES[polished.bucket],
+            )}
+          >
+            {BUCKET_LABELS[polished.bucket]}
+          </span>
+          {polished.role_id && (
+            <span className="rounded-sm border border-border bg-bg-raised px-1.5 py-0.5 font-mono text-xs text-fg-dim">
+              role: {polished.role_id}
+            </span>
+          )}
+        </div>
+
+        {editing ? (
+          <textarea
+            ref={inputRef}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            className="input-base min-h-[140px] resize-none font-mono leading-relaxed"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                e.preventDefault();
+                submitEdit();
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                setEditing(false);
+                setDraft(polished.polished_text);
+              }
+            }}
+          />
+        ) : (
+          <p className="font-mono text-sm leading-relaxed text-success bg-success/5 border border-success/20 rounded-md px-3 py-2">
+            {polished.polished_text}
+          </p>
+        )}
+      </div>
+
+      <div
+        className="border-t border-border px-6 py-2 flex items-center gap-2"
+        data-no-select
+      >
+        {editing ? (
+          <>
+            <Button
+              variant="primary"
+              onClick={submitEdit}
+              disabled={!draft.trim()}
+              title="Save edit (Ctrl+Enter)"
+            >
+              <Check className="h-4 w-4" />
+              Save edit
+              <span className="kbd ml-1">Ctrl</span>
+              <span className="kbd">⏎</span>
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setEditing(false);
+                setDraft(polished.polished_text);
+              }}
+            >
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button variant="primary" onClick={onAccept} title="Accept (a)">
+              <Check className="h-4 w-4" />
+              Accept
+              <span className="kbd ml-1">a</span>
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => setEditing(true)}
+              title="Edit wording (e)"
+            >
+              <Pencil className="h-4 w-4" />
+              Edit
+              <span className="kbd ml-1">e</span>
+            </Button>
+            <Button variant="secondary" onClick={onReject} title="Reject (r)">
+              <X className="h-4 w-4" />
+              Reject
+              <span className="kbd ml-1">r</span>
+            </Button>
+            <Button variant="ghost" onClick={onSkip} title="Skip (s)">
+              <SkipForward className="h-4 w-4" />
+              Skip
+              <span className="kbd ml-1">s</span>
+            </Button>
+            <div className="ml-auto">
+              <Button variant="ghost" onClick={onQuit} title="Quit (q)">
+                Quit
+                <span className="kbd ml-1">q</span>
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/screens/run/enrich-question-pane.tsx
+++ b/desktop/src/screens/run/enrich-question-pane.tsx
@@ -1,0 +1,126 @@
+import { ChevronRight, Loader2, SkipForward, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { useRunSession } from "@/state/run-session";
+
+type Props = {
+  onSubmit: (text: string) => void;
+  onSkip: () => void;
+  onQuit: () => void;
+};
+
+/**
+ * Enrichment question card. Server has emitted `render_question`
+ * followed by a `text` prompt waiting on the user's free-text
+ * answer. The user types facts/metrics in the textarea and either:
+ *   - submits → server runs `polish_answer` → `render_polished`
+ *   - skips → server moves to the next question
+ *   - quits → ends the enrichment session
+ *
+ * The "skip" / "quit" actions submit the literal strings the server
+ * understands (it short-circuits on those values inside
+ * `tools.enrich.run_interactive_session`).
+ */
+export function EnrichQuestionPane({ onSubmit, onSkip, onQuit }: Props) {
+  const question = useRunSession((s) => s.currentQuestion);
+  const index = useRunSession((s) => s.questionIndex);
+  const total = useRunSession((s) => s.questionTotal);
+
+  const [text, setText] = useState("");
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  // Reset the textarea each time a new question lands.
+  useEffect(() => {
+    setText("");
+    ref.current?.focus();
+  }, [question]);
+
+  if (!question) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-fg-dim">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Generating questions…
+      </div>
+    );
+  }
+
+  const submit = () => {
+    if (!text.trim()) return;
+    onSubmit(text);
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="border-b border-border px-6 py-3">
+        <div className="flex items-baseline gap-2">
+          <p className="text-xs uppercase tracking-wider text-fg-muted">
+            Enrichment · question {index} / {total}
+          </p>
+          {question.area && (
+            <span className="rounded-sm border border-border bg-bg-raised px-1.5 py-0.5 font-mono text-xs text-fg-dim">
+              {question.area}
+            </span>
+          )}
+        </div>
+        <h3 className="mt-1 text-sm font-bold text-fg leading-relaxed">
+          {question.question}
+        </h3>
+        {question.why && (
+          <p className="mt-1 text-xs text-fg-dim leading-relaxed">
+            <span className="text-fg-faint">why:</span> {question.why}
+          </p>
+        )}
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        <p className="mb-2 text-xs text-fg-dim leading-relaxed">
+          Answer with facts and metrics — e.g. <span className="text-fg-muted">
+            "I built 50+ endpoints serving 2M requests/day"
+          </span>. Don't type instructions ("make it professional"); the LLM
+          polishes wording in the next step.
+        </p>
+        <textarea
+          ref={ref}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Type the facts here…"
+          className="input-base min-h-[180px] resize-none font-mono leading-relaxed"
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+              e.preventDefault();
+              submit();
+            }
+          }}
+        />
+      </div>
+
+      <div
+        className="border-t border-border px-6 py-2 flex items-center gap-2"
+        data-no-select
+      >
+        <Button
+          variant="primary"
+          onClick={submit}
+          disabled={!text.trim()}
+          title="Polish (Ctrl+Enter)"
+        >
+          <ChevronRight className="h-4 w-4" />
+          Polish
+          <span className="kbd ml-1">Ctrl</span>
+          <span className="kbd">⏎</span>
+        </Button>
+        <Button variant="secondary" onClick={onSkip} title="Skip this question">
+          <SkipForward className="h-4 w-4" />
+          Skip
+        </Button>
+        <div className="ml-auto">
+          <Button variant="ghost" onClick={onQuit} title="End session">
+            <X className="h-4 w-4" />
+            Quit
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/screens/run/workspace.tsx
+++ b/desktop/src/screens/run/workspace.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useRunSession } from "@/state/run-session";
 
 import { AtsSidePane } from "./ats-side-pane";
+import { EnrichPolishedPane } from "./enrich-polished-pane";
+import { EnrichQuestionPane } from "./enrich-question-pane";
 import { FixModal } from "./fix-modal";
 import { IterationConfirm } from "./iteration-confirm";
 import { NodeTimeline } from "./node-timeline";
@@ -19,25 +21,22 @@ type Props = {
 /**
  * Three-pane Run workspace orchestrator. Picks the right center-pane
  * component based on the session phase and the open prompt's role,
- * wires keyboard shortcuts, and owns the Fix / Rejection modals.
- *
- * Phase coverage in this commit:
- *   - `iteration_confirm` → IterationConfirm (Y/N gate)
- *   - `approval` → ProposalPane (3-button + Fix loop)
- *   - `done` / `error` → StatusPane
- *   - everything else → "running" placeholder driven by the timeline
- *
- * Phase 4 (#87) adds the enrichment center-pane components; this
- * file wires the slot for them today (`enrich_question` and
- * `enrich_polished` already render through StatusPane as a
- * placeholder until the Phase 4 components land).
+ * wires keyboard shortcuts, and owns the Fix / Rejection modals plus
+ * the deferred enrichment-edit reply (the `e` choose pick fires a
+ * follow-up text prompt the user fills in via the polished pane).
  */
 export function RunWorkspace({ controller, onReset }: Props) {
   const phase = useRunSession((s) => s.phase);
+  const pending = useRunSession((s) => s.pendingPrompt);
   const promptRole = controller.promptRole;
 
   const [fixOpen, setFixOpen] = useState(false);
   const [rejectOpen, setRejectOpen] = useState(false);
+
+  // When the user picks "Edit" on a polished bullet, we send `e` —
+  // the server then fires a `text` prompt asking for the edited
+  // wording. Stash the draft until that prompt arrives.
+  const pendingEnrichEditRef = useRef<string | null>(null);
 
   // Open the fix modal whenever the controller transitions to
   // `fixing` (server sent the "What should change?" text prompt).
@@ -46,41 +45,79 @@ export function RunWorkspace({ controller, onReset }: Props) {
     else setFixOpen(false);
   }, [phase]);
 
-  // --- Keyboard shortcuts: Enter / x / f / q on the approval pane ---------
+  // When the deferred enrich-edit text prompt arrives, send the
+  // stashed draft.
   useEffect(() => {
-    if (phase !== "approval") return;
+    if (
+      pending?.kind === "text" &&
+      promptRole === "enrich_edit" &&
+      pendingEnrichEditRef.current !== null
+    ) {
+      const draft = pendingEnrichEditRef.current;
+      pendingEnrichEditRef.current = null;
+      controller.sendText(draft);
+    }
+  }, [pending, promptRole, controller]);
+
+  // --- Keyboard shortcuts -------------------------------------------------
+  useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      const tag = document.activeElement?.tagName;
       if (
-        document.activeElement?.tagName === "INPUT" ||
-        document.activeElement?.tagName === "TEXTAREA" ||
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
         rejectOpen ||
         fixOpen
       ) {
         return;
       }
-      switch (e.key) {
-        case "Enter":
-          e.preventDefault();
-          controller.acceptProposal();
-          break;
-        case "x":
-        case "X":
-          e.preventDefault();
-          setRejectOpen(true);
-          // Tell the server we picked Reject; the modal collects the
-          // (optional) reason and sends it with `sendRejectionReason`.
-          controller.beginRejectProposal();
-          break;
-        case "f":
-        case "F":
-          e.preventDefault();
-          controller.beginFixProposal();
-          break;
-        case "q":
-        case "Q":
-          e.preventDefault();
-          controller.quitApproval();
-          break;
+      if (phase === "approval") {
+        switch (e.key) {
+          case "Enter":
+            e.preventDefault();
+            controller.acceptProposal();
+            return;
+          case "x":
+          case "X":
+            e.preventDefault();
+            setRejectOpen(true);
+            controller.beginRejectProposal();
+            return;
+          case "f":
+          case "F":
+            e.preventDefault();
+            controller.beginFixProposal();
+            return;
+          case "q":
+          case "Q":
+            e.preventDefault();
+            controller.quitApproval();
+            return;
+        }
+      }
+      if (phase === "enrich_polished") {
+        switch (e.key) {
+          case "a":
+          case "A":
+            e.preventDefault();
+            controller.acceptEnrich();
+            return;
+          case "r":
+          case "R":
+            e.preventDefault();
+            controller.rejectEnrich();
+            return;
+          case "s":
+          case "S":
+            e.preventDefault();
+            controller.skipEnrich();
+            return;
+          case "q":
+          case "Q":
+            e.preventDefault();
+            controller.quitEnrich();
+            return;
+        }
       }
     };
     window.addEventListener("keydown", handler);
@@ -91,7 +128,17 @@ export function RunWorkspace({ controller, onReset }: Props) {
     <div className="grid h-full grid-cols-[200px_1fr_260px]">
       <NodeTimeline />
       <section className="flex h-full min-w-0 flex-col bg-bg-subtle">
-        <CenterPane controller={controller} onReset={onReset} />
+        <CenterPane
+          controller={controller}
+          onReset={onReset}
+          onEnrichEditSubmit={(text) => {
+            // Send `e` to the server's choose prompt. The text prompt
+            // that follows is answered by the effect above once it
+            // arrives, using the stashed draft.
+            pendingEnrichEditRef.current = text;
+            controller.editEnrich();
+          }}
+        />
       </section>
       <AtsSidePane />
 
@@ -103,9 +150,6 @@ export function RunWorkspace({ controller, onReset }: Props) {
         }}
         onCancel={() => {
           setFixOpen(false);
-          // Server is blocking on the "What should change?" prompt.
-          // Empty submit is a no-op server-side (server keeps the
-          // current proposal on screen and re-asks Y/N/F/Q).
           controller.sendFixFeedback("");
         }}
       />
@@ -128,9 +172,11 @@ export function RunWorkspace({ controller, onReset }: Props) {
 function CenterPane({
   controller,
   onReset,
+  onEnrichEditSubmit,
 }: {
   controller: ReturnType<typeof useRunController>;
   onReset: () => void;
+  onEnrichEditSubmit: (text: string) => void;
 }) {
   const phase = useRunSession((s) => s.phase);
   const promptRole = controller.promptRole;
@@ -172,11 +218,28 @@ function CenterPane({
     );
   }
 
-  // `starting`, `running`, `fixing`, `enrich_question`, `enrich_polished`
-  // — show a quiet "watching the pipeline" placeholder. The node
-  // timeline + status spinner on the side panes carry the visual
-  // signal. Phase 4 (#87) replaces the enrich phases with their own
-  // card stack here.
+  if (phase === "enrich_question") {
+    return (
+      <EnrichQuestionPane
+        onSubmit={(text) => controller.sendText(text)}
+        onSkip={() => controller.sendText("skip")}
+        onQuit={() => controller.sendText("quit")}
+      />
+    );
+  }
+
+  if (phase === "enrich_polished") {
+    return (
+      <EnrichPolishedPane
+        onAccept={controller.acceptEnrich}
+        onEdit={onEnrichEditSubmit}
+        onReject={controller.rejectEnrich}
+        onSkip={controller.skipEnrich}
+        onQuit={controller.quitEnrich}
+      />
+    );
+  }
+
   return <PlaceholderPane phase={phase} />;
 }
 
@@ -185,10 +248,6 @@ function PlaceholderPane({ phase }: { phase: string }) {
     starting: "Connecting to engine…",
     running: "Pipeline running. Watch the timeline on the left.",
     fixing: "Send your feedback in the modal — LLM will revise.",
-    enrich_question:
-      "Enrichment interview — Phase 4 (#87) renders the question card here.",
-    enrich_polished:
-      "Enrichment polish — Phase 4 (#87) renders the accept/edit/reject card here.",
   };
   return (
     <div className="flex h-full items-center justify-center text-sm text-fg-dim text-center px-6">


### PR DESCRIPTION
Replaces the placeholder pane that Phase 3 (https://github.com/takeshi-su57/resume-operator/pull/92) left for the enrichment session phases with proper card components, and wires the `e` (edit) → `text` two-step that `tools.enrich.run_interactive_session` runs server-side.

Closes https://github.com/takeshi-su57/resume-operator/issues/87. Stacked on Phase 3 (#92), which is stacked on #91, which is stacked on #90 — auto-rebases as the chain merges.

## Two new center-pane components

**`EnrichQuestionPane`** ([screens/run/enrich-question-pane.tsx](desktop/src/screens/run/enrich-question-pane.tsx)) renders when the server has emitted `render_question` and is waiting on a `text` prompt.

```
┌─────────────────────────────────────────────┐
│ ENRICHMENT · QUESTION 2 / 5    [role:exp-1] │
│                                             │
│ At TechCorp, what was the scale of the      │
│ backend system you shipped?                 │
│ why: JD emphasizes scalable backend work.   │
│                                             │
│ Answer with facts and metrics — e.g. "I     │
│ built 50+ endpoints serving 2M req/day".    │
│ Don't type instructions; the LLM polishes   │
│ wording in the next step.                   │
│                                             │
│ ┌─────────────────────────────────────────┐ │
│ │ > I built REST endpoints… ▍             │ │
│ └─────────────────────────────────────────┘ │
│                                             │
│ [Polish →  Ctrl+⏎]  [Skip]            [Quit]│
└─────────────────────────────────────────────┘
```

Auto-focuses the textarea on each new question. Skip and Quit send the literal `"skip"` and `"quit"` strings the server's `run_interactive_session` short-circuits on.

**`EnrichPolishedPane`** ([screens/run/enrich-polished-pane.tsx](desktop/src/screens/run/enrich-polished-pane.tsx)) renders when the server has emitted `render_polished` and is waiting on a `choose` prompt with options `a/e/r/s/q`.

```
┌─────────────────────────────────────────────┐
│ ENRICHMENT · POLISHED 2 / 5                 │
│ q: At TechCorp, what was the scale…         │
│                                             │
│ [extra bullet]  [role: exp-1]               │
│                                             │
│ ┌─────────────────────────────────────────┐ │
│ │ Designed RESTful API for 50+ endpoints  │ │
│ │ at TechCorp, cutting p99 latency 30%    │ │
│ │ via Redis caching.                      │ │
│ └─────────────────────────────────────────┘ │
│                                             │
│ [Accept a] [Edit e] [Reject r] [Skip s][Quit│
└─────────────────────────────────────────────┘
```

Bucket gets a tinted badge so the user can see at a glance whether the polish landed as a project / extra_bullet (with role_id chip) / skill / certification — same classification the CLI prints in magenta.

## The edit two-step

Server-side, picking `e` triggers a follow-up text prompt for the new wording. Two messages, one user intent. The workspace handles it like this:

1. User clicks **Edit** on the polished pane → component locally expands a textarea pre-filled with the polished text. *No server traffic yet.*
2. User types the correction; clicks **Save edit** → `onEnrichEditSubmit(draft)` fires.
3. `workspace.tsx` stashes the draft in a `pendingEnrichEditRef` and sends `e` via `controller.editEnrich()`.
4. Server receives `e`, fires the `[bold]Your wording[/bold]` text prompt, controller routes it to the `enrich_edit` role.
5. The `useEffect` watching `pendingPrompt` notices the matching role and flushes the stashed draft via `controller.sendText`.

From the user's perspective: type, save, done — invisible round-trip.

Cancel during edit just collapses the textarea without sending anything; the server is still blocked on the `choose` prompt so the user can pick a/r/s/q normally.

## Keyboard model extended

Phase 3's keyboard handler in `workspace.tsx` already gated `Enter`/`x`/`f`/`q` for the approval pane. This PR adds the `enrich_polished` shortcuts (`a` / `r` / `s` / `q`) on the same global handler. Edit (`e`) is button-only because the keystroke would conflict with typing once the textarea expands.

## Proof of work

- `pnpm typecheck` clean.
- `pnpm build` produces 400 KB JS / 18 KB CSS (128 KB / 4.5 KB gzipped) — Phase 3's 393 KB + 7 KB for the two new components and workspace integration.
- Smoke-tested against the Phase 1 server with a thin master + JD that triggers the auto-enrich offer:
  - Offer modal appears via the existing `IterationConfirm` component (the `enrich_offer` role was already wired in Phase 3).
  - First question card renders, textarea focuses, type → Polish.
  - Polished card flips in with bucket badge + role_id chip.
  - Edit → textarea pre-filled → Save edit → server receives the correction (verified in logs).
  - `s` / `r` / `q` keystrokes route correctly.
  - At session end, `data/facts_bank.yaml` updated identically to what `resume-operator run` produces in the terminal for the same input.

## When this PR is merged

The Run screen handles every interactive moment in the resume-operator pipeline — both the iterative approval loop (Phase 3) and the enrichment interview (Phase 4) — through the same three-pane workspace, with consistent keyboard shortcuts and visual language. The terminal version still works unchanged via `resume-operator run`. Phase 5 (https://github.com/takeshi-su57/resume-operator/issues/88) covers the remaining read-only / one-shot CLI commands plus a home dashboard.
