### PR TITLE
feat(desktop): home + bootstrap + parse + style screens + cmd-K palette (Phase 5, #88)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-tabs": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.4",
     "diff": "^7.0.0",
+    "cmdk": "^1.0.4",
     "@tanstack/react-query": "^5.62.7",
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-dialog": "^2.2.0",

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.0.4
+        version: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       diff:
         specifier: ^7.0.0
         version: 7.0.0
@@ -1249,6 +1252,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3042,6 +3051,18 @@ snapshots:
       clsx: 2.1.1
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   color-convert@2.0.1:
     dependencies:

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,7 +1,12 @@
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 
+import { CommandPalette } from "@/components/command-palette";
 import { NavRail } from "@/components/nav-rail";
 import { TopBar } from "@/components/top-bar";
+import { BootstrapScreen } from "@/screens/bootstrap";
+import { ExtractStyleScreen } from "@/screens/extract-style";
+import { HomeScreen } from "@/screens/home";
+import { ParseResumeScreen } from "@/screens/parse-resume";
 import { RunScreen } from "@/screens/run";
 import { ScoreScreen } from "@/screens/score";
 import { SettingsScreen } from "@/screens/settings";
@@ -9,14 +14,9 @@ import { SettingsScreen } from "@/screens/settings";
 /**
  * Top-level shell — left rail + top bar + routed main pane.
  *
- * Phase 2 shipped Settings + Score; Phase 3 (#86) lights up Run as
- * the third route. Bootstrap / Parse / Extract-style follow in
- * Phase 5 (#88).
- *
- * The Run screen owns its own three-pane layout, so the outer shell
- * collapses to nav-rail + top-bar + main while staying full-bleed
- * inside main — the workspace's panes match the parent rail to
- * preserve a consistent left edge.
+ * Phase 5 (#88) lights up the last four routes (Home, Bootstrap,
+ * Parse, Extract Style) and a global cmd+K command palette. Every
+ * CLI command now has a GUI counterpart.
  */
 export default function App() {
   return (
@@ -25,13 +25,17 @@ export default function App() {
       <TopBar />
       <main className="min-h-0 min-w-0 overflow-hidden bg-bg-subtle border-l border-border">
         <Routes>
-          <Route path="/" element={<Navigate to="/run" replace />} />
+          <Route path="/" element={<HomeScreen />} />
           <Route path="/run" element={<RunScreen />} />
           <Route path="/score" element={<ScoreScreen />} />
+          <Route path="/bootstrap" element={<BootstrapScreen />} />
+          <Route path="/parse" element={<ParseResumeScreen />} />
+          <Route path="/style" element={<ExtractStyleScreen />} />
           <Route path="/settings" element={<SettingsScreen />} />
-          <Route path="*" element={<Navigate to="/run" replace />} />
+          <Route path="*" element={<HomeScreen />} />
         </Routes>
       </main>
+      <CommandPalette />
     </div>
   );
 }

--- a/desktop/src/components/command-palette.tsx
+++ b/desktop/src/components/command-palette.tsx
@@ -1,0 +1,171 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { Command } from "cmdk";
+import {
+  FileSearch,
+  Gauge,
+  Home,
+  PlayCircle,
+  Settings,
+  Sparkles,
+  Wrench,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { cn } from "@/lib/cn";
+
+type Cmd = {
+  id: string;
+  label: string;
+  hint?: string;
+  to: string;
+  icon: React.ComponentType<{ className?: string }>;
+  group: "Navigate";
+};
+
+const COMMANDS: Cmd[] = [
+  { id: "home", label: "Go to Home", to: "/", icon: Home, group: "Navigate" },
+  { id: "run", label: "Tailor a resume", to: "/run", icon: PlayCircle, group: "Navigate" },
+  { id: "score", label: "Score against a JD", to: "/score", icon: Gauge, group: "Navigate" },
+  {
+    id: "bootstrap",
+    label: "Bootstrap master from PDF",
+    to: "/bootstrap",
+    icon: Sparkles,
+    group: "Navigate",
+  },
+  {
+    id: "parse",
+    label: "Parse a resume PDF",
+    to: "/parse",
+    icon: FileSearch,
+    group: "Navigate",
+  },
+  {
+    id: "style",
+    label: "Extract style from .docx",
+    to: "/style",
+    icon: Wrench,
+    group: "Navigate",
+  },
+  {
+    id: "settings",
+    label: "Open Settings",
+    to: "/settings",
+    icon: Settings,
+    group: "Navigate",
+  },
+];
+
+/**
+ * Cmd+K command palette. Phase 5 ships navigation only; recent runs
+ * + arbitrary actions can come later. Linear/Raycast pattern: dim
+ * overlay, centered card, fuzzy search, keyboard-driven (arrows +
+ * Enter). Mounted at the App shell so any screen can fire it.
+ */
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const run = (cmd: Cmd) => {
+    setOpen(false);
+    navigate(cmd.to);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/60 animate-fade-in" />
+        <Dialog.Content
+          className={cn(
+            "fixed left-1/2 top-[20%] -translate-x-1/2",
+            "w-[min(640px,90vw)] panel overflow-hidden shadow-xl animate-fade-in",
+          )}
+        >
+          <Dialog.Title className="sr-only">Command palette</Dialog.Title>
+          <Dialog.Description className="sr-only">
+            Type to search; arrow keys to navigate; Enter to run.
+          </Dialog.Description>
+          <Command label="Command palette">
+            <Command.Input
+              placeholder="Type a command…"
+              className={cn(
+                "w-full border-b border-border bg-transparent",
+                "px-4 py-3 text-sm font-mono outline-none placeholder:text-fg-faint",
+              )}
+            />
+            <Command.List className="max-h-[400px] overflow-y-auto p-1">
+              <Command.Empty className="px-4 py-6 text-center text-sm text-fg-faint">
+                No commands.
+              </Command.Empty>
+              <Command.Group
+                heading="Navigate"
+                className={cn(
+                  "py-1",
+                  "[&_[cmdk-group-heading]]:px-3",
+                  "[&_[cmdk-group-heading]]:py-1",
+                  "[&_[cmdk-group-heading]]:text-xs",
+                  "[&_[cmdk-group-heading]]:uppercase",
+                  "[&_[cmdk-group-heading]]:tracking-wider",
+                  "[&_[cmdk-group-heading]]:text-fg-muted",
+                )}
+              >
+                {COMMANDS.map((cmd) => {
+                  const Icon = cmd.icon;
+                  return (
+                    <Command.Item
+                      key={cmd.id}
+                      value={cmd.label}
+                      onSelect={() => run(cmd)}
+                      className={cn(
+                        "flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm",
+                        "data-[selected=true]:bg-bg-raised data-[selected=true]:text-fg",
+                        "text-fg-muted",
+                      )}
+                    >
+                      <Icon className="h-3.5 w-3.5" />
+                      <span>{cmd.label}</span>
+                    </Command.Item>
+                  );
+                })}
+              </Command.Group>
+            </Command.List>
+            <div
+              className="border-t border-border-subtle bg-bg-panel px-3 py-2 text-xs text-fg-faint flex items-center gap-3"
+              data-no-select
+            >
+              <span>
+                <span className="kbd">↑</span>
+                <span className="kbd ml-0.5">↓</span>
+                <span className="ml-1">navigate</span>
+              </span>
+              <span>
+                <span className="kbd">⏎</span>
+                <span className="ml-1">run</span>
+              </span>
+              <span>
+                <span className="kbd">Esc</span>
+                <span className="ml-1">close</span>
+              </span>
+              <span className="ml-auto">
+                <span className="kbd">⌘</span>
+                <span className="kbd">K</span>
+              </span>
+            </div>
+          </Command>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/desktop/src/components/nav-rail.tsx
+++ b/desktop/src/components/nav-rail.tsx
@@ -1,6 +1,7 @@
 import {
   FileSearch,
   Gauge,
+  Home,
   PlayCircle,
   Settings as SettingsIcon,
   Sparkles,
@@ -14,17 +15,17 @@ type NavItem = {
   to: string;
   label: string;
   icon: React.ComponentType<{ className?: string }>;
-  enabled: boolean;
-  hint?: string;
+  end?: boolean;
 };
 
 const items: NavItem[] = [
-  { to: "/run", label: "Run", icon: PlayCircle, enabled: true },
-  { to: "/score", label: "Score", icon: Gauge, enabled: true },
-  { to: "/bootstrap", label: "Bootstrap", icon: Sparkles, enabled: false, hint: "Phase 5" },
-  { to: "/parse", label: "Parse PDF", icon: FileSearch, enabled: false, hint: "Phase 5" },
-  { to: "/style", label: "Extract Style", icon: Wrench, enabled: false, hint: "Phase 5" },
-  { to: "/settings", label: "Settings", icon: SettingsIcon, enabled: true },
+  { to: "/", label: "Home", icon: Home, end: true },
+  { to: "/run", label: "Run", icon: PlayCircle },
+  { to: "/score", label: "Score", icon: Gauge },
+  { to: "/bootstrap", label: "Bootstrap", icon: Sparkles },
+  { to: "/parse", label: "Parse PDF", icon: FileSearch },
+  { to: "/style", label: "Extract Style", icon: Wrench },
+  { to: "/settings", label: "Settings", icon: SettingsIcon },
 ];
 
 export function NavRail({ className }: { className?: string }) {
@@ -36,7 +37,7 @@ export function NavRail({ className }: { className?: string }) {
       )}
       data-no-select
     >
-      <div className="flex h-10 items-center px-3 border-b border-border">
+      <div className="flex h-10 items-center justify-between px-3 border-b border-border">
         <span className="font-mono text-xs font-bold tracking-wider text-fg">
           resume-operator
         </span>
@@ -46,32 +47,23 @@ export function NavRail({ className }: { className?: string }) {
           <NavRailLink key={item.to} item={item} />
         ))}
       </nav>
+      <div className="mt-auto p-3 text-[0.6875rem] text-fg-faint" data-no-select>
+        <div className="flex items-center gap-1">
+          <span className="kbd">⌘</span>
+          <span className="kbd">K</span>
+          <span className="ml-1">command palette</span>
+        </div>
+      </div>
     </aside>
   );
 }
 
 function NavRailLink({ item }: { item: NavItem }) {
   const Icon = item.icon;
-  if (!item.enabled) {
-    return (
-      <div
-        className={cn(
-          "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-fg-faint",
-          "cursor-not-allowed",
-        )}
-        title={item.hint ? `coming in ${item.hint}` : undefined}
-      >
-        <Icon className="h-4 w-4" />
-        <span className="flex-1">{item.label}</span>
-        {item.hint && (
-          <span className="text-[0.6875rem] text-fg-faint">{item.hint}</span>
-        )}
-      </div>
-    );
-  }
   return (
     <NavLink
       to={item.to}
+      end={item.end}
       className={({ isActive }) =>
         cn(
           "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -202,4 +202,79 @@ export function useScore(
   });
 }
 
+// --- Parse Resume -----------------------------------------------------------
+
+export type ResumeData = {
+  name: string;
+  email: string;
+  phone: string;
+  summary: string;
+  skills: string[];
+  experience: unknown[];
+  education: unknown[];
+  certifications: string[];
+  raw_text: string;
+};
+
+export type ParseResumeResponse = {
+  resume: ResumeData;
+  errors: string[];
+};
+
+export function useParseResume(
+  options?: UseMutationOptions<ParseResumeResponse, ApiError, { resume: string }>,
+) {
+  return useMutation<ParseResumeResponse, ApiError, { resume: string }>({
+    mutationFn: (payload) =>
+      request<ParseResumeResponse>("/api/parse-resume", {
+        method: "POST",
+        json: payload,
+      }),
+    ...options,
+  });
+}
+
+// --- Extract Style ----------------------------------------------------------
+
+export type StyleMargins = {
+  top: number;
+  bottom: number;
+  side: number;
+};
+
+export type StyleSizing = {
+  size: number;
+};
+
+export type StyleTemplate = {
+  font_family: string;
+  margins: StyleMargins;
+  name_style: StyleSizing;
+  section: StyleSizing;
+  body: StyleSizing;
+};
+
+export type ExtractStyleRequest = {
+  source: string;
+  output?: string;
+};
+
+export type ExtractStyleResponse = {
+  style: StyleTemplate;
+  written_to: string | null;
+};
+
+export function useExtractStyle(
+  options?: UseMutationOptions<ExtractStyleResponse, ApiError, ExtractStyleRequest>,
+) {
+  return useMutation<ExtractStyleResponse, ApiError, ExtractStyleRequest>({
+    mutationFn: (payload) =>
+      request<ExtractStyleResponse>("/api/extract-style", {
+        method: "POST",
+        json: payload,
+      }),
+    ...options,
+  });
+}
+
 export { ApiError };

--- a/desktop/src/screens/bootstrap.tsx
+++ b/desktop/src/screens/bootstrap.tsx
@@ -1,0 +1,332 @@
+import { Loader2, PlayCircle } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { FilePicker } from "@/components/file-picker";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ServerMessage } from "@/lib/events";
+import { useFlowSocket } from "@/lib/ws";
+
+type Phase = "idle" | "starting" | "running" | "prompt" | "done" | "error";
+
+type LogEntry = {
+  kind: "panel" | "notice" | "status_start" | "status_end";
+  message: string;
+  title?: string;
+  at: number;
+};
+
+type Pending =
+  | { kind: "confirm"; message: string; default: boolean }
+  | { kind: "choose"; message: string; choices: string[]; default: string }
+  | { kind: "text"; message: string; default: string }
+  | null;
+
+/**
+ * Bootstrap screen — wraps the CLI `bootstrap` command (#60, #70).
+ * PDF in → master YAML out, with the senior-format interview running
+ * over `/api/ws/bootstrap`.
+ *
+ * Simpler than the Run screen — no node timeline, no approval loop,
+ * no enrichment. The activity flows linearly: pick PDF → start →
+ * watch the parser run → answer headline / links / per-role tech /
+ * skill grouping prompts → see the YAML write summary.
+ */
+export function BootstrapScreen() {
+  const [resume, setResume] = useState("");
+  const [output, setOutput] = useState("data/master_resume.yaml");
+  const [skipInterview, setSkipInterview] = useState(false);
+
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [pending, setPending] = useState<Pending>(null);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [result, setResult] = useState<Record<string, unknown> | null>(null);
+
+  const handleMessage = useCallback((msg: ServerMessage) => {
+    switch (msg.type) {
+      case "status_start":
+      case "status_end":
+        setLogs((prev) => [...prev, { kind: msg.type, message: msg.type === "status_start" ? msg.message : "", at: msg.at }]);
+        return;
+      case "panel":
+      case "notice":
+        setLogs((prev) => [
+          ...prev,
+          {
+            kind: msg.type,
+            message: msg.message,
+            title: msg.type === "panel" ? msg.title : undefined,
+            at: Date.now(),
+          },
+        ]);
+        return;
+      case "confirm":
+        setPending({ kind: "confirm", message: msg.message, default: msg.default });
+        setPhase("prompt");
+        return;
+      case "choose":
+        setPending({
+          kind: "choose",
+          message: msg.message,
+          choices: msg.choices,
+          default: msg.default,
+        });
+        setPhase("prompt");
+        return;
+      case "text":
+        setPending({ kind: "text", message: msg.message, default: msg.default });
+        setPhase("prompt");
+        return;
+      case "done":
+        setResult(msg.result);
+        setPhase("done");
+        return;
+      case "error":
+        setErrorMsg(msg.message);
+        setPhase("error");
+        return;
+      default:
+        return;
+    }
+  }, []);
+
+  const ws = useFlowSocket({ onMessage: handleMessage });
+
+  // Send Start once the socket is open.
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (ws.status === "open" && startedRef.current) {
+      ws.send({
+        type: "start",
+        params: { resume, output, skip_interview: skipInterview },
+      });
+      startedRef.current = false;
+      setPhase("running");
+    }
+  }, [ws.status, ws, resume, output, skipInterview]);
+
+  const submit = () => {
+    if (!resume) return;
+    setLogs([]);
+    setPending(null);
+    setResult(null);
+    setErrorMsg(null);
+    startedRef.current = true;
+    setPhase("starting");
+    ws.connect("/api/ws/bootstrap");
+  };
+
+  const reset = () => {
+    ws.disconnect();
+    setPhase("idle");
+    setLogs([]);
+    setPending(null);
+    setResult(null);
+    setErrorMsg(null);
+  };
+
+  const reply = (value: string | boolean) => {
+    ws.send({ type: "reply", value });
+    setPending(null);
+    setPhase("running");
+  };
+
+  return (
+    <div className="grid h-full grid-cols-[320px_1fr]">
+      <aside className="space-y-4 border-r border-border bg-bg-panel p-4 overflow-y-auto">
+        <header>
+          <h1 className="text-sm font-bold text-fg">Bootstrap</h1>
+          <p className="mt-1 text-xs text-fg-dim leading-relaxed">
+            One-time: parse a resume PDF into a hand-editable
+            <span className="font-mono text-fg"> master_resume.yaml</span>.
+            Walks an interview to fill in headline, links, per-role tech,
+            and skill groupings.
+          </p>
+        </header>
+        <div className="space-y-2">
+          <Label>Resume PDF</Label>
+          <FilePicker
+            value={resume}
+            onChange={setResume}
+            placeholder="resume.pdf"
+            filters={[{ name: "PDF", extensions: ["pdf"] }]}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>Output YAML</Label>
+          <Input
+            value={output}
+            onChange={(e) => setOutput(e.target.value)}
+            placeholder="data/master_resume.yaml"
+          />
+        </div>
+        <label className="flex cursor-pointer items-start gap-2 text-sm text-fg">
+          <input
+            type="checkbox"
+            checked={skipInterview}
+            onChange={(e) => setSkipInterview(e.target.checked)}
+            className="mt-0.5 h-4 w-4 rounded border-border accent-accent"
+          />
+          <div>
+            <span>Skip interview</span>
+            <p className="mt-0.5 text-xs text-fg-dim leading-relaxed">
+              Save the parsed YAML as-is, without prompting for senior-format
+              fields.
+            </p>
+          </div>
+        </label>
+        <Button
+          variant="primary"
+          size="lg"
+          className="w-full"
+          disabled={!resume || phase === "running" || phase === "starting"}
+          onClick={phase === "idle" || phase === "done" || phase === "error" ? submit : reset}
+        >
+          {phase === "running" || phase === "starting" ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Running…
+            </>
+          ) : phase === "done" || phase === "error" ? (
+            "Reset"
+          ) : (
+            <>
+              <PlayCircle className="h-4 w-4" />
+              Bootstrap
+            </>
+          )}
+        </Button>
+      </aside>
+
+      <section className="flex flex-col overflow-hidden">
+        <ActivityLog logs={logs} className="flex-1" />
+        {phase === "prompt" && pending && (
+          <PromptPanel pending={pending} onReply={reply} />
+        )}
+        {phase === "done" && (
+          <DonePanel result={result} />
+        )}
+        {phase === "error" && errorMsg && (
+          <ErrorPanel message={errorMsg} />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function ActivityLog({ logs, className }: { logs: LogEntry[]; className?: string }) {
+  if (logs.length === 0) {
+    return (
+      <div className={`flex items-center justify-center text-sm text-fg-faint ${className}`}>
+        Pick a resume PDF and click Bootstrap to begin.
+      </div>
+    );
+  }
+  return (
+    <ul className={`space-y-2 overflow-y-auto p-6 ${className}`}>
+      {logs.map((log, i) => (
+        <li
+          key={i}
+          className={
+            log.kind === "panel"
+              ? "panel p-3 text-sm text-fg leading-relaxed"
+              : "text-xs text-fg-muted"
+          }
+        >
+          {log.title && (
+            <p className="text-xs uppercase tracking-wider text-fg-muted mb-1">
+              {log.title}
+            </p>
+          )}
+          <p className="whitespace-pre-wrap">
+            {log.message.replace(/\[\/?[^\]]+\]/g, "")}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function PromptPanel({
+  pending,
+  onReply,
+}: {
+  pending: Exclude<Pending, null>;
+  onReply: (value: string | boolean) => void;
+}) {
+  const [text, setText] = useState(
+    pending.kind === "text" ? pending.default : "",
+  );
+  return (
+    <div className="border-t border-border bg-bg-panel p-4 space-y-3">
+      <p className="text-sm text-fg leading-relaxed">
+        {pending.message.replace(/\[\/?[^\]]+\]/g, "")}
+      </p>
+      {pending.kind === "confirm" && (
+        <div className="flex gap-2">
+          <Button variant="primary" onClick={() => onReply(true)}>
+            Yes
+          </Button>
+          <Button variant="secondary" onClick={() => onReply(false)}>
+            No
+          </Button>
+        </div>
+      )}
+      {pending.kind === "choose" && (
+        <div className="flex flex-wrap gap-2">
+          {pending.choices.map((c) => (
+            <Button key={c} variant="secondary" onClick={() => onReply(c)}>
+              {c}
+            </Button>
+          ))}
+        </div>
+      )}
+      {pending.kind === "text" && (
+        <div className="flex gap-2">
+          <Input
+            autoFocus
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder={pending.default}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                onReply(text);
+              }
+            }}
+          />
+          <Button variant="primary" onClick={() => onReply(text)}>
+            Send
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DonePanel({ result }: { result: Record<string, unknown> | null }) {
+  const path = typeof result?.output_path === "string" ? result.output_path : null;
+  return (
+    <div className="border-t border-success/40 bg-success/10 p-4 space-y-2">
+      <p className="text-sm font-bold text-success">Bootstrap complete</p>
+      {path && (
+        <p className="text-xs text-fg-muted font-mono break-all">
+          Wrote {path}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ErrorPanel({ message }: { message: string }) {
+  return (
+    <div className="border-t border-danger/40 bg-danger/10 p-4">
+      <p className="text-sm font-bold text-danger">Bootstrap failed</p>
+      <p className="mt-1 text-xs text-fg-dim leading-relaxed break-all">
+        {message}
+      </p>
+    </div>
+  );
+}

--- a/desktop/src/screens/extract-style.tsx
+++ b/desktop/src/screens/extract-style.tsx
@@ -1,0 +1,147 @@
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+
+import { FilePicker } from "@/components/file-picker";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useExtractStyle, type StyleTemplate } from "@/lib/api";
+
+/**
+ * Extract Style — wraps the CLI `extract-style` command (#72).
+ * .docx in → StyleTemplate JSON shown for inspection, optionally
+ * written to a chosen output YAML path.
+ */
+export function ExtractStyleScreen() {
+  const [source, setSource] = useState("");
+  const [output, setOutput] = useState("");
+  const extract = useExtractStyle();
+
+  const submit = () => {
+    if (!source) return;
+    extract.mutate({ source, output: output || undefined });
+  };
+
+  return (
+    <div className="grid h-full grid-cols-[320px_1fr]">
+      <aside className="space-y-4 border-r border-border bg-bg-panel p-4 overflow-y-auto">
+        <header>
+          <h1 className="text-sm font-bold text-fg">Extract Style</h1>
+          <p className="mt-1 text-xs text-fg-dim leading-relaxed">
+            Derive a StyleTemplate YAML from a reference .docx — fonts,
+            margins, sizes. Apply via <span className="font-mono text-fg">
+              run --style
+            </span>.
+          </p>
+        </header>
+        <div className="space-y-2">
+          <Label>Source .docx</Label>
+          <FilePicker
+            value={source}
+            onChange={setSource}
+            placeholder="reference-resume.docx"
+            filters={[{ name: "Word", extensions: ["docx"] }]}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>
+            Output YAML
+            <span className="ml-1 text-fg-faint normal-case">(optional)</span>
+          </Label>
+          <Input
+            value={output}
+            onChange={(e) => setOutput(e.target.value)}
+            placeholder="(leave empty to inspect only)"
+          />
+        </div>
+        <Button
+          variant="primary"
+          size="lg"
+          className="w-full"
+          disabled={!source || extract.isPending}
+          onClick={submit}
+        >
+          {extract.isPending ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Extracting…
+            </>
+          ) : (
+            "Extract"
+          )}
+        </Button>
+        {extract.isError && (
+          <p className="text-xs text-danger">{extract.error?.message}</p>
+        )}
+      </aside>
+
+      <section className="overflow-y-auto p-6">
+        {extract.data ? (
+          <StylePreview
+            template={extract.data.style}
+            writtenTo={extract.data.written_to}
+          />
+        ) : (
+          <EmptyState pending={extract.isPending} />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function StylePreview({
+  template,
+  writtenTo,
+}: {
+  template: StyleTemplate;
+  writtenTo: string | null;
+}) {
+  return (
+    <div className="space-y-4 max-w-2xl">
+      {writtenTo && (
+        <p className="rounded-md border border-success/40 bg-success/10 px-3 py-2 text-xs text-success font-mono break-all">
+          Wrote {writtenTo}
+        </p>
+      )}
+      <section className="panel p-4 space-y-3">
+        <h3 className="text-xs uppercase tracking-wider text-fg-muted">
+          Style Template
+        </h3>
+        <Field label="Font family" value={template.font_family} />
+        <Field label="Margins (top)" value={`${template.margins.top}in`} />
+        <Field label="Margins (bottom)" value={`${template.margins.bottom}in`} />
+        <Field label="Margins (side)" value={`${template.margins.side}in`} />
+        <Field label="Name size" value={`${template.name_style.size}pt`} />
+        <Field label="Section size" value={`${template.section.size}pt`} />
+        <Field label="Body size" value={`${template.body.size}pt`} />
+      </section>
+    </div>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[140px_1fr] items-baseline gap-3">
+      <span className="text-xs uppercase tracking-wider text-fg-muted">
+        {label}
+      </span>
+      <span className="text-sm text-fg font-mono">{value}</span>
+    </div>
+  );
+}
+
+function EmptyState({ pending }: { pending: boolean }) {
+  if (pending) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-fg-dim">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Reading .docx styles…
+      </div>
+    );
+  }
+  return (
+    <div className="flex h-full items-center justify-center text-sm text-fg-faint">
+      <p>Pick a .docx to extract its style template.</p>
+    </div>
+  );
+}

--- a/desktop/src/screens/home.tsx
+++ b/desktop/src/screens/home.tsx
@@ -1,0 +1,158 @@
+import {
+  ChevronRight,
+  FileSearch,
+  Gauge,
+  PlayCircle,
+  Settings,
+  Sparkles,
+  Wrench,
+} from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+import { useHealth } from "@/lib/api";
+import { cn } from "@/lib/cn";
+
+type Tile = {
+  to: string;
+  label: string;
+  description: string;
+  icon: React.ComponentType<{ className?: string }>;
+  primary?: boolean;
+};
+
+const TILES: Tile[] = [
+  {
+    to: "/run",
+    label: "Tailor a resume",
+    description:
+      "Full pipeline — load → score → tailor → optional enrich → optional approval loop → finalize.",
+    icon: PlayCircle,
+    primary: true,
+  },
+  {
+    to: "/score",
+    label: "Score against a JD",
+    description:
+      "Multi-dimensional ATS report (#81). No tailoring, no PDF write — read-only inspection.",
+    icon: Gauge,
+  },
+  {
+    to: "/bootstrap",
+    label: "Bootstrap from PDF",
+    description:
+      "One-time: parse a resume PDF into a hand-editable master_resume.yaml.",
+    icon: Sparkles,
+  },
+  {
+    to: "/parse",
+    label: "Parse PDF",
+    description:
+      "Inspect what the LLM extracts from a resume PDF — fields, counts, raw text.",
+    icon: FileSearch,
+  },
+  {
+    to: "/style",
+    label: "Extract style",
+    description:
+      "Derive a StyleTemplate YAML from a reference .docx (#72). Apply via run --style.",
+    icon: Wrench,
+  },
+  {
+    to: "/settings",
+    label: "Settings",
+    description: "LLM provider + keys, ATS weights, behavior thresholds.",
+    icon: Settings,
+  },
+];
+
+/**
+ * Home / dashboard. Quick-action tiles for every screen plus an
+ * engine status hero. The "recent applications" feed lives on the
+ * roadmap but isn't shipped here — it would need either a fs-listing
+ * server route or `@tauri-apps/plugin-fs`, both of which expand the
+ * Phase 5 scope without unblocking anything. Left as a follow-up.
+ */
+export function HomeScreen() {
+  const { data: health, isError } = useHealth();
+  const navigate = useNavigate();
+  const ok = !!health && !isError;
+
+  return (
+    <div className="overflow-y-auto p-8 max-w-5xl mx-auto">
+      <header className="mb-8">
+        <h1 className="text-lg font-bold text-fg">resume-operator</h1>
+        <p className="mt-1 text-sm text-fg-dim">
+          Local AI agent that tailors your resume to any job description.
+        </p>
+        <div
+          className={cn(
+            "mt-3 inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs",
+            ok
+              ? "border-success/30 bg-success/5 text-success"
+              : "border-danger/30 bg-danger/5 text-danger",
+          )}
+        >
+          <span
+            className={cn(
+              "h-1.5 w-1.5 rounded-full",
+              ok ? "bg-success" : "bg-danger",
+            )}
+          />
+          {ok ? (
+            <span>
+              Engine online · {health!.llm_provider} / {health!.llm_model}
+            </span>
+          ) : (
+            <span>Engine offline — start the sidecar with <span className="font-mono">uv run resume-operator-server</span></span>
+          )}
+        </div>
+      </header>
+
+      <ul className="grid grid-cols-2 gap-3">
+        {TILES.map((tile) => (
+          <Tile key={tile.to} tile={tile} onClick={() => navigate(tile.to)} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function Tile({ tile, onClick }: { tile: Tile; onClick: () => void }) {
+  const Icon = tile.icon;
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          "panel w-full p-4 text-left transition-colors group focus-ring",
+          tile.primary
+            ? "border-accent/40 hover:border-accent/60 hover:bg-bg-raised"
+            : "hover:border-border-strong hover:bg-bg-raised",
+        )}
+      >
+        <div className="flex items-start gap-3">
+          <div
+            className={cn(
+              "rounded-md border p-2",
+              tile.primary
+                ? "border-accent/40 bg-accent/10 text-accent"
+                : "border-border bg-bg-raised text-fg-muted",
+            )}
+          >
+            <Icon className="h-4 w-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 className="text-sm font-bold text-fg flex items-center gap-1">
+              {tile.label}
+              <ChevronRight className="h-3.5 w-3.5 text-fg-faint group-hover:text-fg-muted transition-colors" />
+            </h3>
+            <p className="mt-1 text-xs text-fg-dim leading-relaxed">
+              {tile.description}
+            </p>
+          </div>
+        </div>
+      </button>
+    </li>
+  );
+}

--- a/desktop/src/screens/parse-resume.tsx
+++ b/desktop/src/screens/parse-resume.tsx
@@ -1,0 +1,157 @@
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+
+import { FilePicker } from "@/components/file-picker";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { useParseResume, type ResumeData } from "@/lib/api";
+
+/**
+ * Parse Resume — wraps the CLI `parse-resume` command. PDF in,
+ * read-only inspection of the extracted fields out. No tailoring,
+ * no PDF writing.
+ */
+export function ParseResumeScreen() {
+  const [resume, setResume] = useState("");
+  const parse = useParseResume();
+
+  const submit = () => {
+    if (!resume) return;
+    parse.mutate({ resume });
+  };
+
+  return (
+    <div className="grid h-full grid-cols-[320px_1fr]">
+      <aside className="space-y-4 border-r border-border bg-bg-panel p-4 overflow-y-auto">
+        <header>
+          <h1 className="text-sm font-bold text-fg">Parse Resume</h1>
+          <p className="mt-1 text-xs text-fg-dim leading-relaxed">
+            Inspect what the LLM extracts from a resume PDF. No tailoring,
+            no PDF write — read-only.
+          </p>
+        </header>
+        <div className="space-y-2">
+          <Label>Resume PDF</Label>
+          <FilePicker
+            value={resume}
+            onChange={setResume}
+            placeholder="resume.pdf"
+            filters={[{ name: "PDF", extensions: ["pdf"] }]}
+          />
+        </div>
+        <Button
+          variant="primary"
+          size="lg"
+          className="w-full"
+          disabled={!resume || parse.isPending}
+          onClick={submit}
+        >
+          {parse.isPending ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Parsing…
+            </>
+          ) : (
+            "Parse"
+          )}
+        </Button>
+        {parse.isError && (
+          <p className="text-xs text-danger">{parse.error?.message}</p>
+        )}
+      </aside>
+
+      <section className="overflow-y-auto p-6">
+        {parse.data ? (
+          <ResumeFields data={parse.data.resume} />
+        ) : (
+          <EmptyState pending={parse.isPending} />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function ResumeFields({ data }: { data: ResumeData }) {
+  return (
+    <div className="space-y-4 max-w-2xl">
+      <section className="panel p-4 space-y-2">
+        <Field label="Name" value={data.name} />
+        <Field label="Email" value={data.email} />
+        <Field label="Phone" value={data.phone} />
+      </section>
+      {data.summary && (
+        <section className="panel p-4">
+          <h3 className="text-xs uppercase tracking-wider text-fg-muted mb-2">
+            Summary
+          </h3>
+          <p className="text-sm text-fg leading-relaxed">{data.summary}</p>
+        </section>
+      )}
+      {data.skills.length > 0 && (
+        <section className="panel p-4">
+          <h3 className="text-xs uppercase tracking-wider text-fg-muted mb-2">
+            Skills ({data.skills.length})
+          </h3>
+          <ul className="flex flex-wrap gap-1.5">
+            {data.skills.map((s) => (
+              <li
+                key={s}
+                className="rounded-sm border border-border bg-bg-raised px-1.5 py-0.5 text-xs text-fg-muted"
+              >
+                {s}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+      <section className="panel p-4">
+        <h3 className="text-xs uppercase tracking-wider text-fg-muted mb-2">
+          Counts
+        </h3>
+        <dl className="grid grid-cols-3 gap-3 text-sm">
+          <Stat label="Experience" value={data.experience.length} />
+          <Stat label="Education" value={data.education.length} />
+          <Stat label="Certifications" value={data.certifications.length} />
+        </dl>
+      </section>
+    </div>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[100px_1fr] items-baseline gap-3">
+      <span className="text-xs uppercase tracking-wider text-fg-muted">
+        {label}
+      </span>
+      <span className="text-sm text-fg font-mono break-all">
+        {value || <span className="text-fg-faint">—</span>}
+      </span>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wider text-fg-muted">{label}</dt>
+      <dd className="mt-0.5 text-2xl font-bold tabular-nums text-fg">{value}</dd>
+    </div>
+  );
+}
+
+function EmptyState({ pending }: { pending: boolean }) {
+  if (pending) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-fg-dim">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Running LLM extraction…
+      </div>
+    );
+  }
+  return (
+    <div className="flex h-full items-center justify-center text-sm text-fg-faint">
+      <p>Pick a resume PDF to inspect its parsed fields.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes Phase 5 of the desktop GUI roadmap (https://github.com/takeshi-su57/resume-operator/issues/88). Every CLI command now has a GUI counterpart, plus a home dashboard and a global cmd+K command palette. The app feels like one product instead of a collection of isolated screens.

Stacked on Phase 4 (https://github.com/takeshi-su57/resume-operator/pull/93). Auto-rebases as the chain merges (#90 → #91 → #92 → #93 → #94).

## Four new screens + a palette

### Home (`/`) — [screens/home.tsx](desktop/src/screens/home.tsx)

Landing screen. Engine-status banner (online with provider/model, or offline with the sidecar-start hint) and a 3×2 grid of quick-action tiles, one per screen. "Tailor a resume" is the primary tile (accent-tinted); everything else is a secondary tile. Recent applications feed is intentionally deferred — would need either a server-side `/api/applications` listing route or `@tauri-apps/plugin-fs`, neither of which unblocks anything in the roadmap. Logged as a follow-up.

### Bootstrap (`/bootstrap`) — [screens/bootstrap.tsx](desktop/src/screens/bootstrap.tsx)

Wraps the CLI `bootstrap` command (#60, #70) over `/api/ws/bootstrap`. Two-pane layout: left rail collects PDF + output path + skip-interview flag; right pane shows the activity log and the open prompt panel.

Reuses the same [`useFlowSocket`](desktop/src/lib/ws.ts) hook as the Run screen, with a simplified linear protocol — no node timeline, no approval loop, no enrichment. Confirm / choose / text prompts each get their own minimal control; panels and notices accumulate into the activity feed above. On `done`, a green output-path footer; on `error`, a red message footer.

### Parse Resume (`/parse`) — [screens/parse-resume.tsx](desktop/src/screens/parse-resume.tsx)

Wraps `parse-resume`. Single PDF picker → `POST /api/parse-resume` → fields panel showing name / email / phone / summary / skills + counts (experience / education / certifications). Read-only inspection.

### Extract Style (`/style`) — [screens/extract-style.tsx](desktop/src/screens/extract-style.tsx)

Wraps `extract-style` (#72). .docx picker + optional output YAML path → `POST /api/extract-style` → preview panel showing font family, margins, and the three font sizes. When output path is set, a green "wrote …" banner confirms the YAML was persisted.

### Cmd-K palette — [components/command-palette.tsx](desktop/src/components/command-palette.tsx)

Global keyboard hook on `cmd/ctrl+K` toggles a Linear/Raycast-style palette. Phase 5 ships navigation only (one entry per screen); recent runs + arbitrary actions stay on the roadmap. Mounted at the App shell so any screen can fire it. Keyboard footer shows arrows / Enter / Esc / cmd-K hints.

## API client extension

[`lib/api.ts`](desktop/src/lib/api.ts) gains `useParseResume` and `useExtractStyle` mutations + their matching response types. The Bootstrap screen uses the existing `useFlowSocket` hook directly — its protocol is specific enough that the [`useRunController`](desktop/src/screens/run/use-run-controller.ts) pattern from the Run screen would over-engineer it.

## Nav rail cleanup

[`nav-rail.tsx`](desktop/src/components/nav-rail.tsx) — every item is now enabled; the Phase-3-5 disabled stubs are gone. Cmd-K hint sits at the bottom. Default route `/` is Home.

## Proof of work

- `pnpm typecheck` clean.
- `pnpm build` produces a 430 KB JS / 21 KB CSS bundle (135 KB / 4.8 KB gzipped) — Phase 4's 400 KB plus the four new screens, the command palette, and cmdk's runtime.
- All four screens smoke-tested against the Phase 1 server: parse-resume + extract-style round-trip cleanly; bootstrap drives the WS interview end-to-end and writes `master_resume.yaml` identically to the CLI; cmd+K opens reliably from any screen and Enter navigates.

## When this PR is merged

The desktop GUI ships every resume-operator CLI command — Run, Score, Bootstrap, Parse, Extract Style, Settings — through a coherent shell with consistent keyboard conventions and visual language. The CLI is unchanged. Phase 6 (https://github.com/takeshi-su57/resume-operator/issues/89) is the last lap: PyInstaller-bundle the Python sidecar and produce a signed-or-not Windows MSI installer.
